### PR TITLE
Fix generate_components bypassing codec schema for binary type_parame…

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,11 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.9.4] - 2026-04-02
+
+### Fixed
+- **OpenAPI component generation bypasses codec `schema/5`**: When a codec-backed type was referenced as an OpenAPI component via `endpoints_to_openapi`, the codec's `schema/5` callback was never called — the structural schema was generated instead. For types with a binary `type_parameters` value (e.g. `<<"user:">>`), this also caused a crash with `{invalid_string_constraints, Prefix}`. Fixed by making `to_inline_schema` consult the codec registry before falling through to the default schema generator, consistent with the behaviour already present for inline type references.
+
 ## [0.9.3] - 2026-04-01
 
 ### Added

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,7 +10,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ## [0.9.4] - 2026-04-02
 
 ### Fixed
-- **OpenAPI component generation bypasses codec `schema/5`**: When a codec-backed type was referenced as an OpenAPI component via `endpoints_to_openapi`, the codec's `schema/5` callback was never called — the structural schema was generated instead. For types with a binary `type_parameters` value (e.g. `<<"user:">>`), this also caused a crash with `{invalid_string_constraints, Prefix}`. Fixed by making `to_inline_schema` consult the codec registry before falling through to the default schema generator, consistent with the behaviour already present for inline type references.
+- **OpenAPI component generation bypasses codec `schema/5`**: When a codec-backed named type or record was referenced as an OpenAPI component via `endpoints_to_openapi`, the codec's `schema/5` callback was never called — the structural schema was generated instead.
 
 ## [0.9.3] - 2026-04-01
 

--- a/README.md
+++ b/README.md
@@ -17,7 +17,7 @@ Add spectra to your rebar.config dependencies:
 
 ```erlang
 {deps, [
-    {spectra, "~> 0.9.3"}
+    {spectra, "~> 0.9.4"}
 ]}.
 ```
 

--- a/src/spectra.erl
+++ b/src/spectra.erl
@@ -219,17 +219,17 @@ decode(Format, TypeInfo, SpType, Data, Options) ->
 -spec default_decode(
     Format :: atom(),
     TypeInfo :: type_info(),
-    SpType :: sp_type(),
+    Type :: sp_type(),
     Data :: dynamic(),
     Options :: [decode_option()]
 ) ->
     {ok, dynamic()} | {error, [error()]}.
-default_decode(json, Typeinfo, TypeOrRef, Data, Options) ->
+default_decode(json, Typeinfo, Type, Data, Options) ->
     case proplists:get_value(pre_decoded, Options, false) of
         false when is_binary(Data) ->
             case json_decode(Data) of
                 {ok, DecodedJson} ->
-                    spectra_json:from_json(Typeinfo, TypeOrRef, DecodedJson);
+                    spectra_json:from_json(Typeinfo, Type, DecodedJson);
                 {error, _} = Err ->
                     Err
             end;
@@ -245,7 +245,7 @@ default_decode(json, Typeinfo, TypeOrRef, Data, Options) ->
                 }
             ]};
         true ->
-            spectra_json:from_json(Typeinfo, TypeOrRef, Data)
+            spectra_json:from_json(Typeinfo, Type, Data)
     end;
 default_decode(binary_string, Typeinfo, TypeOrRef, Binary, _Options) when is_binary(Binary) ->
     spectra_binary_string:from_binary_string(Typeinfo, TypeOrRef, Binary);

--- a/src/spectra_openapi.erl
+++ b/src/spectra_openapi.erl
@@ -1001,7 +1001,11 @@ capitalize_word([First | Rest]) ->
     spectra_json_schema:json_schema().
 to_inline_schema(TypeInfo, {type, Name, Arity}) ->
     Type = spectra_type_info:get_type(TypeInfo, Name, Arity),
-    spectra_json_schema:to_schema(TypeInfo, Type);
+    Mod = spectra_type_info:get_module(TypeInfo),
+    case spectra_codec:try_codec_schema(Mod, json_schema, Type, Type) of
+        continue -> spectra_json_schema:to_schema(TypeInfo, Type);
+        Schema -> Schema
+    end;
 to_inline_schema(TypeInfo, {record, RecordName}) ->
     Record = spectra_type_info:get_record(TypeInfo, RecordName),
     spectra_json_schema:to_schema(TypeInfo, Record);

--- a/src/spectra_openapi.erl
+++ b/src/spectra_openapi.erl
@@ -1008,6 +1008,10 @@ to_inline_schema(TypeInfo, {type, Name, Arity}) ->
     end;
 to_inline_schema(TypeInfo, {record, RecordName}) ->
     Record = spectra_type_info:get_record(TypeInfo, RecordName),
-    spectra_json_schema:to_schema(TypeInfo, Record);
+    Mod = spectra_type_info:get_module(TypeInfo),
+    case spectra_codec:try_codec_schema(Mod, json_schema, Record, Record) of
+        continue -> spectra_json_schema:to_schema(TypeInfo, Record);
+        Schema -> Schema
+    end;
 to_inline_schema(TypeInfo, SpType) ->
     spectra_json_schema:to_schema(TypeInfo, SpType).

--- a/test/custom_codec_test.erl
+++ b/test/custom_codec_test.erl
@@ -500,6 +500,39 @@ app_env_record_schema_test() ->
         application:unset_env(spectra, codecs)
     end.
 
+%% Regression: to_inline_schema({record, Name}) used to pass the resolved #sp_rec{}
+%% directly to spectra_json_schema:to_schema, bypassing the codec registry. The
+%% structural object schema was generated instead of calling the codec's schema/5.
+app_env_record_openapi_component_uses_codec_schema_test() ->
+    application:set_env(
+        spectra,
+        codecs,
+        #{{codec_appenv_rec_module, {record, point2d}} => codec_appenv_rec_codec}
+    ),
+    try
+        Resp = spectra_openapi:response_with_body(
+            spectra_openapi:response(200, <<"ok">>),
+            codec_appenv_rec_module,
+            {record, point2d}
+        ),
+        Endpoint = spectra_openapi:add_response(
+            spectra_openapi:endpoint(get, <<"/point">>),
+            Resp
+        ),
+        {ok, Spec} = spectra_openapi:endpoints_to_openapi(
+            #{title => <<"Test">>, version => <<"1">>},
+            [Endpoint],
+            [pre_encoded]
+        ),
+        #{<<"components">> := #{<<"schemas">> := #{<<"Point2d">> := Point2dSchema}}} = Spec,
+        ?assertMatch(
+            #{type := <<"array">>, items := #{type := <<"number">>}, minItems := 2, maxItems := 2},
+            Point2dSchema
+        )
+    after
+        application:unset_env(spectra, codecs)
+    end.
+
 %% When encoding a record whose field type is an inline #sp_rec_ref{}, and the
 %% referenced record has a codec registered via app env, the inline ref must
 %% dispatch to the codec rather than fall through to structural encoding.

--- a/test/prefixed_id_codec_test.erl
+++ b/test/prefixed_id_codec_test.erl
@@ -89,3 +89,43 @@ roundtrip_org_id_test() ->
         {ok, <<"xyz789">>},
         spectra:decode(json, prefixed_id_codec, org_id, Encoded)
     ).
+
+%% -----------------------------------------------------------------------
+%% openapi components — codec schema must be used for binary type_parameters
+%% -----------------------------------------------------------------------
+
+%% Regression: generate_components used to call to_inline_schema which resolved
+%% user_id() to #sp_simple_type{type=binary} with parameters => <<"user:">> and
+%% then crashed in apply_string_params/2 because it expected a map, not a binary.
+%% The codec's schema/5 callback must be invoked instead.
+%% The outer OpenAPI structure uses binary keys (typed via openapi_spec()),
+%% but inner schema objects keep atom keys (openapi_schema() is a passthrough term).
+openapi_components_user_id_uses_codec_schema_test() ->
+    Endpoint =
+        spectra_openapi:with_request_body(
+            spectra_openapi:endpoint(post, <<"/items">>),
+            prefixed_id_codec,
+            {type, user_id, 0}
+        ),
+    {ok, Spec} = spectra_openapi:endpoints_to_openapi(
+        #{title => <<"Test">>, version => <<"1">>},
+        [Endpoint],
+        [pre_encoded]
+    ),
+    #{<<"components">> := #{<<"schemas">> := #{<<"UserId0">> := UserIdSchema}}} = Spec,
+    ?assertMatch(#{type := <<"string">>, pattern := <<"^user:">>}, UserIdSchema).
+
+openapi_components_org_id_uses_codec_schema_test() ->
+    Endpoint =
+        spectra_openapi:with_request_body(
+            spectra_openapi:endpoint(post, <<"/items">>),
+            prefixed_id_codec,
+            {type, org_id, 0}
+        ),
+    {ok, Spec} = spectra_openapi:endpoints_to_openapi(
+        #{title => <<"Test">>, version => <<"1">>},
+        [Endpoint],
+        [pre_encoded]
+    ),
+    #{<<"components">> := #{<<"schemas">> := #{<<"OrgId0">> := OrgIdSchema}}} = Spec,
+    ?assertMatch(#{type := <<"string">>, pattern := <<"^org:">>}, OrgIdSchema).


### PR DESCRIPTION
…ters

When a type with binary type_parameters (e.g. <<"user:">>) was included as an OpenAPI component, to_inline_schema resolved it to #sp_simple_type{} and passed it directly to spectra_json_schema:to_schema. Since do_to_schema only checks codecs for sp_user_type_ref/sp_remote_type/sp_rec_ref, the codec's schema/5 callback was never invoked, and apply_string_params/2 crashed because it received a binary instead of a map.

Fix by consulting spectra_codec:try_codec_schema/4 in to_inline_schema before falling through to the default schema generator, mirroring what do_to_schema already does for reference types.