### PR TITLE
Allow extra fields in JSON objects

### DIFF
--- a/src/spectra_json.erl
+++ b/src/spectra_json.erl
@@ -327,23 +327,25 @@ map_fields_to_json(TypeInfo, MapFieldTypes, Data) ->
             end
     end,
     case spectra_util:fold_until_error(Fun, {[], Data}, MapFieldTypes) of
-        {ok, {MapFields, FinalData}} ->
-            case maps:to_list(FinalData) of
-                [] ->
-                    {ok, MapFields};
-                L ->
-                    {error,
-                        lists:map(
-                            fun({Key, Value}) ->
-                                #sp_error{
-                                    type = not_matched_fields,
-                                    location = [],
-                                    ctx = #{key => Key, value => Value}
-                                }
-                            end,
-                            L
-                        )}
-            end;
+        {ok, {MapFields, _FinalData}} ->
+            {ok, MapFields};
+        % TODO: Add config option to optionally error on extra fields
+        % case maps:to_list(FinalData) of
+        %     [] ->
+        %         {ok, MapFields};
+        %     L ->
+        %         {error,
+        %             lists:map(
+        %                 fun({Key, Value}) ->
+        %                     #sp_error{
+        %                         type = not_matched_fields,
+        %                         location = [],
+        %                         ctx = #{key => Key, value => Value}
+        %                     }
+        %                 end,
+        %                 L
+        %             )}
+        % end;
         {error, _} = Err ->
             Err
     end.
@@ -1010,23 +1012,25 @@ map_from_json(TypeInfo, MapFieldType, Json) when is_map(Json) ->
     end,
 
     case spectra_util:fold_until_error(Fun, {[], Json}, MapFieldType) of
-        {ok, {Fields, NotMapped}} ->
-            case maps:size(NotMapped) of
-                0 ->
-                    {ok, maps:from_list(Fields)};
-                _ ->
-                    {error,
-                        lists:map(
-                            fun({Key, Value}) ->
-                                #sp_error{
-                                    type = not_matched_fields,
-                                    location = [],
-                                    ctx = #{key => Key, value => Value}
-                                }
-                            end,
-                            maps:to_list(NotMapped)
-                        )}
-            end;
+        {ok, {Fields, _NotMapped}} ->
+            {ok, maps:from_list(Fields)};
+        % TODO: Add config option to optionally error on extra fields
+        % case maps:size(NotMapped) of
+        %     0 ->
+        %         {ok, maps:from_list(Fields)};
+        %     _ ->
+        %         {error,
+        %             lists:map(
+        %                 fun({Key, Value}) ->
+        %                     #sp_error{
+        %                         type = not_matched_fields,
+        %                         location = [],
+        %                         ctx = #{key => Key, value => Value}
+        %                     }
+        %                 end,
+        %                 maps:to_list(NotMapped)
+        %             )}
+        % end;
         {error, _} = Err ->
             Err
     end;
@@ -1125,23 +1129,25 @@ do_record_from_json(TypeInfo, RecordName, RecordInfo, Json) when is_map(Json) ->
         end
     end,
     case spectra_util:fold_until_error(Fun, {[], Json}, RecordInfo) of
-        {ok, {Fields, NotMapped}} ->
-            case maps:size(NotMapped) of
-                0 ->
-                    {ok, list_to_tuple([RecordName | lists:reverse(Fields)])};
-                _ ->
-                    {error,
-                        lists:map(
-                            fun({Key, Value}) ->
-                                #sp_error{
-                                    type = not_matched_fields,
-                                    location = [],
-                                    ctx = #{key => Key, value => Value}
-                                }
-                            end,
-                            maps:to_list(NotMapped)
-                        )}
-            end;
+        {ok, {Fields, _NotMapped}} ->
+            {ok, list_to_tuple([RecordName | lists:reverse(Fields)])};
+        % TODO: Add config option to optionally error on extra fields
+        % case maps:size(NotMapped) of
+        %     0 ->
+        %         {ok, list_to_tuple([RecordName | lists:reverse(Fields)])};
+        %     _ ->
+        %         {error,
+        %             lists:map(
+        %                 fun({Key, Value}) ->
+        %                     #sp_error{
+        %                         type = not_matched_fields,
+        %                         location = [],
+        %                         ctx = #{key => Key, value => Value}
+        %                     }
+        %                 end,
+        %                 maps:to_list(NotMapped)
+        %             )}
+        % end;
         {error, Errs} ->
             {error, Errs}
     end;

--- a/test/map_test.erl
+++ b/test/map_test.erl
@@ -363,13 +363,7 @@ map_in_map_value_test() ->
 
 map_in_map_value_bad_test() ->
     ?assertEqual(
-        {error, [
-            #sp_error{
-                location = [hej],
-                type = not_matched_fields,
-                ctx = #{key => <<"key1">>, value => <<"not_integer">>}
-            }
-        ]},
+        {ok, #{<<"hej">> => #{}}},
         to_json_map_in_map_value(#{hej => #{<<"key1">> => <<"not_integer">>}})
     ),
     ?assertMatch(
@@ -425,13 +419,8 @@ from_json_map_in_map_value_bad_test() ->
     ).
 
 from_json_map_in_map_key_test() ->
-    ?assertMatch(
-        {error, [
-            #sp_error{
-                type = not_matched_fields,
-                ctx = #{value := <<"value">>, key := <<"key">>}
-            }
-        ]},
+    ?assertEqual(
+        {ok, #{}},
         from_json_map_in_map_key(#{<<"key">> => <<"value">>})
     ).
 

--- a/test/record_test.erl
+++ b/test/record_test.erl
@@ -46,24 +46,19 @@ missing_test() ->
 
 extra_fields_test() ->
     ?assertMatch(
-        {error, [
-            #sp_error{type = not_matched_fields, ctx = #{key := <<"extra">>, value := <<"field">>}}
-        ]},
+        {ok, #person{name = "John", age = 30}},
         spectra_json:from_json(?MODULE, {record, person}, #{
             <<"name">> => <<"John">>, <<"age">> => 30, <<"extra">> => <<"field">>
         }),
-        "Extra fields in JSON should cause an error"
+        "Extra fields in JSON should be ignored"
     ),
     ?assertMatch(
-        {error, [
-            #sp_error{type = not_matched_fields, ctx = #{key := <<"extra1">>}},
-            #sp_error{type = not_matched_fields, ctx = #{key := <<"extra2">>}}
-        ]},
+        {ok, #person{name = "John", age = 30}},
         spectra_json:from_json(?MODULE, {record, person}, #{
             <<"name">> => <<"John">>,
             <<"age">> => 30,
             <<"extra1">> => <<"value1">>,
             <<"extra2">> => <<"value2">>
         }),
-        "Multiple extra fields in JSON should all be reported"
+        "Multiple extra fields in JSON should be ignored"
     ).

--- a/test/union_test.erl
+++ b/test/union_test.erl
@@ -35,9 +35,11 @@ validate_weird_union_test() ->
         to_json_weird_union(ValidMap)
     ),
 
-    % Test with invalid data
-    {error, Errors} = to_json_weird_union(InvalidData),
-    ?assertMatch([#sp_error{type = no_match}], Errors),
+    % Test with extra fields (now ignored)
+    ?assertEqual(
+        {ok, #{}},
+        to_json_weird_union(InvalidData)
+    ),
 
     % Test JSON conversion using from_json
     ValidRecordJson = #{<<"street">> => <<"Main St">>, <<"city">> => <<"New York">>},
@@ -67,9 +69,11 @@ validate_weird_union_test() ->
         from_json_weird_union(ValidMapJson)
     ),
 
-    % Test from_json with invalid data
-    {error, FromErrors} = from_json_weird_union(InvalidJson),
-    ?assertMatch([#sp_error{type = no_match}], FromErrors).
+    % Test from_json with extra fields (now ignored)
+    ?assertEqual(
+        {ok, #{}},
+        from_json_weird_union(InvalidJson)
+    ).
 
 -spec to_json_weird_union(weird_union()) ->
     {ok, json:encode_value()} | {error, [spectra:error()]}.


### PR DESCRIPTION
Remove errors when JSON keys don't match map/struct/record fields.
Extra fields are now silently ignored during serialization and deserialization.
Error-handling code preserved as comments for future config option to control this behavior.
