### PR TITLE
Fix unused function warnings in test files

### DIFF
--- a/test/remote_type_field_args_test.erl
+++ b/test/remote_type_field_args_test.erl
@@ -92,6 +92,15 @@ organization_invalid_users_test() ->
     Result = to_json_organization(InvalidData),
     ?assertMatch({error, [_ | _]}, Result).
 
+organization_from_json_test() ->
+    ValidJson =
+        #{<<"users">> => [#{<<"id">> => <<"user1">>, <<"balance">> => 100}],
+          <<"results">> => #{<<"value">> => <<"success">>, <<"errors">> => []}},
+    Expected =
+        #{users => [#{id => "user1", balance => 100}],
+          results => #result{value = "success", errors = []}},
+    ?assertEqual({ok, Expected}, from_json_organization(ValidJson)).
+
 %% Tests for complex_data type
 
 complex_data_valid_test() ->
@@ -118,6 +127,13 @@ complex_data_invalid_nested_test() ->
     Result = to_json_complex_data(InvalidData),
     ?assertMatch({error, [_ | _]}, Result).
 
+complex_data_from_json_test() ->
+    ValidJson =
+        #{<<"primary">> =>
+              #{<<"account">> => #{<<"id">> => <<"primary">>, <<"balance">> => 1000}}},
+    Expected = #{primary => #{account => #{id => "primary", balance => 1000}}},
+    ?assertEqual({ok, Expected}, from_json_complex_data(ValidJson)).
+
 %% Tests for mixed_requirements type
 
 mixed_requirements_all_fields_test() ->
@@ -143,6 +159,15 @@ mixed_requirements_missing_required_test() ->
     % Missing required_account
     Result = to_json_mixed_requirements(InvalidData),
     ?assertMatch({error, [_ | _]}, Result).
+
+mixed_requirements_from_json_test() ->
+    ValidJson =
+        #{<<"required_account">> => #{<<"id">> => <<"req1">>, <<"balance">> => 1000},
+          <<"required_list">> => [#{<<"id">> => <<"list1">>, <<"balance">> => 100}]},
+    Expected =
+        #{required_account => #{id => "req1", balance => 1000},
+          required_list => [#{id => "list1", balance => 100}]},
+    ?assertEqual({ok, Expected}, from_json_mixed_requirements(ValidJson)).
 
 %% JSON conversion functions
 

--- a/test/remote_type_test.erl
+++ b/test/remote_type_test.erl
@@ -30,7 +30,12 @@ validate_missing_test() ->
 
     % This should return an error due to missing remote type
     Result = to_json_missing(ValidData),
-    ?assertMatch({error, _}, Result).
+    ?assertMatch({error, _}, Result),
+
+    % Test from_json as well
+    Json = #{<<"a">> => <<"some_value">>},
+    FromJsonResult = from_json_missing(Json),
+    ?assertMatch({error, _}, FromJsonResult).
 
 -spec to_json_remote(remote()) -> {ok, json:json()} | {error, [#ed_error{}]}.
 to_json_remote(Data) ->


### PR DESCRIPTION
## Summary
- Fixed unused function warnings for `from_json_*` functions in test files
- Added proper test coverage with specific assertions for all previously unused functions
- All 75 tests continue to pass

## Test plan
- [x] Build completes without unused function warnings
- [x] All existing tests continue to pass  
- [x] New test functions properly exercise the from_json conversion functions

🤖 Generated with [Claude Code](https://claude.ai/code)