### PR TITLE
Fix sp_union types field missing type annotation

### DIFF
--- a/include/spectra_internal.hrl
+++ b/include/spectra_internal.hrl
@@ -33,7 +33,7 @@
     meta = #{} :: spectra:sp_type_meta()
 }).
 -record(sp_union, {
-    types = [spectra:sp_type()],
+    types :: [spectra:sp_type()],
     meta = #{} :: spectra:sp_type_meta()
 }).
 -record(sp_literal, {


### PR DESCRIPTION
## Summary

- `#sp_union{}` had `types = [spectra:sp_type()]` which sets a literal list as the default value instead of declaring the type
- Fixed to `types :: [spectra:sp_type()]` to match all other non-defaulted fields in the codebase

🤖 Generated with [Claude Code](https://claude.com/claude-code)