### PR TITLE
Thread sp_config through encode/decode pipeline, replace VSN cache with local/persistent/none modes

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -39,7 +39,7 @@ cover:
 check_app_calls:
 	rebar3 check_app_calls
 
-build-test: compile xref type_check test dialyzer hank check_app_calls format_verify cover
+build-test: compile xref type_check test dialyzer lint hank check_app_calls format_verify cover
 
 clean:
 	rebar3 clean

--- a/README.md
+++ b/README.md
@@ -697,7 +697,7 @@ You can configure spectra behavior using application environment variables:
   - `persistent` — stores type info in `persistent_term`, shared across all processes. Fastest for read-heavy workloads. Writes are expensive and trigger a global GC scan.
   - `local` — stores type info in the calling process's dictionary for the duration of a single `spectra:decode/encode/schema` call. Automatically cleared on return. Useful for request-scoped caching without the global write cost of `persistent_term`.
   - `none` — no caching; type info is always re-extracted from BEAM debug info.
-- **Note**: The module vsn is used for cache invalidation. When only changing types and not code, the module vsn is not updated, so the types will not be reflected until `spectra_module_types:clear/1` (for `persistent`) or a new call (for `local`) is made, or the module is recompiled.
+- **Note**: With `persistent`, cached type info remains until you explicitly clear it with `spectra_module_types:clear/1`. With `local`, the cache only exists for a single `spectra:decode/encode/schema` call and is automatically cleared when that call returns, so type changes are picked up on the next call.
 - **Recommendation**: Use `persistent` in production systems where no hot code reloading is done. Use `local` when you want per-call caching without affecting other processes.
 
 #### `check_unicode`

--- a/README.md
+++ b/README.md
@@ -144,35 +144,35 @@ Implement the `spectra_codec` behaviour in your module. Codec callbacks receive 
 -module(my_geo_codec).
 -behaviour(spectra_codec).
 
--export([encode/6, decode/6, schema/5]).
+-export([encode/7, decode/7, schema/6]).
 
 %% point() is an opaque type: {X, Y} tuple serialised as a JSON [X, Y] array.
 -type point() :: {float(), float()}.
 -export_type([point/0]).
 
-encode(json, _Mod, {type, point, 0}, {X, Y}, _SpType, _Params) when is_number(X), is_number(Y) ->
+encode(json, _Mod, {type, point, 0}, {X, Y}, _SpType, _Params, _Config) when is_number(X), is_number(Y) ->
     {ok, [X, Y]};
-encode(_Format, _Mod, {type, point, 0}, Data, _SpType, _Params) ->
+encode(_Format, _Mod, {type, point, 0}, Data, _SpType, _Params, _Config) ->
     {error, [sp_error:type_mismatch({type, point, 0}, Data)]};
-encode(_Format, _Mod, _TypeRef, _Data, _SpType, _Params) ->
+encode(_Format, _Mod, _TypeRef, _Data, _SpType, _Params, _Config) ->
     continue.
 
-decode(json, _Mod, {type, point, 0}, [X, Y], _SpType, _Params) when is_number(X), is_number(Y) ->
+decode(json, _Mod, {type, point, 0}, [X, Y], _SpType, _Params, _Config) when is_number(X), is_number(Y) ->
     {ok, {X, Y}};
-decode(_Format, _Mod, {type, point, 0}, Data, _SpType, _Params) ->
+decode(_Format, _Mod, {type, point, 0}, Data, _SpType, _Params, _Config) ->
     {error, [sp_error:type_mismatch({type, point, 0}, Data)]};
-decode(_Format, _Mod, _TypeRef, _Input, _SpType, _Params) ->
+decode(_Format, _Mod, _TypeRef, _Input, _SpType, _Params, _Config) ->
     continue.
 
-schema(json_schema, _Mod, {type, point, 0}, _SpType, _Params) ->
+schema(json_schema, _Mod, {type, point, 0}, _SpType, _Params, _Config) ->
     #{type => <<"array">>, items => #{type => <<"number">>}, minItems => 2, maxItems => 2};
-schema(_Format, _Mod, _TypeRef, _SpType, _Params) ->
+schema(_Format, _Mod, _TypeRef, _SpType, _Params, _Config) ->
     continue.
 ```
 
 For types your codec owns, return `{error, [sp_error:type_mismatch(TypeRef, Data)]}` when the data does not match — this allows spectra to correctly handle union types like `point() | undefined` by trying the next alternative instead of crashing on structural encoding of an opaque type.
 
-The `schema/5` callback is optional — you do not need to export it. If it is absent, calling `spectra:schema/3,4` for a type owned by that codec raises `{schema_not_implemented, Module, TypeRef}`.
+The `schema/6` callback is optional — you do not need to export it. If it is absent, calling `spectra:schema/3,4` for a type owned by that codec raises `{schema_not_implemented, Module, TypeRef}`.
 
 ### Types in the Same Module (No Configuration)
 
@@ -312,7 +312,7 @@ Unknown keys in the `type_parameters` map crash with `{invalid_string_constraint
 
 ### Codec Configuration
 
-The `type_parameters` value is passed as `Params` (the 6th argument) to `encode/6`, `decode/6`, and `schema/5`. This lets you reuse a single codec across multiple types that differ only by configuration.
+The `type_parameters` value is passed as `Params` (the 6th argument) to `encode/7`, `decode/7`, and `schema/6`. This lets you reuse a single codec across multiple types that differ only by configuration.
 
 For example, a prefixed-ID codec where each type carries its own expected prefix:
 
@@ -320,7 +320,7 @@ For example, a prefixed-ID codec where each type carries its own expected prefix
 -module(prefixed_id_codec).
 -behaviour(spectra_codec).
 
--export([encode/6, decode/6, schema/5]).
+-export([encode/7, decode/7, schema/6]).
 
 %% Only user_id() and org_id() are defined in this module, so spectra will only
 %% ever call this codec for those two types — no continue clause needed.
@@ -335,21 +335,21 @@ For example, a prefixed-ID codec where each type carries its own expected prefix
 -export_type([user_id/0, org_id/0]).
 
 %% Strips the prefix on decode, re-attaches it on encode.
-decode(json, ?MODULE, TypeRef, Data, _SpType, Prefix) when is_binary(Data), is_binary(Prefix) ->
+decode(json, ?MODULE, TypeRef, Data, _SpType, Prefix, _Config) when is_binary(Data), is_binary(Prefix) ->
     PrefixLen = byte_size(Prefix),
     case Data of
         <<Prefix:PrefixLen/binary, Rest/binary>> -> {ok, Rest};
         _ -> {error, [sp_error:type_mismatch(TypeRef, Data)]}
     end;
-decode(json, ?MODULE, TypeRef, Data, _SpType, _Prefix) ->
+decode(json, ?MODULE, TypeRef, Data, _SpType, _Prefix, _Config) ->
     {error, [sp_error:type_mismatch(TypeRef, Data)]}.
 
-encode(json, ?MODULE, _TypeRef, Data, _SpType, Prefix) when is_binary(Data), is_binary(Prefix) ->
+encode(json, ?MODULE, _TypeRef, Data, _SpType, Prefix, _Config) when is_binary(Data), is_binary(Prefix) ->
     {ok, <<Prefix/binary, Data/binary>>};
-encode(json, ?MODULE, TypeRef, Data, _SpType, _Prefix) ->
+encode(json, ?MODULE, TypeRef, Data, _SpType, _Prefix, _Config) ->
     {error, [sp_error:type_mismatch(TypeRef, Data)]}.
 
-schema(json_schema, ?MODULE, _TypeRef, _SpType, Prefix) when is_binary(Prefix) ->
+schema(json_schema, ?MODULE, _TypeRef, _SpType, Prefix, _Config) when is_binary(Prefix) ->
     #{type => <<"string">>, pattern => <<"^", Prefix/binary>>}.
 ```
 

--- a/README.md
+++ b/README.md
@@ -172,7 +172,7 @@ schema(_Format, _Mod, _TypeRef, _SpType, _Params, _Config) ->
 
 For types your codec owns, return `{error, [sp_error:type_mismatch(TypeRef, Data)]}` when the data does not match — this allows spectra to correctly handle union types like `point() | undefined` by trying the next alternative instead of crashing on structural encoding of an opaque type.
 
-The `schema/6` callback is optional — you do not need to export it. If it is absent, calling `spectra:schema/3,4` for a type owned by that codec raises `{schema_not_implemented, Module, TypeRef}`.
+The `schema/6` callback is optional — you do not need to export it if you only support formats that don't have a schema.
 
 ### Types in the Same Module (No Configuration)
 

--- a/README.md
+++ b/README.md
@@ -690,12 +690,15 @@ It would be interesting to add support for key value lists, but as it isn't a na
 
 You can configure spectra behavior using application environment variables:
 
-#### `use_module_types_cache`
-- **Type**: `boolean()`
-- **Default**: `false`
-- **Description**: When set to `true`, enables caching of extracted type information for modules using persistent terms. This can improve performance when repeatedly processing the same modules.
-- **Note**: The module vsn is used for cache invalidation. When only changing types and not code, the module vsn is not updated, so the types will not be reflected until `spectra_module_types:clear/1` is called or the module is recompiled.
-- **Recommendation**: Enable this in production systems where no hot code reloading is done.
+#### `module_types_cache`
+- **Type**: `persistent | local | none`
+- **Default**: `local`
+- **Description**: Controls caching of extracted type information for modules.
+  - `persistent` — stores type info in `persistent_term`, shared across all processes. Fastest for read-heavy workloads. Writes are expensive and trigger a global GC scan.
+  - `local` — stores type info in the calling process's dictionary for the duration of a single `spectra:decode/encode/schema` call. Automatically cleared on return. Useful for request-scoped caching without the global write cost of `persistent_term`.
+  - `none` — no caching; type info is always re-extracted from BEAM debug info.
+- **Note**: The module vsn is used for cache invalidation. When only changing types and not code, the module vsn is not updated, so the types will not be reflected until `spectra_module_types:clear/1` (for `persistent`) or a new call (for `local`) is made, or the module is recompiled.
+- **Recommendation**: Use `persistent` in production systems where no hot code reloading is done. Use `local` when you want per-call caching without affecting other processes.
 
 #### `check_unicode`
 - **Type**: `boolean()`
@@ -706,7 +709,7 @@ Example configuration in `sys.config`:
 
 ```erlang
 {spectra, [
-    {use_module_types_cache, true},
+    {module_types_cache, local},
     {check_unicode, false}
 ]}.
 ```

--- a/include/spectra_internal.hrl
+++ b/include/spectra_internal.hrl
@@ -104,7 +104,7 @@
 %% Runtime configuration snapshot — read once at the spectra.erl entry point and
 %% threaded through all format modules to avoid repeated application:get_env calls.
 -record(sp_config, {
-    use_module_types_cache = false :: boolean(),
+    module_types_cache = local :: spectra:module_types_cache(),
     check_unicode = false :: boolean(),
     codecs = #{} :: #{spectra:codec_key() => module()}
 }).

--- a/include/spectra_internal.hrl
+++ b/include/spectra_internal.hrl
@@ -101,6 +101,14 @@
     key_type :: spectra:sp_type(),
     val_type :: spectra:sp_type()
 }).
+%% Runtime configuration snapshot — read once at the spectra.erl entry point and
+%% threaded through all format modules to avoid repeated application:get_env calls.
+-record(sp_config, {
+    use_module_types_cache = false :: boolean(),
+    check_unicode = false :: boolean(),
+    codecs = #{} :: #{spectra:codec_key() => module()}
+}).
+
 %% New structured type information
 -record(type_info, {
     module :: module(),

--- a/src/spectra.app.src
+++ b/src/spectra.app.src
@@ -3,7 +3,7 @@
     {vsn, "git"},
     {registered, []},
     {applications, [kernel, stdlib]},
-    {env, [{check_unicode, false}, {use_module_types_cache, false}]},
+    {env, [{check_unicode, false}, {module_types_cache, local}]},
     {modules, []},
     {licenses, ["Apache-2.0"]},
     {links, [{"GitHub", "https://github.com/andreashasse/spectra"}]}

--- a/src/spectra.erl
+++ b/src/spectra.erl
@@ -70,6 +70,7 @@
 -type encode_option() :: pre_encoded | {pre_encoded, boolean()}.
 -type schema_option() :: pre_encoded | {pre_encoded, boolean()}.
 -type codec_key() :: {module(), sp_type_reference()}.
+-type module_types_cache() :: persistent | local | none.
 -type binary_string_decode_opts() :: map().
 -type binary_string_encode_opts() :: map().
 -doc """
@@ -132,6 +133,7 @@ Return type for codec `decode/4` callbacks. See `spectra_codec`.
     codec_encode_result/0,
     codec_decode_result/0,
     codec_key/0,
+    module_types_cache/0,
     schema_option/0,
     sp_config/0
 ]).
@@ -198,11 +200,15 @@ Accepts an options list. Supported options:
     {ok, dynamic()} | {error, [error()]}.
 decode(Format, Module, TypeOrRef, Data, Options) when is_atom(Module) ->
     Config = get_config(),
-    TypeInfo = spectra_module_types:get(Module, Config#sp_config.use_module_types_cache),
-    do_decode(Format, TypeInfo, TypeOrRef, Data, Options, Config);
+    TypeInfo = spectra_module_types:get(Module, Config#sp_config.module_types_cache),
+    Result = do_decode(Format, TypeInfo, TypeOrRef, Data, Options, Config),
+    maybe_clear_local_cache(Config),
+    Result;
 decode(Format, TypeInfo, TypeOrRef, Data, Options) ->
     Config = get_config(),
-    do_decode(Format, TypeInfo, TypeOrRef, Data, Options, Config).
+    Result = do_decode(Format, TypeInfo, TypeOrRef, Data, Options, Config),
+    maybe_clear_local_cache(Config),
+    Result.
 
 -spec do_decode(
     Format :: atom(),
@@ -330,11 +336,15 @@ Accepts an options list. Supported options:
     {ok, dynamic()} | {error, [error()]}.
 encode(Format, Module, TypeOrRef, Data, Options) when is_atom(Module) ->
     Config = get_config(),
-    TypeInfo = spectra_module_types:get(Module, Config#sp_config.use_module_types_cache),
-    do_encode(Format, TypeInfo, TypeOrRef, Data, Options, Config);
+    TypeInfo = spectra_module_types:get(Module, Config#sp_config.module_types_cache),
+    Result = do_encode(Format, TypeInfo, TypeOrRef, Data, Options, Config),
+    maybe_clear_local_cache(Config),
+    Result;
 encode(Format, TypeInfo, TypeOrRef, Data, Options) ->
     Config = get_config(),
-    do_encode(Format, TypeInfo, TypeOrRef, Data, Options, Config).
+    Result = do_encode(Format, TypeInfo, TypeOrRef, Data, Options, Config),
+    maybe_clear_local_cache(Config),
+    Result.
 
 -spec do_encode(
     Format :: atom(),
@@ -447,11 +457,15 @@ Accepts an options list. Supported options:
     iodata() | dynamic().
 schema(Format, Module, TypeOrRef, Options) when is_atom(Module) ->
     Config = get_config(),
-    TypeInfo = spectra_module_types:get(Module, Config#sp_config.use_module_types_cache),
-    do_schema(Format, TypeInfo, TypeOrRef, Options, Config);
+    TypeInfo = spectra_module_types:get(Module, Config#sp_config.module_types_cache),
+    Result = do_schema(Format, TypeInfo, TypeOrRef, Options, Config),
+    maybe_clear_local_cache(Config),
+    Result;
 schema(Format, TypeInfo, TypeOrRef, Options) ->
     Config = get_config(),
-    do_schema(Format, TypeInfo, TypeOrRef, Options, Config).
+    Result = do_schema(Format, TypeInfo, TypeOrRef, Options, Config),
+    maybe_clear_local_cache(Config),
+    Result.
 
 -spec resolve_type_ref(type_info(), sp_type_reference()) -> sp_type().
 resolve_type_ref(TypeInfo, {type, TypeName, TypeArity}) ->
@@ -505,7 +519,7 @@ maybe_codec_decode(Format, TypeInfo, SpType, Data, Options, Config) ->
             Data,
             SpType,
             Config#sp_config.codecs,
-            Config#sp_config.use_module_types_cache
+            Config#sp_config.module_types_cache
         )
     of
         continue -> default_decode(Format, TypeInfo, SpType, Data, Options, Config);
@@ -530,7 +544,7 @@ maybe_codec_encode(Format, TypeInfo, SpType, Data, Options, Config) ->
             Data,
             SpType,
             Config#sp_config.codecs,
-            Config#sp_config.use_module_types_cache
+            Config#sp_config.module_types_cache
         )
     of
         continue -> default_encode(Format, TypeInfo, SpType, Data, Options, Config);
@@ -596,10 +610,16 @@ atom_to_type_ref(TypeInfo, Atom) ->
 -spec get_config() -> sp_config().
 get_config() ->
     #sp_config{
-        use_module_types_cache = application:get_env(spectra, use_module_types_cache, false),
+        module_types_cache = application:get_env(spectra, module_types_cache, local),
         check_unicode = application:get_env(spectra, check_unicode, false),
         codecs = application:get_env(spectra, codecs, #{})
     }.
+
+-spec maybe_clear_local_cache(sp_config()) -> ok.
+maybe_clear_local_cache(#sp_config{module_types_cache = local}) ->
+    spectra_module_types:clear_local();
+maybe_clear_local_cache(_) ->
+    ok.
 
 json_decode(Binary) ->
     try

--- a/src/spectra.erl
+++ b/src/spectra.erl
@@ -214,7 +214,7 @@ decode(Format, TypeInfo, TypeOrRef, Data, Options) ->
 ) ->
     {ok, dynamic()} | {error, [error()]}.
 do_decode(Format, TypeInfo, RefAtom, Data, Options, Config) when is_atom(RefAtom) ->
-    TypeRef = spectra_util:normalize_type_ref(TypeInfo, RefAtom),
+    TypeRef = atom_to_type_ref(TypeInfo, RefAtom),
     do_decode(Format, TypeInfo, TypeRef, Data, Options, Config);
 do_decode(Format, TypeInfo, {type, _, _} = TypeRef, Data, Options, Config) ->
     SpType = resolve_type_ref(TypeInfo, TypeRef),
@@ -346,7 +346,7 @@ encode(Format, TypeInfo, TypeOrRef, Data, Options) ->
 ) ->
     {ok, dynamic()} | {error, [error()]}.
 do_encode(Format, TypeInfo, TypeAtom, Data, Options, Config) when is_atom(TypeAtom) ->
-    TypeRef = spectra_util:normalize_type_ref(TypeInfo, TypeAtom),
+    TypeRef = atom_to_type_ref(TypeInfo, TypeAtom),
     do_encode(Format, TypeInfo, TypeRef, Data, Options, Config);
 do_encode(Format, TypeInfo, {type, _, _} = TypeRef, Data, Options, Config) ->
     SpType = resolve_type_ref(TypeInfo, TypeRef),
@@ -537,10 +537,10 @@ maybe_codec_encode(Format, TypeInfo, SpType, Data, Options, Config) ->
         Result -> Result
     end.
 
--spec do_schema(atom(), type_info(), sp_type_or_ref(), [schema_option()], sp_config()) ->
+-spec do_schema(atom(), type_info(), atom() | sp_type_or_ref(), [schema_option()], sp_config()) ->
     iodata() | map().
 do_schema(Format, TypeInfo, TypeAtom, Options, Config) when is_atom(TypeAtom) ->
-    TypeRef = spectra_util:normalize_type_ref(TypeInfo, TypeAtom),
+    TypeRef = atom_to_type_ref(TypeInfo, TypeAtom),
     do_schema_ref(Format, TypeInfo, TypeRef, Options, Config);
 do_schema(Format, TypeInfo, {type, _, _} = TypeRef, Options, Config) ->
     do_schema_ref(Format, TypeInfo, TypeRef, Options, Config);
@@ -577,6 +577,20 @@ type_ref_from_meta(SpType) ->
     case spectra_type:get_meta(SpType) of
         #{name := TypeRef} -> {ok, TypeRef};
         #{} -> error
+    end.
+
+-spec atom_to_type_ref(type_info(), atom()) -> sp_type_reference().
+atom_to_type_ref(TypeInfo, Atom) ->
+    case spectra_type_info:find_type(TypeInfo, Atom, 0) of
+        {ok, _} ->
+            {type, Atom, 0};
+        error ->
+            case spectra_type_info:find_record(TypeInfo, Atom) of
+                {ok, _} ->
+                    {record, Atom};
+                error ->
+                    erlang:error({type_or_record_not_found, Atom})
+            end
     end.
 
 -spec get_config() -> sp_config().

--- a/src/spectra.erl
+++ b/src/spectra.erl
@@ -516,7 +516,7 @@ finalize_schema(Format, _SchemaMap, _Options) ->
 maybe_codec_decode(Format, TypeInfo, SpType, Data, Options, Config) ->
     Mod = spectra_type_info:get_module(TypeInfo),
     case
-        spectra_codec:try_codec_decode(Mod, Format, SpType, Data, SpType, Config#sp_config.codecs)
+        spectra_codec:try_codec_decode(Mod, Format, SpType, Data, SpType, Config#sp_config.codecs, Config#sp_config.use_module_types_cache)
     of
         continue -> default_decode(Format, TypeInfo, SpType, Data, Options, Config);
         Result -> Result
@@ -533,7 +533,7 @@ maybe_codec_decode(Format, TypeInfo, SpType, Data, Options, Config) ->
 maybe_codec_encode(Format, TypeInfo, SpType, Data, Options, Config) ->
     Mod = spectra_type_info:get_module(TypeInfo),
     case
-        spectra_codec:try_codec_encode(Mod, Format, SpType, Data, SpType, Config#sp_config.codecs)
+        spectra_codec:try_codec_encode(Mod, Format, SpType, Data, SpType, Config#sp_config.codecs, Config#sp_config.use_module_types_cache)
     of
         continue -> default_encode(Format, TypeInfo, SpType, Data, Options, Config);
         Result -> Result

--- a/src/spectra.erl
+++ b/src/spectra.erl
@@ -7,6 +7,7 @@
 -include("../include/spectra.hrl").
 -include("../include/spectra_internal.hrl").
 
+-type sp_config() :: #sp_config{}.
 -type type_info() :: spectra_type_info:type_info().
 -type var_type() :: {VarName :: atom(), sp_type()}.
 -type user_type_name() :: atom().
@@ -131,7 +132,8 @@ Return type for codec `decode/4` callbacks. See `spectra_codec`.
     codec_encode_result/0,
     codec_decode_result/0,
     codec_key/0,
-    schema_option/0
+    schema_option/0,
+    sp_config/0
 ]).
 
 -doc """
@@ -195,41 +197,56 @@ Accepts an options list. Supported options:
 ) ->
     {ok, dynamic()} | {error, [error()]}.
 decode(Format, Module, TypeOrRef, Data, Options) when is_atom(Module) ->
-    TypeInfo = spectra_module_types:get(Module),
-    decode(Format, TypeInfo, TypeOrRef, Data, Options);
-decode(Format, TypeInfo, RefAtom, Data, Options) when is_atom(RefAtom) ->
+    Config = get_config(),
+    TypeInfo = spectra_module_types:get(Module, Config#sp_config.use_module_types_cache),
+    do_decode(Format, TypeInfo, TypeOrRef, Data, Options, Config);
+decode(Format, TypeInfo, TypeOrRef, Data, Options) ->
+    Config = get_config(),
+    do_decode(Format, TypeInfo, TypeOrRef, Data, Options, Config).
+
+-spec do_decode(
+    Format :: atom(),
+    TypeInfo :: type_info(),
+    TypeOrRef :: atom() | sp_type_or_ref(),
+    Data :: dynamic(),
+    Options :: [decode_option()],
+    Config :: sp_config()
+) ->
+    {ok, dynamic()} | {error, [error()]}.
+do_decode(Format, TypeInfo, RefAtom, Data, Options, Config) when is_atom(RefAtom) ->
     TypeRef = spectra_util:normalize_type_ref(TypeInfo, RefAtom),
-    decode(Format, TypeInfo, TypeRef, Data, Options);
-decode(Format, TypeInfo, {type, _, _} = TypeRef, Data, Options) ->
+    do_decode(Format, TypeInfo, TypeRef, Data, Options, Config);
+do_decode(Format, TypeInfo, {type, _, _} = TypeRef, Data, Options, Config) ->
     SpType = resolve_type_ref(TypeInfo, TypeRef),
-    maybe_codec_decode(Format, TypeInfo, SpType, Data, Options);
-decode(Format, TypeInfo, {record, _} = TypeRef, Data, Options) ->
+    maybe_codec_decode(Format, TypeInfo, SpType, Data, Options, Config);
+do_decode(Format, TypeInfo, {record, _} = TypeRef, Data, Options, Config) ->
     SpType = resolve_type_ref(TypeInfo, TypeRef),
-    maybe_codec_decode(Format, TypeInfo, SpType, Data, Options);
-decode(Format, TypeInfo, SpType, Data, Options) when is_record(TypeInfo, type_info) ->
+    maybe_codec_decode(Format, TypeInfo, SpType, Data, Options, Config);
+do_decode(Format, TypeInfo, SpType, Data, Options, Config) when is_record(TypeInfo, type_info) ->
     case type_ref_from_meta(SpType) of
         {ok, _TypeRef} ->
-            maybe_codec_decode(Format, TypeInfo, SpType, Data, Options);
+            maybe_codec_decode(Format, TypeInfo, SpType, Data, Options, Config);
         error ->
-            default_decode(Format, TypeInfo, SpType, Data, Options)
+            default_decode(Format, TypeInfo, SpType, Data, Options, Config)
     end;
-decode(Format, TypeInfo, SpType, Data, Options) ->
-    default_decode(Format, TypeInfo, SpType, Data, Options).
+do_decode(Format, TypeInfo, SpType, Data, Options, Config) ->
+    default_decode(Format, TypeInfo, SpType, Data, Options, Config).
 
 -spec default_decode(
     Format :: atom(),
     TypeInfo :: type_info(),
     Type :: sp_type(),
     Data :: dynamic(),
-    Options :: [decode_option()]
+    Options :: [decode_option()],
+    Config :: sp_config()
 ) ->
     {ok, dynamic()} | {error, [error()]}.
-default_decode(json, Typeinfo, Type, Data, Options) ->
+default_decode(json, Typeinfo, Type, Data, Options, Config) ->
     case proplists:get_value(pre_decoded, Options, false) of
         false when is_binary(Data) ->
             case json_decode(Data) of
                 {ok, DecodedJson} ->
-                    spectra_json:from_json(Typeinfo, Type, DecodedJson);
+                    spectra_json:from_json(Typeinfo, Type, DecodedJson, Config);
                 {error, _} = Err ->
                     Err
             end;
@@ -245,12 +262,14 @@ default_decode(json, Typeinfo, Type, Data, Options) ->
                 }
             ]};
         true ->
-            spectra_json:from_json(Typeinfo, Type, Data)
+            spectra_json:from_json(Typeinfo, Type, Data, Config)
     end;
-default_decode(binary_string, Typeinfo, TypeOrRef, Binary, _Options) when is_binary(Binary) ->
-    spectra_binary_string:from_binary_string(Typeinfo, TypeOrRef, Binary);
-default_decode(string, Typeinfo, TypeOrRef, String, _Options) when is_list(String) ->
-    spectra_string:from_string(Typeinfo, TypeOrRef, String).
+default_decode(binary_string, Typeinfo, TypeOrRef, Binary, _Options, Config) when
+    is_binary(Binary)
+->
+    spectra_binary_string:from_binary_string(Typeinfo, TypeOrRef, Binary, #{}, Config);
+default_decode(string, Typeinfo, TypeOrRef, String, _Options, Config) when is_list(String) ->
+    spectra_string:from_string(Typeinfo, TypeOrRef, String, Config).
 
 -doc """
 Encodes an Erlang term to the specified format based on type information.
@@ -310,37 +329,52 @@ Accepts an options list. Supported options:
 ) ->
     {ok, dynamic()} | {error, [error()]}.
 encode(Format, Module, TypeOrRef, Data, Options) when is_atom(Module) ->
-    TypeInfo = spectra_module_types:get(Module),
-    encode(Format, TypeInfo, TypeOrRef, Data, Options);
-encode(Format, TypeInfo, TypeAtom, Data, Options) when is_atom(TypeAtom) ->
+    Config = get_config(),
+    TypeInfo = spectra_module_types:get(Module, Config#sp_config.use_module_types_cache),
+    do_encode(Format, TypeInfo, TypeOrRef, Data, Options, Config);
+encode(Format, TypeInfo, TypeOrRef, Data, Options) ->
+    Config = get_config(),
+    do_encode(Format, TypeInfo, TypeOrRef, Data, Options, Config).
+
+-spec do_encode(
+    Format :: atom(),
+    TypeInfo :: type_info(),
+    TypeOrRef :: atom() | sp_type_or_ref(),
+    Data :: dynamic(),
+    Options :: [encode_option()],
+    Config :: sp_config()
+) ->
+    {ok, dynamic()} | {error, [error()]}.
+do_encode(Format, TypeInfo, TypeAtom, Data, Options, Config) when is_atom(TypeAtom) ->
     TypeRef = spectra_util:normalize_type_ref(TypeInfo, TypeAtom),
-    encode(Format, TypeInfo, TypeRef, Data, Options);
-encode(Format, TypeInfo, {type, _, _} = TypeRef, Data, Options) ->
+    do_encode(Format, TypeInfo, TypeRef, Data, Options, Config);
+do_encode(Format, TypeInfo, {type, _, _} = TypeRef, Data, Options, Config) ->
     SpType = resolve_type_ref(TypeInfo, TypeRef),
-    maybe_codec_encode(Format, TypeInfo, SpType, Data, Options);
-encode(Format, TypeInfo, {record, _} = TypeRef, Data, Options) ->
+    maybe_codec_encode(Format, TypeInfo, SpType, Data, Options, Config);
+do_encode(Format, TypeInfo, {record, _} = TypeRef, Data, Options, Config) ->
     SpType = resolve_type_ref(TypeInfo, TypeRef),
-    maybe_codec_encode(Format, TypeInfo, SpType, Data, Options);
-encode(Format, TypeInfo, SpType, Data, Options) when is_record(TypeInfo, type_info) ->
+    maybe_codec_encode(Format, TypeInfo, SpType, Data, Options, Config);
+do_encode(Format, TypeInfo, SpType, Data, Options, Config) when is_record(TypeInfo, type_info) ->
     case type_ref_from_meta(SpType) of
         {ok, _TypeRef} ->
-            maybe_codec_encode(Format, TypeInfo, SpType, Data, Options);
+            maybe_codec_encode(Format, TypeInfo, SpType, Data, Options, Config);
         error ->
-            default_encode(Format, TypeInfo, SpType, Data, Options)
+            default_encode(Format, TypeInfo, SpType, Data, Options, Config)
     end;
-encode(Format, TypeInfo, SpType, Data, Options) ->
-    default_encode(Format, TypeInfo, SpType, Data, Options).
+do_encode(Format, TypeInfo, SpType, Data, Options, Config) ->
+    default_encode(Format, TypeInfo, SpType, Data, Options, Config).
 
 -spec default_encode(
     Format :: atom(),
     TypeInfo :: type_info(),
     SpType :: sp_type(),
     Data :: dynamic(),
-    Options :: [encode_option()]
+    Options :: [encode_option()],
+    Config :: sp_config()
 ) ->
     {ok, dynamic()} | {error, [error()]}.
-default_encode(json, Typeinfo, TypeOrRef, Data, Options) ->
-    case spectra_json:to_json(Typeinfo, TypeOrRef, Data) of
+default_encode(json, Typeinfo, TypeOrRef, Data, Options, Config) ->
+    case spectra_json:to_json(Typeinfo, TypeOrRef, Data, Config) of
         {ok, Json} ->
             case proplists:get_value(pre_encoded, Options, false) of
                 false -> {ok, json:encode(Json)};
@@ -349,10 +383,10 @@ default_encode(json, Typeinfo, TypeOrRef, Data, Options) ->
         {error, _} = Err ->
             Err
     end;
-default_encode(binary_string, Typeinfo, TypeOrRef, Data, _Options) ->
-    spectra_binary_string:to_binary_string(Typeinfo, TypeOrRef, Data);
-default_encode(string, Typeinfo, TypeOrRef, Data, _Options) ->
-    spectra_string:to_string(Typeinfo, TypeOrRef, Data).
+default_encode(binary_string, Typeinfo, TypeOrRef, Data, _Options, Config) ->
+    spectra_binary_string:to_binary_string(Typeinfo, TypeOrRef, Data, #{}, Config);
+default_encode(string, Typeinfo, TypeOrRef, Data, _Options, Config) ->
+    spectra_string:to_string(Typeinfo, TypeOrRef, Data, Config).
 
 -doc """
 Generates a schema for the specified type in the given format.
@@ -412,7 +446,8 @@ Accepts an options list. Supported options:
 ) ->
     iodata() | dynamic().
 schema(Format, Module, TypeOrRef, Options) when is_atom(Module) ->
-    TypeInfo = spectra_module_types:get(Module),
+    UseCache = application:get_env(spectra, use_module_types_cache, false),
+    TypeInfo = spectra_module_types:get(Module, UseCache),
     schema(Format, TypeInfo, TypeOrRef, Options);
 schema(Format, TypeInfo, TypeAtom, Options) when is_atom(TypeAtom) ->
     TypeRef = spectra_util:normalize_type_ref(TypeInfo, TypeAtom),
@@ -475,12 +510,15 @@ finalize_schema(Format, _SchemaMap, _Options) ->
     TypeInfo :: type_info(),
     SpType :: sp_type(),
     Data :: dynamic(),
-    Options :: [decode_option()]
+    Options :: [decode_option()],
+    Config :: sp_config()
 ) -> {ok, dynamic()} | {error, [error()]}.
-maybe_codec_decode(Format, TypeInfo, SpType, Data, Options) ->
+maybe_codec_decode(Format, TypeInfo, SpType, Data, Options, Config) ->
     Mod = spectra_type_info:get_module(TypeInfo),
-    case spectra_codec:try_codec_decode(Mod, Format, SpType, Data, SpType) of
-        continue -> default_decode(Format, TypeInfo, SpType, Data, Options);
+    case
+        spectra_codec:try_codec_decode(Mod, Format, SpType, Data, SpType, Config#sp_config.codecs)
+    of
+        continue -> default_decode(Format, TypeInfo, SpType, Data, Options, Config);
         Result -> Result
     end.
 
@@ -489,12 +527,15 @@ maybe_codec_decode(Format, TypeInfo, SpType, Data, Options) ->
     TypeInfo :: type_info(),
     SpType :: sp_type(),
     Data :: dynamic(),
-    Options :: [encode_option()]
+    Options :: [encode_option()],
+    Config :: sp_config()
 ) -> {ok, dynamic()} | {error, [error()]}.
-maybe_codec_encode(Format, TypeInfo, SpType, Data, Options) ->
+maybe_codec_encode(Format, TypeInfo, SpType, Data, Options, Config) ->
     Mod = spectra_type_info:get_module(TypeInfo),
-    case spectra_codec:try_codec_encode(Mod, Format, SpType, Data, SpType) of
-        continue -> default_encode(Format, TypeInfo, SpType, Data, Options);
+    case
+        spectra_codec:try_codec_encode(Mod, Format, SpType, Data, SpType, Config#sp_config.codecs)
+    of
+        continue -> default_encode(Format, TypeInfo, SpType, Data, Options, Config);
         Result -> Result
     end.
 
@@ -515,6 +556,14 @@ type_ref_from_meta(SpType) ->
         #{name := TypeRef} -> {ok, TypeRef};
         #{} -> error
     end.
+
+-spec get_config() -> sp_config().
+get_config() ->
+    #sp_config{
+        use_module_types_cache = application:get_env(spectra, use_module_types_cache, false),
+        check_unicode = application:get_env(spectra, check_unicode, false),
+        codecs = application:get_env(spectra, codecs, #{})
+    }.
 
 json_decode(Binary) ->
     try

--- a/src/spectra.erl
+++ b/src/spectra.erl
@@ -606,10 +606,18 @@ type_ref_from_meta(SpType) ->
 -spec get_config() -> sp_config().
 get_config() ->
     #sp_config{
-        module_types_cache = application:get_env(spectra, module_types_cache, local),
+        module_types_cache = valid_module_types_cache(
+            application:get_env(spectra, module_types_cache, local)
+        ),
         check_unicode = application:get_env(spectra, check_unicode, false),
         codecs = application:get_env(spectra, codecs, #{})
     }.
+
+-spec valid_module_types_cache(term()) -> module_types_cache().
+valid_module_types_cache(persistent) -> persistent;
+valid_module_types_cache(local) -> local;
+valid_module_types_cache(none) -> none;
+valid_module_types_cache(Value) -> erlang:error({invalid_config, module_types_cache, Value}).
 
 -spec maybe_clear_local_cache(sp_config()) -> ok.
 maybe_clear_local_cache(#sp_config{module_types_cache = local}) ->

--- a/src/spectra.erl
+++ b/src/spectra.erl
@@ -200,7 +200,7 @@ Accepts an options list. Supported options:
     {ok, dynamic()} | {error, [error()]}.
 decode(Format, Module, TypeOrRef, Data, Options) when is_atom(Module) ->
     Config = get_config(),
-    TypeInfo = spectra_module_types:get(Module, Config#sp_config.module_types_cache),
+    TypeInfo = spectra_module_types:get(Module, Config),
     try
         do_decode(Format, TypeInfo, TypeOrRef, Data, Options, Config)
     after
@@ -340,7 +340,7 @@ Accepts an options list. Supported options:
     {ok, dynamic()} | {error, [error()]}.
 encode(Format, Module, TypeOrRef, Data, Options) when is_atom(Module) ->
     Config = get_config(),
-    TypeInfo = spectra_module_types:get(Module, Config#sp_config.module_types_cache),
+    TypeInfo = spectra_module_types:get(Module, Config),
     try
         do_encode(Format, TypeInfo, TypeOrRef, Data, Options, Config)
     after
@@ -465,7 +465,7 @@ Accepts an options list. Supported options:
     iodata() | dynamic().
 schema(Format, Module, TypeOrRef, Options) when is_atom(Module) ->
     Config = get_config(),
-    TypeInfo = spectra_module_types:get(Module, Config#sp_config.module_types_cache),
+    TypeInfo = spectra_module_types:get(Module, Config),
     try
         do_schema(Format, TypeInfo, TypeOrRef, Options, Config)
     after

--- a/src/spectra.erl
+++ b/src/spectra.erl
@@ -516,7 +516,15 @@ finalize_schema(Format, _SchemaMap, _Options) ->
 maybe_codec_decode(Format, TypeInfo, SpType, Data, Options, Config) ->
     Mod = spectra_type_info:get_module(TypeInfo),
     case
-        spectra_codec:try_codec_decode(Mod, Format, SpType, Data, SpType, Config#sp_config.codecs, Config#sp_config.use_module_types_cache)
+        spectra_codec:try_codec_decode(
+            Mod,
+            Format,
+            SpType,
+            Data,
+            SpType,
+            Config#sp_config.codecs,
+            Config#sp_config.use_module_types_cache
+        )
     of
         continue -> default_decode(Format, TypeInfo, SpType, Data, Options, Config);
         Result -> Result
@@ -533,7 +541,15 @@ maybe_codec_decode(Format, TypeInfo, SpType, Data, Options, Config) ->
 maybe_codec_encode(Format, TypeInfo, SpType, Data, Options, Config) ->
     Mod = spectra_type_info:get_module(TypeInfo),
     case
-        spectra_codec:try_codec_encode(Mod, Format, SpType, Data, SpType, Config#sp_config.codecs, Config#sp_config.use_module_types_cache)
+        spectra_codec:try_codec_encode(
+            Mod,
+            Format,
+            SpType,
+            Data,
+            SpType,
+            Config#sp_config.codecs,
+            Config#sp_config.use_module_types_cache
+        )
     of
         continue -> default_encode(Format, TypeInfo, SpType, Data, Options, Config);
         Result -> Result

--- a/src/spectra.erl
+++ b/src/spectra.erl
@@ -224,7 +224,7 @@ decode(Format, TypeInfo, TypeOrRef, Data, Options) ->
 ) ->
     {ok, dynamic()} | {error, [error()]}.
 do_decode(Format, TypeInfo, RefAtom, Data, Options, Config) when is_atom(RefAtom) ->
-    TypeRef = atom_to_type_ref(TypeInfo, RefAtom),
+    TypeRef = spectra_util:normalize_type_ref(TypeInfo, RefAtom),
     do_decode(Format, TypeInfo, TypeRef, Data, Options, Config);
 do_decode(Format, TypeInfo, {type, _, _} = TypeRef, Data, Options, Config) ->
     SpType = resolve_type_ref(TypeInfo, TypeRef),
@@ -364,7 +364,7 @@ encode(Format, TypeInfo, TypeOrRef, Data, Options) ->
 ) ->
     {ok, dynamic()} | {error, [error()]}.
 do_encode(Format, TypeInfo, TypeAtom, Data, Options, Config) when is_atom(TypeAtom) ->
-    TypeRef = atom_to_type_ref(TypeInfo, TypeAtom),
+    TypeRef = spectra_util:normalize_type_ref(TypeInfo, TypeAtom),
     do_encode(Format, TypeInfo, TypeRef, Data, Options, Config);
 do_encode(Format, TypeInfo, {type, _, _} = TypeRef, Data, Options, Config) ->
     SpType = resolve_type_ref(TypeInfo, TypeRef),
@@ -564,8 +564,8 @@ maybe_codec_encode(Format, TypeInfo, SpType, Data, Options, Config) ->
 -spec do_schema(atom(), type_info(), atom() | sp_type_or_ref(), [schema_option()], sp_config()) ->
     iodata() | map().
 do_schema(Format, TypeInfo, TypeAtom, Options, Config) when is_atom(TypeAtom) ->
-    TypeRef = atom_to_type_ref(TypeInfo, TypeAtom),
-    do_schema_ref(Format, TypeInfo, TypeRef, Options, Config);
+    TypeRef = spectra_util:normalize_type_ref(TypeInfo, TypeAtom),
+    do_schema(Format, TypeInfo, TypeRef, Options, Config);
 do_schema(Format, TypeInfo, {type, _, _} = TypeRef, Options, Config) ->
     do_schema_ref(Format, TypeInfo, TypeRef, Options, Config);
 do_schema(Format, TypeInfo, {record, _} = TypeRef, Options, Config) ->
@@ -601,20 +601,6 @@ type_ref_from_meta(SpType) ->
     case spectra_type:get_meta(SpType) of
         #{name := TypeRef} -> {ok, TypeRef};
         #{} -> error
-    end.
-
--spec atom_to_type_ref(type_info(), atom()) -> sp_type_reference().
-atom_to_type_ref(TypeInfo, Atom) ->
-    case spectra_type_info:find_type(TypeInfo, Atom, 0) of
-        {ok, _} ->
-            {type, Atom, 0};
-        error ->
-            case spectra_type_info:find_record(TypeInfo, Atom) of
-                {ok, _} ->
-                    {record, Atom};
-                error ->
-                    erlang:error({type_or_record_not_found, Atom})
-            end
     end.
 
 -spec get_config() -> sp_config().

--- a/src/spectra.erl
+++ b/src/spectra.erl
@@ -490,8 +490,7 @@ resolve_type_ref(TypeInfo, {record, RecordName}) ->
     spectra_json_schema:json_schema_object().
 maybe_codec_schema(Format, TypeInfo, TypeRef, Config) ->
     SpType = resolve_type_ref(TypeInfo, TypeRef),
-    Mod = spectra_type_info:get_module(TypeInfo),
-    case spectra_codec:try_codec_schema(Mod, Format, SpType, SpType, Config) of
+    case spectra_codec:try_codec_schema(TypeInfo, Format, SpType, SpType, Config) of
         continue -> default_schema(Format, TypeInfo, SpType, Config);
         Schema -> Schema
     end.
@@ -522,10 +521,9 @@ finalize_schema(Format, _SchemaMap, _Options) ->
     Config :: sp_config()
 ) -> {ok, dynamic()} | {error, [error()]}.
 maybe_codec_decode(Format, TypeInfo, SpType, Data, Options, Config) ->
-    Mod = spectra_type_info:get_module(TypeInfo),
     case
         spectra_codec:try_codec_decode(
-            Mod,
+            TypeInfo,
             Format,
             SpType,
             Data,
@@ -546,10 +544,9 @@ maybe_codec_decode(Format, TypeInfo, SpType, Data, Options, Config) ->
     Config :: sp_config()
 ) -> {ok, dynamic()} | {error, [error()]}.
 maybe_codec_encode(Format, TypeInfo, SpType, Data, Options, Config) ->
-    Mod = spectra_type_info:get_module(TypeInfo),
     case
         spectra_codec:try_codec_encode(
-            Mod,
+            TypeInfo,
             Format,
             SpType,
             Data,

--- a/src/spectra.erl
+++ b/src/spectra.erl
@@ -446,30 +446,12 @@ Accepts an options list. Supported options:
 ) ->
     iodata() | dynamic().
 schema(Format, Module, TypeOrRef, Options) when is_atom(Module) ->
-    UseCache = application:get_env(spectra, use_module_types_cache, false),
-    TypeInfo = spectra_module_types:get(Module, UseCache),
-    schema(Format, TypeInfo, TypeOrRef, Options);
-schema(Format, TypeInfo, TypeAtom, Options) when is_atom(TypeAtom) ->
-    TypeRef = spectra_util:normalize_type_ref(TypeInfo, TypeAtom),
-    schema(Format, TypeInfo, TypeRef, Options);
-schema(Format, TypeInfo, {type, _, _} = TypeRef, Options) ->
-    do_schema_ref(Format, TypeInfo, TypeRef, Options);
-schema(Format, TypeInfo, {record, _} = TypeRef, Options) ->
-    do_schema_ref(Format, TypeInfo, TypeRef, Options);
-schema(json_schema, TypeInfo, SpType, Options) when is_record(TypeInfo, type_info) ->
-    SchemaMap =
-        case type_ref_from_meta(SpType) of
-            {ok, TypeRef} -> maybe_codec_schema(json_schema, TypeInfo, TypeRef);
-            error -> default_schema(json_schema, TypeInfo, SpType)
-        end,
-    finalize_schema(json_schema, spectra_json_schema:add_schema_version(SchemaMap), Options);
-schema(Format, TypeInfo, SpType, Options) when is_record(TypeInfo, type_info) ->
-    SchemaMap =
-        case type_ref_from_meta(SpType) of
-            {ok, TypeRef} -> maybe_codec_schema(Format, TypeInfo, TypeRef);
-            error -> default_schema(Format, TypeInfo, SpType)
-        end,
-    finalize_schema(Format, SchemaMap, Options).
+    Config = get_config(),
+    TypeInfo = spectra_module_types:get(Module, Config#sp_config.use_module_types_cache),
+    do_schema(Format, TypeInfo, TypeOrRef, Options, Config);
+schema(Format, TypeInfo, TypeOrRef, Options) ->
+    Config = get_config(),
+    do_schema(Format, TypeInfo, TypeOrRef, Options, Config).
 
 -spec resolve_type_ref(type_info(), sp_type_reference()) -> sp_type().
 resolve_type_ref(TypeInfo, {type, TypeName, TypeArity}) ->
@@ -478,21 +460,21 @@ resolve_type_ref(TypeInfo, {type, TypeName, TypeArity}) ->
 resolve_type_ref(TypeInfo, {record, RecordName}) ->
     spectra_type_info:get_record(TypeInfo, RecordName).
 
--spec maybe_codec_schema(atom(), type_info(), sp_type_reference()) ->
+-spec maybe_codec_schema(atom(), type_info(), sp_type_reference(), sp_config()) ->
     spectra_json_schema:json_schema_object().
-maybe_codec_schema(Format, TypeInfo, TypeRef) ->
+maybe_codec_schema(Format, TypeInfo, TypeRef, Config) ->
     SpType = resolve_type_ref(TypeInfo, TypeRef),
     Mod = spectra_type_info:get_module(TypeInfo),
-    case spectra_codec:try_codec_schema(Mod, Format, SpType, SpType) of
-        continue -> default_schema(Format, TypeInfo, SpType);
+    case spectra_codec:try_codec_schema(Mod, Format, SpType, SpType, Config) of
+        continue -> default_schema(Format, TypeInfo, SpType, Config);
         Schema -> Schema
     end.
 
--spec default_schema(atom(), type_info(), sp_type()) ->
+-spec default_schema(atom(), type_info(), sp_type(), sp_config()) ->
     spectra_json_schema:json_schema_object().
-default_schema(json_schema, TypeInfo, SpType) ->
-    spectra_json_schema:to_schema(TypeInfo, SpType);
-default_schema(Format, _TypeInfo, _SpType) ->
+default_schema(json_schema, TypeInfo, SpType, Config) ->
+    spectra_json_schema:to_schema(TypeInfo, SpType, Config);
+default_schema(Format, _TypeInfo, _SpType, _Config) ->
     erlang:error({unsupported_format, Format}).
 
 -spec finalize_schema(atom(), spectra_json_schema:json_schema(), [schema_option()]) ->
@@ -555,15 +537,39 @@ maybe_codec_encode(Format, TypeInfo, SpType, Data, Options, Config) ->
         Result -> Result
     end.
 
--spec do_schema_ref(atom(), type_info(), sp_type_reference(), [schema_option()]) ->
+-spec do_schema(atom(), type_info(), sp_type_or_ref(), [schema_option()], sp_config()) ->
     iodata() | map().
-do_schema_ref(json_schema, TypeInfo, TypeRef, Options) ->
+do_schema(Format, TypeInfo, TypeAtom, Options, Config) when is_atom(TypeAtom) ->
+    TypeRef = spectra_util:normalize_type_ref(TypeInfo, TypeAtom),
+    do_schema_ref(Format, TypeInfo, TypeRef, Options, Config);
+do_schema(Format, TypeInfo, {type, _, _} = TypeRef, Options, Config) ->
+    do_schema_ref(Format, TypeInfo, TypeRef, Options, Config);
+do_schema(Format, TypeInfo, {record, _} = TypeRef, Options, Config) ->
+    do_schema_ref(Format, TypeInfo, TypeRef, Options, Config);
+do_schema(json_schema, TypeInfo, SpType, Options, Config) ->
+    SchemaMap =
+        case type_ref_from_meta(SpType) of
+            {ok, TypeRef} -> maybe_codec_schema(json_schema, TypeInfo, TypeRef, Config);
+            error -> default_schema(json_schema, TypeInfo, SpType, Config)
+        end,
+    finalize_schema(json_schema, spectra_json_schema:add_schema_version(SchemaMap), Options);
+do_schema(Format, TypeInfo, SpType, Options, Config) ->
+    SchemaMap =
+        case type_ref_from_meta(SpType) of
+            {ok, TypeRef} -> maybe_codec_schema(Format, TypeInfo, TypeRef, Config);
+            error -> default_schema(Format, TypeInfo, SpType, Config)
+        end,
+    finalize_schema(Format, SchemaMap, Options).
+
+-spec do_schema_ref(atom(), type_info(), sp_type_reference(), [schema_option()], sp_config()) ->
+    iodata() | map().
+do_schema_ref(json_schema, TypeInfo, TypeRef, Options, Config) ->
     SchemaMap = spectra_json_schema:add_schema_version(
-        maybe_codec_schema(json_schema, TypeInfo, TypeRef)
+        maybe_codec_schema(json_schema, TypeInfo, TypeRef, Config)
     ),
     finalize_schema(json_schema, SchemaMap, Options);
-do_schema_ref(Format, TypeInfo, TypeRef, Options) ->
-    SchemaMap = maybe_codec_schema(Format, TypeInfo, TypeRef),
+do_schema_ref(Format, TypeInfo, TypeRef, Options, Config) ->
+    SchemaMap = maybe_codec_schema(Format, TypeInfo, TypeRef, Config),
     finalize_schema(Format, SchemaMap, Options).
 
 -spec type_ref_from_meta(sp_type()) -> {ok, sp_type_reference()} | error.

--- a/src/spectra.erl
+++ b/src/spectra.erl
@@ -201,14 +201,18 @@ Accepts an options list. Supported options:
 decode(Format, Module, TypeOrRef, Data, Options) when is_atom(Module) ->
     Config = get_config(),
     TypeInfo = spectra_module_types:get(Module, Config#sp_config.module_types_cache),
-    Result = do_decode(Format, TypeInfo, TypeOrRef, Data, Options, Config),
-    maybe_clear_local_cache(Config),
-    Result;
+    try
+        do_decode(Format, TypeInfo, TypeOrRef, Data, Options, Config)
+    after
+        maybe_clear_local_cache(Config)
+    end;
 decode(Format, TypeInfo, TypeOrRef, Data, Options) ->
     Config = get_config(),
-    Result = do_decode(Format, TypeInfo, TypeOrRef, Data, Options, Config),
-    maybe_clear_local_cache(Config),
-    Result.
+    try
+        do_decode(Format, TypeInfo, TypeOrRef, Data, Options, Config)
+    after
+        maybe_clear_local_cache(Config)
+    end.
 
 -spec do_decode(
     Format :: atom(),
@@ -337,14 +341,18 @@ Accepts an options list. Supported options:
 encode(Format, Module, TypeOrRef, Data, Options) when is_atom(Module) ->
     Config = get_config(),
     TypeInfo = spectra_module_types:get(Module, Config#sp_config.module_types_cache),
-    Result = do_encode(Format, TypeInfo, TypeOrRef, Data, Options, Config),
-    maybe_clear_local_cache(Config),
-    Result;
+    try
+        do_encode(Format, TypeInfo, TypeOrRef, Data, Options, Config)
+    after
+        maybe_clear_local_cache(Config)
+    end;
 encode(Format, TypeInfo, TypeOrRef, Data, Options) ->
     Config = get_config(),
-    Result = do_encode(Format, TypeInfo, TypeOrRef, Data, Options, Config),
-    maybe_clear_local_cache(Config),
-    Result.
+    try
+        do_encode(Format, TypeInfo, TypeOrRef, Data, Options, Config)
+    after
+        maybe_clear_local_cache(Config)
+    end.
 
 -spec do_encode(
     Format :: atom(),
@@ -458,14 +466,18 @@ Accepts an options list. Supported options:
 schema(Format, Module, TypeOrRef, Options) when is_atom(Module) ->
     Config = get_config(),
     TypeInfo = spectra_module_types:get(Module, Config#sp_config.module_types_cache),
-    Result = do_schema(Format, TypeInfo, TypeOrRef, Options, Config),
-    maybe_clear_local_cache(Config),
-    Result;
+    try
+        do_schema(Format, TypeInfo, TypeOrRef, Options, Config)
+    after
+        maybe_clear_local_cache(Config)
+    end;
 schema(Format, TypeInfo, TypeOrRef, Options) ->
     Config = get_config(),
-    Result = do_schema(Format, TypeInfo, TypeOrRef, Options, Config),
-    maybe_clear_local_cache(Config),
-    Result.
+    try
+        do_schema(Format, TypeInfo, TypeOrRef, Options, Config)
+    after
+        maybe_clear_local_cache(Config)
+    end.
 
 -spec resolve_type_ref(type_info(), sp_type_reference()) -> sp_type().
 resolve_type_ref(TypeInfo, {type, TypeName, TypeArity}) ->
@@ -518,8 +530,7 @@ maybe_codec_decode(Format, TypeInfo, SpType, Data, Options, Config) ->
             SpType,
             Data,
             SpType,
-            Config#sp_config.codecs,
-            Config#sp_config.module_types_cache
+            Config
         )
     of
         continue -> default_decode(Format, TypeInfo, SpType, Data, Options, Config);
@@ -543,8 +554,7 @@ maybe_codec_encode(Format, TypeInfo, SpType, Data, Options, Config) ->
             SpType,
             Data,
             SpType,
-            Config#sp_config.codecs,
-            Config#sp_config.module_types_cache
+            Config
         )
     of
         continue -> default_encode(Format, TypeInfo, SpType, Data, Options, Config);

--- a/src/spectra.erl
+++ b/src/spectra.erl
@@ -1,8 +1,8 @@
 -module(spectra).
 
--export([decode/4, decode/5, encode/4, encode/5, schema/3, schema/4]).
+-export([decode/4, decode/5, encode/4, encode/5, schema/3, schema/4, get_config/0]).
 
--ignore_xref([decode/4, decode/5, encode/4, encode/5, schema/3, schema/4]).
+-ignore_xref([decode/4, decode/5, encode/4, encode/5, schema/3, schema/4, get_config/0]).
 
 -include("../include/spectra.hrl").
 -include("../include/spectra_internal.hrl").

--- a/src/spectra_binary_string.erl
+++ b/src/spectra_binary_string.erl
@@ -74,7 +74,7 @@ from_binary_string(
     Opts,
     Config
 ) ->
-    RemoteTypeInfo = spectra_module_types:get(Module, Config#sp_config.module_types_cache),
+    RemoteTypeInfo = spectra_module_types:get(Module, Config),
     RemoteType = spectra_type_info:get_type(RemoteTypeInfo, TypeName, TypeArity),
     case
         spectra_codec:try_codec_decode(
@@ -214,7 +214,7 @@ to_binary_string(
     Opts,
     Config
 ) ->
-    RemoteTypeInfo = spectra_module_types:get(Module, Config#sp_config.module_types_cache),
+    RemoteTypeInfo = spectra_module_types:get(Module, Config),
     RemoteType = spectra_type_info:get_type(RemoteTypeInfo, TypeName, TypeArity),
     case
         spectra_codec:try_codec_encode(

--- a/src/spectra_binary_string.erl
+++ b/src/spectra_binary_string.erl
@@ -81,9 +81,9 @@ Equivalent to calling from_binary_string/5 with a default configuration.
 ) ->
     {ok, dynamic()} | {error, [spectra:error()]}.
 from_binary_string(TypeInfo, Type, BinaryString, Opts) ->
-    UseCache = application:get_env(spectra, use_module_types_cache, false),
+    CacheMode = application:get_env(spectra, module_types_cache, local),
     Codecs = application:get_env(spectra, codecs, #{}),
-    Config = #sp_config{use_module_types_cache = UseCache, codecs = Codecs},
+    Config = #sp_config{module_types_cache = CacheMode, codecs = Codecs},
     from_binary_string(TypeInfo, Type, BinaryString, Opts, Config).
 
 -doc """
@@ -131,7 +131,7 @@ from_binary_string(
             BinaryString,
             UserTypeRef,
             Config#sp_config.codecs,
-            Config#sp_config.use_module_types_cache
+            Config#sp_config.module_types_cache
         )
     of
         continue ->
@@ -147,7 +147,7 @@ from_binary_string(
     Opts,
     Config
 ) ->
-    RemoteTypeInfo = spectra_module_types:get(Module, Config#sp_config.use_module_types_cache),
+    RemoteTypeInfo = spectra_module_types:get(Module, Config#sp_config.module_types_cache),
     RemoteType = spectra_type_info:get_type(RemoteTypeInfo, TypeName, TypeArity),
     case
         spectra_codec:try_codec_decode(
@@ -157,7 +157,7 @@ from_binary_string(
             BinaryString,
             RemoteRef,
             Config#sp_config.codecs,
-            Config#sp_config.use_module_types_cache
+            Config#sp_config.module_types_cache
         )
     of
         continue ->
@@ -181,7 +181,7 @@ from_binary_string(
             BinaryString,
             RecordRef,
             Config#sp_config.codecs,
-            Config#sp_config.use_module_types_cache
+            Config#sp_config.module_types_cache
         )
     of
         continue -> erlang:error({type_not_supported, RecordType});
@@ -288,9 +288,9 @@ Equivalent to calling to_binary_string/5 with a default configuration.
 ) ->
     {ok, binary()} | {error, [spectra:error()]}.
 to_binary_string(TypeInfo, Type, Data, Opts) ->
-    UseCache = application:get_env(spectra, use_module_types_cache, false),
+    CacheMode = application:get_env(spectra, module_types_cache, local),
     Codecs = application:get_env(spectra, codecs, #{}),
-    Config = #sp_config{use_module_types_cache = UseCache, codecs = Codecs},
+    Config = #sp_config{module_types_cache = CacheMode, codecs = Codecs},
     to_binary_string(TypeInfo, Type, Data, Opts, Config).
 
 -doc """
@@ -338,7 +338,7 @@ to_binary_string(
             Data,
             UserTypeRef,
             Config#sp_config.codecs,
-            Config#sp_config.use_module_types_cache
+            Config#sp_config.module_types_cache
         )
     of
         continue ->
@@ -354,7 +354,7 @@ to_binary_string(
     Opts,
     Config
 ) ->
-    RemoteTypeInfo = spectra_module_types:get(Module, Config#sp_config.use_module_types_cache),
+    RemoteTypeInfo = spectra_module_types:get(Module, Config#sp_config.module_types_cache),
     RemoteType = spectra_type_info:get_type(RemoteTypeInfo, TypeName, TypeArity),
     case
         spectra_codec:try_codec_encode(
@@ -364,7 +364,7 @@ to_binary_string(
             Data,
             RemoteRef,
             Config#sp_config.codecs,
-            Config#sp_config.use_module_types_cache
+            Config#sp_config.module_types_cache
         )
     of
         continue ->
@@ -384,7 +384,7 @@ to_binary_string(TypeInfo, #sp_rec_ref{record_name = RecordName} = RecordRef, Da
             Data,
             RecordRef,
             Config#sp_config.codecs,
-            Config#sp_config.use_module_types_cache
+            Config#sp_config.module_types_cache
         )
     of
         continue -> erlang:error({type_not_supported, RecordType});

--- a/src/spectra_binary_string.erl
+++ b/src/spectra_binary_string.erl
@@ -125,7 +125,13 @@ from_binary_string(
     Type = spectra_type_info:get_type(TypeInfo, N, Arity),
     case
         spectra_codec:try_codec_decode(
-            Mod, binary_string, Type, BinaryString, UserTypeRef, Config#sp_config.codecs, Config#sp_config.use_module_types_cache
+            Mod,
+            binary_string,
+            Type,
+            BinaryString,
+            UserTypeRef,
+            Config#sp_config.codecs,
+            Config#sp_config.use_module_types_cache
         )
     of
         continue ->
@@ -145,7 +151,13 @@ from_binary_string(
     RemoteType = spectra_type_info:get_type(RemoteTypeInfo, TypeName, TypeArity),
     case
         spectra_codec:try_codec_decode(
-            Module, binary_string, RemoteType, BinaryString, RemoteRef, Config#sp_config.codecs, Config#sp_config.use_module_types_cache
+            Module,
+            binary_string,
+            RemoteType,
+            BinaryString,
+            RemoteRef,
+            Config#sp_config.codecs,
+            Config#sp_config.use_module_types_cache
         )
     of
         continue ->
@@ -163,7 +175,13 @@ from_binary_string(
     RecordType = spectra_type_info:get_record(TypeInfo, RecordName),
     case
         spectra_codec:try_codec_decode(
-            Mod, binary_string, RecordType, BinaryString, RecordRef, Config#sp_config.codecs, Config#sp_config.use_module_types_cache
+            Mod,
+            binary_string,
+            RecordType,
+            BinaryString,
+            RecordRef,
+            Config#sp_config.codecs,
+            Config#sp_config.use_module_types_cache
         )
     of
         continue -> erlang:error({type_not_supported, RecordType});
@@ -314,7 +332,13 @@ to_binary_string(
     Type = spectra_type_info:get_type(TypeInfo, TypeName, Arity),
     case
         spectra_codec:try_codec_encode(
-            Mod, binary_string, Type, Data, UserTypeRef, Config#sp_config.codecs, Config#sp_config.use_module_types_cache
+            Mod,
+            binary_string,
+            Type,
+            Data,
+            UserTypeRef,
+            Config#sp_config.codecs,
+            Config#sp_config.use_module_types_cache
         )
     of
         continue ->
@@ -334,7 +358,13 @@ to_binary_string(
     RemoteType = spectra_type_info:get_type(RemoteTypeInfo, TypeName, TypeArity),
     case
         spectra_codec:try_codec_encode(
-            Module, binary_string, RemoteType, Data, RemoteRef, Config#sp_config.codecs, Config#sp_config.use_module_types_cache
+            Module,
+            binary_string,
+            RemoteType,
+            Data,
+            RemoteRef,
+            Config#sp_config.codecs,
+            Config#sp_config.use_module_types_cache
         )
     of
         continue ->
@@ -348,7 +378,13 @@ to_binary_string(TypeInfo, #sp_rec_ref{record_name = RecordName} = RecordRef, Da
     RecordType = spectra_type_info:get_record(TypeInfo, RecordName),
     case
         spectra_codec:try_codec_encode(
-            Mod, binary_string, RecordType, Data, RecordRef, Config#sp_config.codecs, Config#sp_config.use_module_types_cache
+            Mod,
+            binary_string,
+            RecordType,
+            Data,
+            RecordRef,
+            Config#sp_config.codecs,
+            Config#sp_config.use_module_types_cache
         )
     of
         continue -> erlang:error({type_not_supported, RecordType});

--- a/src/spectra_binary_string.erl
+++ b/src/spectra_binary_string.erl
@@ -125,7 +125,7 @@ from_binary_string(
     Type = spectra_type_info:get_type(TypeInfo, N, Arity),
     case
         spectra_codec:try_codec_decode(
-            Mod, binary_string, Type, BinaryString, UserTypeRef, Config#sp_config.codecs
+            Mod, binary_string, Type, BinaryString, UserTypeRef, Config#sp_config.codecs, Config#sp_config.use_module_types_cache
         )
     of
         continue ->
@@ -145,7 +145,7 @@ from_binary_string(
     RemoteType = spectra_type_info:get_type(RemoteTypeInfo, TypeName, TypeArity),
     case
         spectra_codec:try_codec_decode(
-            Module, binary_string, RemoteType, BinaryString, RemoteRef, Config#sp_config.codecs
+            Module, binary_string, RemoteType, BinaryString, RemoteRef, Config#sp_config.codecs, Config#sp_config.use_module_types_cache
         )
     of
         continue ->
@@ -163,7 +163,7 @@ from_binary_string(
     RecordType = spectra_type_info:get_record(TypeInfo, RecordName),
     case
         spectra_codec:try_codec_decode(
-            Mod, binary_string, RecordType, BinaryString, RecordRef, Config#sp_config.codecs
+            Mod, binary_string, RecordType, BinaryString, RecordRef, Config#sp_config.codecs, Config#sp_config.use_module_types_cache
         )
     of
         continue -> erlang:error({type_not_supported, RecordType});
@@ -314,7 +314,7 @@ to_binary_string(
     Type = spectra_type_info:get_type(TypeInfo, TypeName, Arity),
     case
         spectra_codec:try_codec_encode(
-            Mod, binary_string, Type, Data, UserTypeRef, Config#sp_config.codecs
+            Mod, binary_string, Type, Data, UserTypeRef, Config#sp_config.codecs, Config#sp_config.use_module_types_cache
         )
     of
         continue ->
@@ -334,7 +334,7 @@ to_binary_string(
     RemoteType = spectra_type_info:get_type(RemoteTypeInfo, TypeName, TypeArity),
     case
         spectra_codec:try_codec_encode(
-            Module, binary_string, RemoteType, Data, RemoteRef, Config#sp_config.codecs
+            Module, binary_string, RemoteType, Data, RemoteRef, Config#sp_config.codecs, Config#sp_config.use_module_types_cache
         )
     of
         continue ->
@@ -348,7 +348,7 @@ to_binary_string(TypeInfo, #sp_rec_ref{record_name = RecordName} = RecordRef, Da
     RecordType = spectra_type_info:get_record(TypeInfo, RecordName),
     case
         spectra_codec:try_codec_encode(
-            Mod, binary_string, RecordType, Data, RecordRef, Config#sp_config.codecs
+            Mod, binary_string, RecordType, Data, RecordRef, Config#sp_config.codecs, Config#sp_config.use_module_types_cache
         )
     of
         continue -> erlang:error({type_not_supported, RecordType});

--- a/src/spectra_binary_string.erl
+++ b/src/spectra_binary_string.erl
@@ -1,90 +1,18 @@
 -module(spectra_binary_string).
 
 -export([
-    from_binary_string/3,
-    from_binary_string/4,
     from_binary_string/5,
-    to_binary_string/3,
-    to_binary_string/4,
     to_binary_string/5
 ]).
 
 -ignore_xref([
-    {spectra_binary_string, from_binary_string, 3},
-    {spectra_binary_string, from_binary_string, 4},
     {spectra_binary_string, from_binary_string, 5},
-    {spectra_binary_string, to_binary_string, 3},
-    {spectra_binary_string, to_binary_string, 4},
     {spectra_binary_string, to_binary_string, 5}
 ]).
 
 -include("../include/spectra_internal.hrl").
 
 %% API
-
--doc """
-Converts a binary string value to an Erlang value based on a type specification.
-
-This function validates the given binary string value against the specified type definition
-and converts it to the corresponding Erlang value.
-
-Equivalent to calling from_binary_string/4 with an empty options map.
-
-### Returns
-{ok, ErlangValue} if conversion succeeds, or {error, Errors} if validation fails
-""".
--doc #{
-    equiv => from_binary_string(TypeInfo, Type, BinaryString, #{}),
-    params =>
-        #{
-            "BinaryString" => "The binary string value to convert to Erlang format",
-            "Type" => "The type specification (spectra:sp_type())",
-            "TypeInfo" => "The type information containing type definitions"
-        }
-}.
-
--spec from_binary_string(
-    TypeInfo :: spectra:type_info(),
-    Type :: spectra:sp_type(),
-    BinaryString :: binary()
-) ->
-    {ok, dynamic()} | {error, [spectra:error()]}.
-from_binary_string(TypeInfo, Type, BinaryString) ->
-    from_binary_string(TypeInfo, Type, BinaryString, #{}).
-
--doc """
-Converts a binary string value to an Erlang value based on a type specification.
-
-This function validates the given binary string value against the specified type definition
-and converts it to the corresponding Erlang value.
-
-Equivalent to calling from_binary_string/5 with a default configuration.
-
-### Returns
-{ok, ErlangValue} if conversion succeeds, or {error, Errors} if validation fails
-""".
--doc #{
-    params =>
-        #{
-            "BinaryString" => "The binary string value to convert to Erlang format",
-            "Opts" => "Decode options",
-            "Type" => "The type specification (spectra:sp_type())",
-            "TypeInfo" => "The type information containing type definitions"
-        }
-}.
-
--spec from_binary_string(
-    TypeInfo :: spectra:type_info(),
-    Type :: spectra:sp_type(),
-    BinaryString :: binary(),
-    Opts :: spectra:binary_string_decode_opts()
-) ->
-    {ok, dynamic()} | {error, [spectra:error()]}.
-from_binary_string(TypeInfo, Type, BinaryString, Opts) ->
-    CacheMode = application:get_env(spectra, module_types_cache, local),
-    Codecs = application:get_env(spectra, codecs, #{}),
-    Config = #sp_config{module_types_cache = CacheMode, codecs = Codecs},
-    from_binary_string(TypeInfo, Type, BinaryString, Opts, Config).
 
 -doc """
 Converts a binary string value to an Erlang value based on a type specification.
@@ -228,70 +156,6 @@ from_binary_string(_TypeInfo, #sp_rec{} = T, _BinaryString, _Opts, _Config) ->
     erlang:error({type_not_supported, T});
 from_binary_string(_TypeInfo, Type, BinaryString, _Opts, _Config) ->
     {error, [sp_error:type_mismatch(Type, BinaryString)]}.
-
--doc """
-Converts an Erlang value to a binary string based on a type specification.
-
-This function validates the given Erlang value against the specified type definition
-and converts it to a binary string representation.
-
-Equivalent to calling to_binary_string/4 with an empty options map.
-
-### Returns
-{ok, BinaryString} if conversion succeeds, or {error, Errors} if validation fails
-""".
--doc #{
-    equiv => to_binary_string(TypeInfo, Type, Data, #{}),
-    params =>
-        #{
-            "Data" => "The Erlang value to convert to binary string format",
-            "Type" => "The type specification (spectra:sp_type())",
-            "TypeInfo" => "The type information containing type definitions"
-        }
-}.
-
--spec to_binary_string(
-    TypeInfo :: spectra:type_info(),
-    Type :: spectra:sp_type(),
-    Data :: dynamic()
-) ->
-    {ok, binary()} | {error, [spectra:error()]}.
-to_binary_string(TypeInfo, Type, Data) ->
-    to_binary_string(TypeInfo, Type, Data, #{}).
-
--doc """
-Converts an Erlang value to a binary string based on a type specification.
-
-This function validates the given Erlang value against the specified type definition
-and converts it to a binary string representation.
-
-Equivalent to calling to_binary_string/5 with a default configuration.
-
-### Returns
-{ok, BinaryString} if conversion succeeds, or {error, Errors} if validation fails
-""".
--doc #{
-    params =>
-        #{
-            "Data" => "The Erlang value to convert to binary string format",
-            "Opts" => "Encode options",
-            "Type" => "The type specification (spectra:sp_type())",
-            "TypeInfo" => "The type information containing type definitions"
-        }
-}.
-
--spec to_binary_string(
-    TypeInfo :: spectra:type_info(),
-    Type :: spectra:sp_type(),
-    Data :: dynamic(),
-    Opts :: spectra:binary_string_encode_opts()
-) ->
-    {ok, binary()} | {error, [spectra:error()]}.
-to_binary_string(TypeInfo, Type, Data, Opts) ->
-    CacheMode = application:get_env(spectra, module_types_cache, local),
-    Codecs = application:get_env(spectra, codecs, #{}),
-    Config = #sp_config{module_types_cache = CacheMode, codecs = Codecs},
-    to_binary_string(TypeInfo, Type, Data, Opts, Config).
 
 -doc """
 Converts an Erlang value to a binary string based on a type specification.

--- a/src/spectra_binary_string.erl
+++ b/src/spectra_binary_string.erl
@@ -49,11 +49,10 @@ from_binary_string(
     Opts,
     Config
 ) ->
-    Mod = spectra_type_info:get_module(TypeInfo),
     Type = spectra_type_info:get_type(TypeInfo, N, Arity),
     case
         spectra_codec:try_codec_decode(
-            Mod,
+            TypeInfo,
             binary_string,
             Type,
             BinaryString,
@@ -78,7 +77,7 @@ from_binary_string(
     RemoteType = spectra_type_info:get_type(RemoteTypeInfo, TypeName, TypeArity),
     case
         spectra_codec:try_codec_decode(
-            Module,
+            RemoteTypeInfo,
             binary_string,
             RemoteType,
             BinaryString,
@@ -97,11 +96,10 @@ from_binary_string(
 from_binary_string(
     TypeInfo, #sp_rec_ref{record_name = RecordName} = RecordRef, BinaryString, _Opts, Config
 ) ->
-    Mod = spectra_type_info:get_module(TypeInfo),
     RecordType = spectra_type_info:get_record(TypeInfo, RecordName),
     case
         spectra_codec:try_codec_decode(
-            Mod,
+            TypeInfo,
             binary_string,
             RecordType,
             BinaryString,
@@ -189,11 +187,10 @@ to_binary_string(
     Opts,
     Config
 ) ->
-    Mod = spectra_type_info:get_module(TypeInfo),
     Type = spectra_type_info:get_type(TypeInfo, TypeName, Arity),
     case
         spectra_codec:try_codec_encode(
-            Mod,
+            TypeInfo,
             binary_string,
             Type,
             Data,
@@ -218,7 +215,7 @@ to_binary_string(
     RemoteType = spectra_type_info:get_type(RemoteTypeInfo, TypeName, TypeArity),
     case
         spectra_codec:try_codec_encode(
-            Module,
+            RemoteTypeInfo,
             binary_string,
             RemoteType,
             Data,
@@ -233,11 +230,10 @@ to_binary_string(
             Result
     end;
 to_binary_string(TypeInfo, #sp_rec_ref{record_name = RecordName} = RecordRef, Data, _Opts, Config) ->
-    Mod = spectra_type_info:get_module(TypeInfo),
     RecordType = spectra_type_info:get_record(TypeInfo, RecordName),
     case
         spectra_codec:try_codec_encode(
-            Mod,
+            TypeInfo,
             binary_string,
             RecordType,
             Data,

--- a/src/spectra_binary_string.erl
+++ b/src/spectra_binary_string.erl
@@ -61,7 +61,7 @@ from_binary_string(
         )
     of
         continue ->
-            TypeWithoutVars = apply_args(TypeInfo, Type, Args),
+            TypeWithoutVars = spectra_util:apply_args(TypeInfo, Type, Args),
             from_binary_string(TypeInfo, TypeWithoutVars, BinaryString, Opts, Config);
         Result ->
             Result
@@ -87,7 +87,7 @@ from_binary_string(
     of
         continue ->
             TypeResolved = spectra_type:propagate_params(
-                RemoteRef, apply_args(RemoteTypeInfo, RemoteType, Args)
+                RemoteRef, spectra_util:apply_args(RemoteTypeInfo, RemoteType, Args)
             ),
             from_binary_string(RemoteTypeInfo, TypeResolved, BinaryString, Opts, Config);
         Result ->
@@ -199,7 +199,7 @@ to_binary_string(
         )
     of
         continue ->
-            TypeWithoutVars = apply_args(TypeInfo, Type, Args),
+            TypeWithoutVars = spectra_util:apply_args(TypeInfo, Type, Args),
             to_binary_string(TypeInfo, TypeWithoutVars, Data, Opts, Config);
         Result ->
             Result
@@ -224,7 +224,7 @@ to_binary_string(
         )
     of
         continue ->
-            TypeWithoutVars = apply_args(RemoteTypeInfo, RemoteType, Args),
+            TypeWithoutVars = spectra_util:apply_args(RemoteTypeInfo, RemoteType, Args),
             to_binary_string(RemoteTypeInfo, TypeWithoutVars, Data, Opts, Config);
         Result ->
             Result
@@ -446,19 +446,6 @@ do_first(Fun, TypeInfo, [Type | Rest], BinaryString, Opts, Config, ErrorsAcc) ->
         {error, Errors} ->
             do_first(Fun, TypeInfo, Rest, BinaryString, Opts, Config, [{Type, Errors} | ErrorsAcc])
     end.
-
-apply_args(TypeInfo, Type, TypeArgs) when is_list(TypeArgs) ->
-    ArgNames = arg_names(Type),
-    NamedTypes =
-        maps:from_list(
-            lists:zip(ArgNames, TypeArgs)
-        ),
-    spectra_util:type_replace_vars(TypeInfo, Type, NamedTypes).
-
-arg_names(#sp_type_with_variables{vars = Args}) ->
-    Args;
-arg_names(_) ->
-    [].
 
 convert_type_to_binary_string(integer, Data) when is_integer(Data) ->
     {ok, integer_to_binary(Data)};

--- a/src/spectra_binary_string.erl
+++ b/src/spectra_binary_string.erl
@@ -1,12 +1,21 @@
 -module(spectra_binary_string).
 
--export([from_binary_string/3, from_binary_string/4, to_binary_string/3, to_binary_string/4]).
+-export([
+    from_binary_string/3,
+    from_binary_string/4,
+    from_binary_string/5,
+    to_binary_string/3,
+    to_binary_string/4,
+    to_binary_string/5
+]).
 
 -ignore_xref([
     {spectra_binary_string, from_binary_string, 3},
     {spectra_binary_string, from_binary_string, 4},
+    {spectra_binary_string, from_binary_string, 5},
     {spectra_binary_string, to_binary_string, 3},
-    {spectra_binary_string, to_binary_string, 4}
+    {spectra_binary_string, to_binary_string, 4},
+    {spectra_binary_string, to_binary_string, 5}
 ]).
 
 -include("../include/spectra_internal.hrl").
@@ -49,6 +58,8 @@ Converts a binary string value to an Erlang value based on a type specification.
 This function validates the given binary string value against the specified type definition
 and converts it to the corresponding Erlang value.
 
+Equivalent to calling from_binary_string/5 with a default configuration.
+
 ### Returns
 {ok, ErlangValue} if conversion succeeds, or {error, Errors} if validation fails
 """.
@@ -69,18 +80,57 @@ and converts it to the corresponding Erlang value.
     Opts :: spectra:binary_string_decode_opts()
 ) ->
     {ok, dynamic()} | {error, [spectra:error()]}.
+from_binary_string(TypeInfo, Type, BinaryString, Opts) ->
+    UseCache = application:get_env(spectra, use_module_types_cache, false),
+    Codecs = application:get_env(spectra, codecs, #{}),
+    Config = #sp_config{use_module_types_cache = UseCache, codecs = Codecs},
+    from_binary_string(TypeInfo, Type, BinaryString, Opts, Config).
+
+-doc """
+Converts a binary string value to an Erlang value based on a type specification.
+
+This function validates the given binary string value against the specified type definition
+and converts it to the corresponding Erlang value.
+
+### Returns
+{ok, ErlangValue} if conversion succeeds, or {error, Errors} if validation fails
+""".
+-doc #{
+    params =>
+        #{
+            "BinaryString" => "The binary string value to convert to Erlang format",
+            "Config" => "Runtime configuration",
+            "Opts" => "Decode options",
+            "Type" => "The type specification (spectra:sp_type())",
+            "TypeInfo" => "The type information containing type definitions"
+        }
+}.
+
+-spec from_binary_string(
+    TypeInfo :: spectra:type_info(),
+    Type :: spectra:sp_type(),
+    BinaryString :: binary(),
+    Opts :: spectra:binary_string_decode_opts(),
+    Config :: spectra:sp_config()
+) ->
+    {ok, dynamic()} | {error, [spectra:error()]}.
 from_binary_string(
     TypeInfo,
     #sp_user_type_ref{type_name = N, variables = Args, arity = Arity} = UserTypeRef,
     BinaryString,
-    Opts
+    Opts,
+    Config
 ) ->
     Mod = spectra_type_info:get_module(TypeInfo),
     Type = spectra_type_info:get_type(TypeInfo, N, Arity),
-    case spectra_codec:try_codec_decode(Mod, binary_string, Type, BinaryString, UserTypeRef) of
+    case
+        spectra_codec:try_codec_decode(
+            Mod, binary_string, Type, BinaryString, UserTypeRef, Config#sp_config.codecs
+        )
+    of
         continue ->
             TypeWithoutVars = apply_args(TypeInfo, Type, Args),
-            from_binary_string(TypeInfo, TypeWithoutVars, BinaryString, Opts);
+            from_binary_string(TypeInfo, TypeWithoutVars, BinaryString, Opts, Config);
         Result ->
             Result
     end;
@@ -88,32 +138,39 @@ from_binary_string(
     _TypeInfo,
     #sp_remote_type{mfargs = {Module, TypeName, Args}, arity = TypeArity} = RemoteRef,
     BinaryString,
-    Opts
+    Opts,
+    Config
 ) ->
-    RemoteTypeInfo = spectra_module_types:get(Module),
+    RemoteTypeInfo = spectra_module_types:get(Module, Config#sp_config.use_module_types_cache),
     RemoteType = spectra_type_info:get_type(RemoteTypeInfo, TypeName, TypeArity),
     case
-        spectra_codec:try_codec_decode(Module, binary_string, RemoteType, BinaryString, RemoteRef)
+        spectra_codec:try_codec_decode(
+            Module, binary_string, RemoteType, BinaryString, RemoteRef, Config#sp_config.codecs
+        )
     of
         continue ->
             TypeResolved = spectra_type:propagate_params(
                 RemoteRef, apply_args(RemoteTypeInfo, RemoteType, Args)
             ),
-            from_binary_string(RemoteTypeInfo, TypeResolved, BinaryString, Opts);
+            from_binary_string(RemoteTypeInfo, TypeResolved, BinaryString, Opts, Config);
         Result ->
             Result
     end;
 from_binary_string(
-    TypeInfo, #sp_rec_ref{record_name = RecordName} = RecordRef, BinaryString, _Opts
+    TypeInfo, #sp_rec_ref{record_name = RecordName} = RecordRef, BinaryString, _Opts, Config
 ) ->
     Mod = spectra_type_info:get_module(TypeInfo),
     RecordType = spectra_type_info:get_record(TypeInfo, RecordName),
-    case spectra_codec:try_codec_decode(Mod, binary_string, RecordType, BinaryString, RecordRef) of
+    case
+        spectra_codec:try_codec_decode(
+            Mod, binary_string, RecordType, BinaryString, RecordRef, Config#sp_config.codecs
+        )
+    of
         continue -> erlang:error({type_not_supported, RecordType});
         Result -> Result
     end;
 from_binary_string(
-    _TypeInfo, #sp_simple_type{type = NotSupported} = T, _BinaryString, _Opts
+    _TypeInfo, #sp_simple_type{type = NotSupported} = T, _BinaryString, _Opts, _Config
 ) when
     NotSupported =:= pid orelse
         NotSupported =:= port orelse
@@ -123,7 +180,7 @@ from_binary_string(
         NotSupported =:= none
 ->
     erlang:error({type_not_supported, T});
-from_binary_string(_TypeInfo, #sp_simple_type{type = PrimaryType}, BinaryString, _Opts) ->
+from_binary_string(_TypeInfo, #sp_simple_type{type = PrimaryType}, BinaryString, _Opts, _Config) ->
     convert_binary_string_to_type(PrimaryType, BinaryString);
 from_binary_string(
     _TypeInfo,
@@ -134,7 +191,8 @@ from_binary_string(
     } =
         Range,
     BinaryString,
-    _Opts
+    _Opts,
+    _Config
 ) ->
     case convert_binary_string_to_type(integer, BinaryString) of
         {ok, Value} when Min =< Value, Value =< Max ->
@@ -144,13 +202,13 @@ from_binary_string(
         {error, Reason} ->
             {error, Reason}
     end;
-from_binary_string(_TypeInfo, #sp_literal{value = Literal}, BinaryString, _Opts) ->
+from_binary_string(_TypeInfo, #sp_literal{value = Literal}, BinaryString, _Opts, _Config) ->
     try_convert_binary_string_to_literal(Literal, BinaryString);
-from_binary_string(TypeInfo, #sp_union{} = Type, BinaryString, Opts) ->
-    union(fun from_binary_string/4, TypeInfo, Type, BinaryString, Opts);
-from_binary_string(_TypeInfo, #sp_rec{} = T, _BinaryString, _Opts) ->
+from_binary_string(TypeInfo, #sp_union{} = Type, BinaryString, Opts, Config) ->
+    union(fun from_binary_string/5, TypeInfo, Type, BinaryString, Opts, Config);
+from_binary_string(_TypeInfo, #sp_rec{} = T, _BinaryString, _Opts, _Config) ->
     erlang:error({type_not_supported, T});
-from_binary_string(_TypeInfo, Type, BinaryString, _Opts) ->
+from_binary_string(_TypeInfo, Type, BinaryString, _Opts, _Config) ->
     {error, [sp_error:type_mismatch(Type, BinaryString)]}.
 
 -doc """
@@ -189,6 +247,8 @@ Converts an Erlang value to a binary string based on a type specification.
 This function validates the given Erlang value against the specified type definition
 and converts it to a binary string representation.
 
+Equivalent to calling to_binary_string/5 with a default configuration.
+
 ### Returns
 {ok, BinaryString} if conversion succeeds, or {error, Errors} if validation fails
 """.
@@ -209,18 +269,57 @@ and converts it to a binary string representation.
     Opts :: spectra:binary_string_encode_opts()
 ) ->
     {ok, binary()} | {error, [spectra:error()]}.
+to_binary_string(TypeInfo, Type, Data, Opts) ->
+    UseCache = application:get_env(spectra, use_module_types_cache, false),
+    Codecs = application:get_env(spectra, codecs, #{}),
+    Config = #sp_config{use_module_types_cache = UseCache, codecs = Codecs},
+    to_binary_string(TypeInfo, Type, Data, Opts, Config).
+
+-doc """
+Converts an Erlang value to a binary string based on a type specification.
+
+This function validates the given Erlang value against the specified type definition
+and converts it to a binary string representation.
+
+### Returns
+{ok, BinaryString} if conversion succeeds, or {error, Errors} if validation fails
+""".
+-doc #{
+    params =>
+        #{
+            "Data" => "The Erlang value to convert to binary string format",
+            "Config" => "Runtime configuration",
+            "Opts" => "Encode options",
+            "Type" => "The type specification (spectra:sp_type())",
+            "TypeInfo" => "The type information containing type definitions"
+        }
+}.
+
+-spec to_binary_string(
+    TypeInfo :: spectra:type_info(),
+    Type :: spectra:sp_type(),
+    Data :: dynamic(),
+    Opts :: spectra:binary_string_encode_opts(),
+    Config :: spectra:sp_config()
+) ->
+    {ok, binary()} | {error, [spectra:error()]}.
 to_binary_string(
     TypeInfo,
     #sp_user_type_ref{type_name = TypeName, variables = Args, arity = Arity} = UserTypeRef,
     Data,
-    Opts
+    Opts,
+    Config
 ) ->
     Mod = spectra_type_info:get_module(TypeInfo),
     Type = spectra_type_info:get_type(TypeInfo, TypeName, Arity),
-    case spectra_codec:try_codec_encode(Mod, binary_string, Type, Data, UserTypeRef) of
+    case
+        spectra_codec:try_codec_encode(
+            Mod, binary_string, Type, Data, UserTypeRef, Config#sp_config.codecs
+        )
+    of
         continue ->
             TypeWithoutVars = apply_args(TypeInfo, Type, Args),
-            to_binary_string(TypeInfo, TypeWithoutVars, Data, Opts);
+            to_binary_string(TypeInfo, TypeWithoutVars, Data, Opts, Config);
         Result ->
             Result
     end;
@@ -228,25 +327,34 @@ to_binary_string(
     _TypeInfo,
     #sp_remote_type{mfargs = {Module, TypeName, Args}, arity = TypeArity} = RemoteRef,
     Data,
-    Opts
+    Opts,
+    Config
 ) ->
-    RemoteTypeInfo = spectra_module_types:get(Module),
+    RemoteTypeInfo = spectra_module_types:get(Module, Config#sp_config.use_module_types_cache),
     RemoteType = spectra_type_info:get_type(RemoteTypeInfo, TypeName, TypeArity),
-    case spectra_codec:try_codec_encode(Module, binary_string, RemoteType, Data, RemoteRef) of
+    case
+        spectra_codec:try_codec_encode(
+            Module, binary_string, RemoteType, Data, RemoteRef, Config#sp_config.codecs
+        )
+    of
         continue ->
             TypeWithoutVars = apply_args(RemoteTypeInfo, RemoteType, Args),
-            to_binary_string(RemoteTypeInfo, TypeWithoutVars, Data, Opts);
+            to_binary_string(RemoteTypeInfo, TypeWithoutVars, Data, Opts, Config);
         Result ->
             Result
     end;
-to_binary_string(TypeInfo, #sp_rec_ref{record_name = RecordName} = RecordRef, Data, _Opts) ->
+to_binary_string(TypeInfo, #sp_rec_ref{record_name = RecordName} = RecordRef, Data, _Opts, Config) ->
     Mod = spectra_type_info:get_module(TypeInfo),
     RecordType = spectra_type_info:get_record(TypeInfo, RecordName),
-    case spectra_codec:try_codec_encode(Mod, binary_string, RecordType, Data, RecordRef) of
+    case
+        spectra_codec:try_codec_encode(
+            Mod, binary_string, RecordType, Data, RecordRef, Config#sp_config.codecs
+        )
+    of
         continue -> erlang:error({type_not_supported, RecordType});
         Result -> Result
     end;
-to_binary_string(_TypeInfo, #sp_simple_type{type = NotSupported} = T, _Data, _Opts) when
+to_binary_string(_TypeInfo, #sp_simple_type{type = NotSupported} = T, _Data, _Opts, _Config) when
     NotSupported =:= pid orelse
         NotSupported =:= port orelse
         NotSupported =:= reference orelse
@@ -255,7 +363,7 @@ to_binary_string(_TypeInfo, #sp_simple_type{type = NotSupported} = T, _Data, _Op
         NotSupported =:= none
 ->
     erlang:error({type_not_supported, T});
-to_binary_string(_TypeInfo, #sp_simple_type{type = PrimaryType}, Data, _Opts) ->
+to_binary_string(_TypeInfo, #sp_simple_type{type = PrimaryType}, Data, _Opts, _Config) ->
     convert_type_to_binary_string(PrimaryType, Data);
 to_binary_string(
     _TypeInfo,
@@ -266,7 +374,8 @@ to_binary_string(
     } =
         Range,
     Data,
-    _Opts
+    _Opts,
+    _Config
 ) ->
     case convert_type_to_binary_string(integer, Data) of
         {ok, BinaryString} when Min =< Data, Data =< Max ->
@@ -276,13 +385,13 @@ to_binary_string(
         {error, Reason} ->
             {error, Reason}
     end;
-to_binary_string(_TypeInfo, #sp_literal{} = Type, Data, _Opts) ->
+to_binary_string(_TypeInfo, #sp_literal{} = Type, Data, _Opts, _Config) ->
     try_convert_literal_to_binary_string(Type, Data);
-to_binary_string(TypeInfo, #sp_union{} = Type, Data, Opts) ->
-    union_to_binary_string(TypeInfo, Type, Data, Opts);
-to_binary_string(_TypeInfo, #sp_rec{} = T, _Data, _Opts) ->
+to_binary_string(TypeInfo, #sp_union{} = Type, Data, Opts, Config) ->
+    union_to_binary_string(TypeInfo, Type, Data, Opts, Config);
+to_binary_string(_TypeInfo, #sp_rec{} = T, _Data, _Opts, _Config) ->
     erlang:error({type_not_supported, T});
-to_binary_string(_TypeInfo, Type, Data, _Opts) ->
+to_binary_string(_TypeInfo, Type, Data, _Opts, _Config) ->
     {error, [sp_error:type_mismatch(Type, Data)]}.
 
 %% INTERNAL
@@ -430,22 +539,22 @@ try_convert_binary_string_to_literal(Literal, BinaryString) ->
         )
     ]}.
 
-union(Fun, TypeInfo, #sp_union{types = Types} = T, BinaryString, Opts) ->
-    case do_first(Fun, TypeInfo, Types, BinaryString, Opts, []) of
+union(Fun, TypeInfo, #sp_union{types = Types} = T, BinaryString, Opts, Config) ->
+    case do_first(Fun, TypeInfo, Types, BinaryString, Opts, Config, []) of
         {error, UnionErrors} ->
             {error, [sp_error:no_match(T, BinaryString, UnionErrors)]};
         Result ->
             Result
     end.
 
-do_first(_Fun, _TypeInfo, [], _BinaryString, _Opts, Errors) ->
+do_first(_Fun, _TypeInfo, [], _BinaryString, _Opts, _Config, Errors) ->
     {error, Errors};
-do_first(Fun, TypeInfo, [Type | Rest], BinaryString, Opts, ErrorsAcc) ->
-    case Fun(TypeInfo, Type, BinaryString, Opts) of
+do_first(Fun, TypeInfo, [Type | Rest], BinaryString, Opts, Config, ErrorsAcc) ->
+    case Fun(TypeInfo, Type, BinaryString, Opts, Config) of
         {ok, Result} ->
             {ok, Result};
         {error, Errors} ->
-            do_first(Fun, TypeInfo, Rest, BinaryString, Opts, [{Type, Errors} | ErrorsAcc])
+            do_first(Fun, TypeInfo, Rest, BinaryString, Opts, Config, [{Type, Errors} | ErrorsAcc])
     end.
 
 apply_args(TypeInfo, Type, TypeArgs) when is_list(TypeArgs) ->
@@ -551,20 +660,22 @@ try_convert_literal_to_binary_string(#sp_literal{value = Literal}, Literal) when
 try_convert_literal_to_binary_string(#sp_literal{} = Type, Data) ->
     {error, [sp_error:type_mismatch(Type, Data)]}.
 
-union_to_binary_string(TypeInfo, #sp_union{types = Types} = T, Data, Opts) ->
-    case do_first_to_binary_string(TypeInfo, Types, Data, Opts, []) of
+union_to_binary_string(TypeInfo, #sp_union{types = Types} = T, Data, Opts, Config) ->
+    case do_first_to_binary_string(TypeInfo, Types, Data, Opts, Config, []) of
         {error, UnionErrors} ->
             {error, [sp_error:no_match(T, Data, UnionErrors)]};
         Result ->
             Result
     end.
 
-do_first_to_binary_string(_TypeInfo, [], _Data, _Opts, Errors) ->
+do_first_to_binary_string(_TypeInfo, [], _Data, _Opts, _Config, Errors) ->
     {error, Errors};
-do_first_to_binary_string(TypeInfo, [Type | Rest], Data, Opts, ErrorsAcc) ->
-    case to_binary_string(TypeInfo, Type, Data, Opts) of
+do_first_to_binary_string(TypeInfo, [Type | Rest], Data, Opts, Config, ErrorsAcc) ->
+    case to_binary_string(TypeInfo, Type, Data, Opts, Config) of
         {ok, Result} ->
             {ok, Result};
         {error, Errors} ->
-            do_first_to_binary_string(TypeInfo, Rest, Data, Opts, [{Type, Errors} | ErrorsAcc])
+            do_first_to_binary_string(TypeInfo, Rest, Data, Opts, Config, [
+                {Type, Errors} | ErrorsAcc
+            ])
     end.

--- a/src/spectra_binary_string.erl
+++ b/src/spectra_binary_string.erl
@@ -58,8 +58,7 @@ from_binary_string(
             Type,
             BinaryString,
             UserTypeRef,
-            Config#sp_config.codecs,
-            Config#sp_config.module_types_cache
+            Config
         )
     of
         continue ->
@@ -84,8 +83,7 @@ from_binary_string(
             RemoteType,
             BinaryString,
             RemoteRef,
-            Config#sp_config.codecs,
-            Config#sp_config.module_types_cache
+            Config
         )
     of
         continue ->
@@ -108,8 +106,7 @@ from_binary_string(
             RecordType,
             BinaryString,
             RecordRef,
-            Config#sp_config.codecs,
-            Config#sp_config.module_types_cache
+            Config
         )
     of
         continue -> erlang:error({type_not_supported, RecordType});
@@ -201,8 +198,7 @@ to_binary_string(
             Type,
             Data,
             UserTypeRef,
-            Config#sp_config.codecs,
-            Config#sp_config.module_types_cache
+            Config
         )
     of
         continue ->
@@ -227,8 +223,7 @@ to_binary_string(
             RemoteType,
             Data,
             RemoteRef,
-            Config#sp_config.codecs,
-            Config#sp_config.module_types_cache
+            Config
         )
     of
         continue ->
@@ -247,8 +242,7 @@ to_binary_string(TypeInfo, #sp_rec_ref{record_name = RecordName} = RecordRef, Da
             RecordType,
             Data,
             RecordRef,
-            Config#sp_config.codecs,
-            Config#sp_config.module_types_cache
+            Config
         )
     of
         continue -> erlang:error({type_not_supported, RecordType});

--- a/src/spectra_calendar_codec.erl
+++ b/src/spectra_calendar_codec.erl
@@ -48,11 +48,14 @@ DT = {{2024, 1, 15}, {10, 30, 0}},
 
 -behaviour(spectra_codec).
 
--export([encode/6, decode/6, schema/5]).
+-export([encode/7, decode/7, schema/6]).
 
--spec encode(atom(), module(), spectra:sp_type_reference(), dynamic(), spectra:sp_type(), term()) ->
+-spec encode(
+    atom(), module(), spectra:sp_type_reference(), dynamic(), spectra:sp_type(), term(),
+    spectra:sp_config()
+) ->
     spectra:codec_encode_result().
-encode(json, _Mod, {type, datetime, 0}, {{Y, Mo, D}, {H, Mi, S}}, _SpType, _Params) when
+encode(json, _Mod, {type, datetime, 0}, {{Y, Mo, D}, {H, Mi, S}}, _SpType, _Params, _Config) when
     is_integer(Y),
     is_integer(Mo),
     is_integer(D),
@@ -64,38 +67,43 @@ encode(json, _Mod, {type, datetime, 0}, {{Y, Mo, D}, {H, Mi, S}}, _SpType, _Para
         io_lib:format("~4..0w-~2..0w-~2..0wT~2..0w:~2..0w:~2..0wZ", [Y, Mo, D, H, Mi, S])
     ),
     {ok, Bin};
-encode(json, _Mod, {type, datetime, 0} = TypeRef, Data, _SpType, _Params) ->
+encode(json, _Mod, {type, datetime, 0} = TypeRef, Data, _SpType, _Params, _Config) ->
     {error, [sp_error:type_mismatch(TypeRef, Data)]};
-encode(json, _Mod, {type, date, 0}, {Y, Mo, D}, _SpType, _Params) when
+encode(json, _Mod, {type, date, 0}, {Y, Mo, D}, _SpType, _Params, _Config) when
     is_integer(Y), is_integer(Mo), is_integer(D)
 ->
     Bin = iolist_to_binary(io_lib:format("~4..0w-~2..0w-~2..0w", [Y, Mo, D])),
     {ok, Bin};
-encode(json, _Mod, {type, date, 0} = TypeRef, Data, _SpType, _Params) ->
+encode(json, _Mod, {type, date, 0} = TypeRef, Data, _SpType, _Params, _Config) ->
     {error, [sp_error:type_mismatch(TypeRef, Data)]}.
 
--spec decode(atom(), module(), spectra:sp_type_reference(), dynamic(), spectra:sp_type(), term()) ->
+-spec decode(
+    atom(), module(), spectra:sp_type_reference(), dynamic(), spectra:sp_type(), term(),
+    spectra:sp_config()
+) ->
     spectra:codec_decode_result().
-decode(json, _Mod, {type, datetime, 0}, Bin, _SpType, _Params) when is_binary(Bin) ->
+decode(json, _Mod, {type, datetime, 0}, Bin, _SpType, _Params, _Config) when is_binary(Bin) ->
     case parse_datetime(Bin) of
         {ok, DT} -> {ok, DT};
         error -> {error, [sp_error:type_mismatch({type, datetime, 0}, Bin)]}
     end;
-decode(json, _Mod, {type, datetime, 0} = TypeRef, Data, _SpType, _Params) ->
+decode(json, _Mod, {type, datetime, 0} = TypeRef, Data, _SpType, _Params, _Config) ->
     {error, [sp_error:type_mismatch(TypeRef, Data)]};
-decode(json, _Mod, {type, date, 0}, Bin, _SpType, _Params) when is_binary(Bin) ->
+decode(json, _Mod, {type, date, 0}, Bin, _SpType, _Params, _Config) when is_binary(Bin) ->
     case parse_date(Bin) of
         {ok, D} -> {ok, D};
         error -> {error, [sp_error:type_mismatch({type, date, 0}, Bin)]}
     end;
-decode(json, _Mod, {type, date, 0} = TypeRef, Data, _SpType, _Params) ->
+decode(json, _Mod, {type, date, 0} = TypeRef, Data, _SpType, _Params, _Config) ->
     {error, [sp_error:type_mismatch(TypeRef, Data)]}.
 
--spec schema(atom(), module(), spectra:sp_type_reference(), spectra:sp_type(), term()) ->
+-spec schema(
+    atom(), module(), spectra:sp_type_reference(), spectra:sp_type(), term(), spectra:sp_config()
+) ->
     dynamic().
-schema(json_schema, _Mod, {type, datetime, 0}, _SpType, _Params) ->
+schema(json_schema, _Mod, {type, datetime, 0}, _SpType, _Params, _Config) ->
     #{type => <<"string">>, format => <<"date-time">>};
-schema(json_schema, _Mod, {type, date, 0}, _SpType, _Params) ->
+schema(json_schema, _Mod, {type, date, 0}, _SpType, _Params, _Config) ->
     #{type => <<"string">>, format => <<"date">>}.
 
 %% Internal helpers

--- a/src/spectra_calendar_codec.erl
+++ b/src/spectra_calendar_codec.erl
@@ -51,7 +51,12 @@ DT = {{2024, 1, 15}, {10, 30, 0}},
 -export([encode/7, decode/7, schema/6]).
 
 -spec encode(
-    atom(), module(), spectra:sp_type_reference(), dynamic(), spectra:sp_type(), term(),
+    atom(),
+    module(),
+    spectra:sp_type_reference(),
+    dynamic(),
+    spectra:sp_type(),
+    term(),
     spectra:sp_config()
 ) ->
     spectra:codec_encode_result().
@@ -78,7 +83,12 @@ encode(json, _Mod, {type, date, 0} = TypeRef, Data, _SpType, _Params, _Config) -
     {error, [sp_error:type_mismatch(TypeRef, Data)]}.
 
 -spec decode(
-    atom(), module(), spectra:sp_type_reference(), dynamic(), spectra:sp_type(), term(),
+    atom(),
+    module(),
+    spectra:sp_type_reference(),
+    dynamic(),
+    spectra:sp_type(),
+    term(),
     spectra:sp_config()
 ) ->
     spectra:codec_decode_result().

--- a/src/spectra_codec.erl
+++ b/src/spectra_codec.erl
@@ -103,18 +103,19 @@ where the reference node is available.
     try_codec_schema/5
 ]).
 
--doc "Encodes `Data` via a registered codec for `{Mod, TypeReference}`, or returns `continue`.".
+-doc "Encodes `Data` via a registered codec for the module owning `TypeInfo`, or returns `continue`.".
 -spec try_codec_encode(
-    Mod :: module(),
+    TypeInfo :: spectra:type_info(),
     Format :: atom(),
     Type :: spectra:sp_type(),
     Data :: dynamic(),
     SpType :: spectra:sp_type(),
     Config :: spectra:sp_config()
 ) -> spectra:codec_encode_result().
-try_codec_encode(Mod, Format, Type, Data, SpType, Config) ->
+try_codec_encode(TypeInfo, Format, Type, Data, SpType, Config) ->
     #{name := TypeReference} = spectra_type:get_meta(Type),
-    case spectra_type_info:find_codec(Mod, TypeReference, Config) of
+    Mod = spectra_type_info:get_module(TypeInfo),
+    case spectra_type_info:find_codec(TypeInfo, TypeReference, Config) of
         {ok, M} ->
             M:encode(
                 Format, Mod, TypeReference, Data, SpType, spectra_type:parameters(Type), Config
@@ -123,18 +124,19 @@ try_codec_encode(Mod, Format, Type, Data, SpType, Config) ->
             continue
     end.
 
--doc "Decodes `Data` via a registered codec for `{Mod, TypeReference}`, or returns `continue`.".
+-doc "Decodes `Data` via a registered codec for the module owning `TypeInfo`, or returns `continue`.".
 -spec try_codec_decode(
-    Mod :: module(),
+    TypeInfo :: spectra:type_info(),
     Format :: atom(),
     Type :: spectra:sp_type(),
     Data :: dynamic(),
     SpType :: spectra:sp_type(),
     Config :: spectra:sp_config()
 ) -> spectra:codec_decode_result().
-try_codec_decode(Mod, Format, Type, Data, SpType, Config) ->
+try_codec_decode(TypeInfo, Format, Type, Data, SpType, Config) ->
     #{name := TypeReference} = spectra_type:get_meta(Type),
-    case spectra_type_info:find_codec(Mod, TypeReference, Config) of
+    Mod = spectra_type_info:get_module(TypeInfo),
+    case spectra_type_info:find_codec(TypeInfo, TypeReference, Config) of
         {ok, M} ->
             M:decode(
                 Format, Mod, TypeReference, Data, SpType, spectra_type:parameters(Type), Config
@@ -143,17 +145,18 @@ try_codec_decode(Mod, Format, Type, Data, SpType, Config) ->
             continue
     end.
 
--doc "Returns the schema for `{Mod, TypeReference}` via a registered codec, or `continue`.".
+-doc "Returns the schema for the module owning `TypeInfo` via a registered codec, or `continue`.".
 -spec try_codec_schema(
-    Mod :: module(),
+    TypeInfo :: spectra:type_info(),
     Format :: atom(),
     Type :: spectra:sp_type(),
     SpType :: spectra:sp_type(),
     Config :: spectra:sp_config()
 ) -> dynamic() | continue.
-try_codec_schema(Mod, Format, Type, SpType, Config) ->
+try_codec_schema(TypeInfo, Format, Type, SpType, Config) ->
     #{name := TypeReference} = spectra_type:get_meta(Type),
-    case spectra_type_info:find_codec(Mod, TypeReference, Config) of
+    Mod = spectra_type_info:get_module(TypeInfo),
+    case spectra_type_info:find_codec(TypeInfo, TypeReference, Config) of
         {ok, M} ->
             case erlang:function_exported(M, schema, 6) of
                 true ->

--- a/src/spectra_codec.erl
+++ b/src/spectra_codec.erl
@@ -100,8 +100,8 @@ where the reference node is available.
 -optional_callbacks([schema/6]).
 
 -export([
-    try_codec_encode/7,
-    try_codec_decode/7,
+    try_codec_encode/6,
+    try_codec_decode/6,
     try_codec_schema/5
 ]).
 
@@ -112,13 +112,11 @@ where the reference node is available.
     Type :: spectra:sp_type(),
     Data :: dynamic(),
     SpType :: spectra:sp_type(),
-    Codecs :: #{spectra:codec_key() => module()},
-    CacheMode :: spectra:module_types_cache()
+    Config :: spectra:sp_config()
 ) -> spectra:codec_encode_result().
-try_codec_encode(Mod, Format, Type, Data, SpType, Codecs, CacheMode) ->
-    Config = #sp_config{codecs = Codecs, module_types_cache = CacheMode},
+try_codec_encode(Mod, Format, Type, Data, SpType, Config) ->
     #{name := TypeReference} = spectra_type:get_meta(Type),
-    case spectra_type_info:find_codec(Mod, TypeReference, Codecs, CacheMode) of
+    case spectra_type_info:find_codec(Mod, TypeReference, Config) of
         {ok, M} ->
             M:encode(
                 Format, Mod, TypeReference, Data, SpType, spectra_type:parameters(Type), Config
@@ -134,13 +132,11 @@ try_codec_encode(Mod, Format, Type, Data, SpType, Codecs, CacheMode) ->
     Type :: spectra:sp_type(),
     Data :: dynamic(),
     SpType :: spectra:sp_type(),
-    Codecs :: #{spectra:codec_key() => module()},
-    CacheMode :: spectra:module_types_cache()
+    Config :: spectra:sp_config()
 ) -> spectra:codec_decode_result().
-try_codec_decode(Mod, Format, Type, Data, SpType, Codecs, CacheMode) ->
-    Config = #sp_config{codecs = Codecs, module_types_cache = CacheMode},
+try_codec_decode(Mod, Format, Type, Data, SpType, Config) ->
     #{name := TypeReference} = spectra_type:get_meta(Type),
-    case spectra_type_info:find_codec(Mod, TypeReference, Codecs, CacheMode) of
+    case spectra_type_info:find_codec(Mod, TypeReference, Config) of
         {ok, M} ->
             M:decode(
                 Format, Mod, TypeReference, Data, SpType, spectra_type:parameters(Type), Config
@@ -159,11 +155,7 @@ try_codec_decode(Mod, Format, Type, Data, SpType, Codecs, CacheMode) ->
 ) -> dynamic() | continue.
 try_codec_schema(Mod, Format, Type, SpType, Config) ->
     #{name := TypeReference} = spectra_type:get_meta(Type),
-    case
-        spectra_type_info:find_codec(
-            Mod, TypeReference, Config#sp_config.codecs, Config#sp_config.module_types_cache
-        )
-    of
+    case spectra_type_info:find_codec(Mod, TypeReference, Config) of
         {ok, M} ->
             case erlang:function_exported(M, schema, 6) of
                 true ->

--- a/src/spectra_codec.erl
+++ b/src/spectra_codec.erl
@@ -95,8 +95,8 @@ where the reference node is available.
 -optional_callbacks([schema/5]).
 
 -export([
-    try_codec_encode/5,
-    try_codec_decode/5,
+    try_codec_encode/6,
+    try_codec_decode/6,
     try_codec_schema/4
 ]).
 
@@ -105,11 +105,12 @@ where the reference node is available.
     Format :: atom(),
     Type :: spectra:sp_type(),
     Data :: dynamic(),
-    SpType :: spectra:sp_type()
+    SpType :: spectra:sp_type(),
+    Codecs :: #{spectra:codec_key() => module()}
 ) -> spectra:codec_encode_result().
-try_codec_encode(Mod, Format, Type, Data, SpType) ->
+try_codec_encode(Mod, Format, Type, Data, SpType, Codecs) ->
     #{name := TypeReference} = spectra_type:get_meta(Type),
-    case spectra_type_info:find_codec(Mod, TypeReference) of
+    case spectra_type_info:find_codec(Mod, TypeReference, Codecs, false) of
         {ok, M} ->
             M:encode(Format, Mod, TypeReference, Data, SpType, spectra_type:parameters(Type));
         error ->
@@ -121,11 +122,12 @@ try_codec_encode(Mod, Format, Type, Data, SpType) ->
     Format :: atom(),
     Type :: spectra:sp_type(),
     Data :: dynamic(),
-    SpType :: spectra:sp_type()
+    SpType :: spectra:sp_type(),
+    Codecs :: #{spectra:codec_key() => module()}
 ) -> spectra:codec_decode_result().
-try_codec_decode(Mod, Format, Type, Data, SpType) ->
+try_codec_decode(Mod, Format, Type, Data, SpType, Codecs) ->
     #{name := TypeReference} = spectra_type:get_meta(Type),
-    case spectra_type_info:find_codec(Mod, TypeReference) of
+    case spectra_type_info:find_codec(Mod, TypeReference, Codecs, false) of
         {ok, M} ->
             M:decode(Format, Mod, TypeReference, Data, SpType, spectra_type:parameters(Type));
         error ->
@@ -140,7 +142,8 @@ try_codec_decode(Mod, Format, Type, Data, SpType) ->
 ) -> dynamic() | continue.
 try_codec_schema(Mod, Format, Type, SpType) ->
     #{name := TypeReference} = spectra_type:get_meta(Type),
-    case spectra_type_info:find_codec(Mod, TypeReference) of
+    GlobalCodecs = application:get_env(spectra, codecs, #{}),
+    case spectra_type_info:find_codec(Mod, TypeReference, GlobalCodecs, false) of
         {ok, M} ->
             case erlang:function_exported(M, schema, 5) of
                 true ->

--- a/src/spectra_codec.erl
+++ b/src/spectra_codec.erl
@@ -110,11 +110,11 @@ where the reference node is available.
     Data :: dynamic(),
     SpType :: spectra:sp_type(),
     Codecs :: #{spectra:codec_key() => module()},
-    UseCache :: boolean()
+    CacheMode :: spectra:module_types_cache()
 ) -> spectra:codec_encode_result().
-try_codec_encode(Mod, Format, Type, Data, SpType, Codecs, UseCache) ->
+try_codec_encode(Mod, Format, Type, Data, SpType, Codecs, CacheMode) ->
     #{name := TypeReference} = spectra_type:get_meta(Type),
-    case spectra_type_info:find_codec(Mod, TypeReference, Codecs, UseCache) of
+    case spectra_type_info:find_codec(Mod, TypeReference, Codecs, CacheMode) of
         {ok, M} ->
             M:encode(Format, Mod, TypeReference, Data, SpType, spectra_type:parameters(Type));
         error ->
@@ -129,11 +129,11 @@ try_codec_encode(Mod, Format, Type, Data, SpType, Codecs, UseCache) ->
     Data :: dynamic(),
     SpType :: spectra:sp_type(),
     Codecs :: #{spectra:codec_key() => module()},
-    UseCache :: boolean()
+    CacheMode :: spectra:module_types_cache()
 ) -> spectra:codec_decode_result().
-try_codec_decode(Mod, Format, Type, Data, SpType, Codecs, UseCache) ->
+try_codec_decode(Mod, Format, Type, Data, SpType, Codecs, CacheMode) ->
     #{name := TypeReference} = spectra_type:get_meta(Type),
-    case spectra_type_info:find_codec(Mod, TypeReference, Codecs, UseCache) of
+    case spectra_type_info:find_codec(Mod, TypeReference, Codecs, CacheMode) of
         {ok, M} ->
             M:decode(Format, Mod, TypeReference, Data, SpType, spectra_type:parameters(Type));
         error ->
@@ -152,7 +152,7 @@ try_codec_schema(Mod, Format, Type, SpType, Config) ->
     #{name := TypeReference} = spectra_type:get_meta(Type),
     case
         spectra_type_info:find_codec(
-            Mod, TypeReference, Config#sp_config.codecs, Config#sp_config.use_module_types_cache
+            Mod, TypeReference, Config#sp_config.codecs, Config#sp_config.module_types_cache
         )
     of
         {ok, M} ->

--- a/src/spectra_codec.erl
+++ b/src/spectra_codec.erl
@@ -96,10 +96,13 @@ where the reference node is available.
 
 -export([
     try_codec_encode/6,
+    try_codec_encode/7,
     try_codec_decode/6,
+    try_codec_decode/7,
     try_codec_schema/4
 ]).
 
+-doc #{equiv => try_codec_encode(Mod, Format, Type, Data, SpType, Codecs, false)}.
 -spec try_codec_encode(
     Mod :: module(),
     Format :: atom(),
@@ -109,14 +112,28 @@ where the reference node is available.
     Codecs :: #{spectra:codec_key() => module()}
 ) -> spectra:codec_encode_result().
 try_codec_encode(Mod, Format, Type, Data, SpType, Codecs) ->
+    try_codec_encode(Mod, Format, Type, Data, SpType, Codecs, false).
+
+-doc "Encodes `Data` via a registered codec for `{Mod, TypeReference}`, or returns `continue`.".
+-spec try_codec_encode(
+    Mod :: module(),
+    Format :: atom(),
+    Type :: spectra:sp_type(),
+    Data :: dynamic(),
+    SpType :: spectra:sp_type(),
+    Codecs :: #{spectra:codec_key() => module()},
+    UseCache :: boolean()
+) -> spectra:codec_encode_result().
+try_codec_encode(Mod, Format, Type, Data, SpType, Codecs, UseCache) ->
     #{name := TypeReference} = spectra_type:get_meta(Type),
-    case spectra_type_info:find_codec(Mod, TypeReference, Codecs, false) of
+    case spectra_type_info:find_codec(Mod, TypeReference, Codecs, UseCache) of
         {ok, M} ->
             M:encode(Format, Mod, TypeReference, Data, SpType, spectra_type:parameters(Type));
         error ->
             continue
     end.
 
+-doc #{equiv => try_codec_decode(Mod, Format, Type, Data, SpType, Codecs, false)}.
 -spec try_codec_decode(
     Mod :: module(),
     Format :: atom(),
@@ -126,8 +143,21 @@ try_codec_encode(Mod, Format, Type, Data, SpType, Codecs) ->
     Codecs :: #{spectra:codec_key() => module()}
 ) -> spectra:codec_decode_result().
 try_codec_decode(Mod, Format, Type, Data, SpType, Codecs) ->
+    try_codec_decode(Mod, Format, Type, Data, SpType, Codecs, false).
+
+-doc "Decodes `Data` via a registered codec for `{Mod, TypeReference}`, or returns `continue`.".
+-spec try_codec_decode(
+    Mod :: module(),
+    Format :: atom(),
+    Type :: spectra:sp_type(),
+    Data :: dynamic(),
+    SpType :: spectra:sp_type(),
+    Codecs :: #{spectra:codec_key() => module()},
+    UseCache :: boolean()
+) -> spectra:codec_decode_result().
+try_codec_decode(Mod, Format, Type, Data, SpType, Codecs, UseCache) ->
     #{name := TypeReference} = spectra_type:get_meta(Type),
-    case spectra_type_info:find_codec(Mod, TypeReference, Codecs, false) of
+    case spectra_type_info:find_codec(Mod, TypeReference, Codecs, UseCache) of
         {ok, M} ->
             M:decode(Format, Mod, TypeReference, Data, SpType, spectra_type:parameters(Type));
         error ->

--- a/src/spectra_codec.erl
+++ b/src/spectra_codec.erl
@@ -158,13 +158,12 @@ try_codec_schema(TypeInfo, Format, Type, SpType, Config) ->
     Mod = spectra_type_info:get_module(TypeInfo),
     case spectra_type_info:find_codec(TypeInfo, TypeReference, Config) of
         {ok, M} ->
-            case erlang:function_exported(M, schema, 6) of
-                true ->
-                    M:schema(
-                        Format, Mod, TypeReference, SpType, spectra_type:parameters(Type), Config
-                    );
-                false ->
-                    erlang:error({schema_not_implemented, M, TypeReference})
+            try
+                M:schema(
+                    Format, Mod, TypeReference, SpType, spectra_type:parameters(Type), Config
+                )
+            catch
+                error:undef -> erlang:error({schema_not_implemented, M, TypeReference})
             end;
         error ->
             continue

--- a/src/spectra_codec.erl
+++ b/src/spectra_codec.erl
@@ -120,7 +120,9 @@ try_codec_encode(Mod, Format, Type, Data, SpType, Codecs, CacheMode) ->
     #{name := TypeReference} = spectra_type:get_meta(Type),
     case spectra_type_info:find_codec(Mod, TypeReference, Codecs, CacheMode) of
         {ok, M} ->
-            M:encode(Format, Mod, TypeReference, Data, SpType, spectra_type:parameters(Type), Config);
+            M:encode(
+                Format, Mod, TypeReference, Data, SpType, spectra_type:parameters(Type), Config
+            );
         error ->
             continue
     end.
@@ -140,7 +142,9 @@ try_codec_decode(Mod, Format, Type, Data, SpType, Codecs, CacheMode) ->
     #{name := TypeReference} = spectra_type:get_meta(Type),
     case spectra_type_info:find_codec(Mod, TypeReference, Codecs, CacheMode) of
         {ok, M} ->
-            M:decode(Format, Mod, TypeReference, Data, SpType, spectra_type:parameters(Type), Config);
+            M:decode(
+                Format, Mod, TypeReference, Data, SpType, spectra_type:parameters(Type), Config
+            );
         error ->
             continue
     end.
@@ -163,7 +167,9 @@ try_codec_schema(Mod, Format, Type, SpType, Config) ->
         {ok, M} ->
             case erlang:function_exported(M, schema, 6) of
                 true ->
-                    M:schema(Format, Mod, TypeReference, SpType, spectra_type:parameters(Type), Config);
+                    M:schema(
+                        Format, Mod, TypeReference, SpType, spectra_type:parameters(Type), Config
+                    );
                 false ->
                     erlang:error({schema_not_implemented, M, TypeReference})
             end;

--- a/src/spectra_codec.erl
+++ b/src/spectra_codec.erl
@@ -36,9 +36,9 @@ on the type definition, or `undefined` when no such attribute is present.
 The codec receives `<<"user:">>` as `Params` and can use it directly:
 
 ```erlang
-encode(json, _Mod, _TypeRef, Data, _SpType, Prefix) when is_binary(Prefix) ->
+encode(json, _Mod, _TypeRef, Data, _SpType, Prefix, _Config) when is_binary(Prefix) ->
     {ok, <<Prefix/binary, Data/binary>>};
-encode(_Format, _Mod, _TypeRef, _Data, _SpType, _Params) ->
+encode(_Format, _Mod, _TypeRef, _Data, _SpType, _Params, _Config) ->
     continue.
 ```
 
@@ -54,10 +54,10 @@ For a type written as `dict:dict(binary(), integer())` the codec receives the
 recursively encode/decode keys and values:
 
 ```erlang
-encode(json, Mod, _TypeRef, Data, SpType, _Params) ->
-    TypeInfo = spectra_module_types:get(Mod),
+encode(json, Mod, _TypeRef, Data, SpType, _Params, Config) ->
+    TypeInfo = spectra_module_types:get(Mod, Config#sp_config.module_types_cache),
     [KeyType, ValueType] = spectra_type:type_args(SpType),
-    encode_pairs(TypeInfo, KeyType, ValueType, dict:to_list(Data), #{}).
+    encode_pairs(TypeInfo, KeyType, ValueType, dict:to_list(Data), #{}, Config).
 ```
 
 Note: when a codec is invoked from the `spectra:encode/decode/schema` entry
@@ -73,7 +73,8 @@ where the reference node is available.
     TypeRef :: spectra:sp_type_reference(),
     Data :: dynamic(),
     SpType :: spectra:sp_type(),
-    Params :: term()
+    Params :: term(),
+    Config :: spectra:sp_config()
 ) ->
     spectra:codec_encode_result().
 -callback decode(
@@ -82,7 +83,8 @@ where the reference node is available.
     TypeRef :: spectra:sp_type_reference(),
     Input :: dynamic(),
     SpType :: spectra:sp_type(),
-    Params :: term()
+    Params :: term(),
+    Config :: spectra:sp_config()
 ) ->
     spectra:codec_decode_result().
 -callback schema(
@@ -90,11 +92,12 @@ where the reference node is available.
     Module :: module(),
     TypeRef :: spectra:sp_type_reference(),
     SpType :: spectra:sp_type(),
-    Params :: term()
+    Params :: term(),
+    Config :: spectra:sp_config()
 ) ->
     dynamic().
 
--optional_callbacks([schema/5]).
+-optional_callbacks([schema/6]).
 
 -export([
     try_codec_encode/7,
@@ -113,10 +116,11 @@ where the reference node is available.
     CacheMode :: spectra:module_types_cache()
 ) -> spectra:codec_encode_result().
 try_codec_encode(Mod, Format, Type, Data, SpType, Codecs, CacheMode) ->
+    Config = #sp_config{codecs = Codecs, module_types_cache = CacheMode},
     #{name := TypeReference} = spectra_type:get_meta(Type),
     case spectra_type_info:find_codec(Mod, TypeReference, Codecs, CacheMode) of
         {ok, M} ->
-            M:encode(Format, Mod, TypeReference, Data, SpType, spectra_type:parameters(Type));
+            M:encode(Format, Mod, TypeReference, Data, SpType, spectra_type:parameters(Type), Config);
         error ->
             continue
     end.
@@ -132,10 +136,11 @@ try_codec_encode(Mod, Format, Type, Data, SpType, Codecs, CacheMode) ->
     CacheMode :: spectra:module_types_cache()
 ) -> spectra:codec_decode_result().
 try_codec_decode(Mod, Format, Type, Data, SpType, Codecs, CacheMode) ->
+    Config = #sp_config{codecs = Codecs, module_types_cache = CacheMode},
     #{name := TypeReference} = spectra_type:get_meta(Type),
     case spectra_type_info:find_codec(Mod, TypeReference, Codecs, CacheMode) of
         {ok, M} ->
-            M:decode(Format, Mod, TypeReference, Data, SpType, spectra_type:parameters(Type));
+            M:decode(Format, Mod, TypeReference, Data, SpType, spectra_type:parameters(Type), Config);
         error ->
             continue
     end.
@@ -156,9 +161,9 @@ try_codec_schema(Mod, Format, Type, SpType, Config) ->
         )
     of
         {ok, M} ->
-            case erlang:function_exported(M, schema, 5) of
+            case erlang:function_exported(M, schema, 6) of
                 true ->
-                    M:schema(Format, Mod, TypeReference, SpType, spectra_type:parameters(Type));
+                    M:schema(Format, Mod, TypeReference, SpType, spectra_type:parameters(Type), Config);
                 false ->
                     erlang:error({schema_not_implemented, M, TypeReference})
             end;

--- a/src/spectra_codec.erl
+++ b/src/spectra_codec.erl
@@ -1,5 +1,7 @@
 -module(spectra_codec).
 
+-include("../include/spectra_internal.hrl").
+
 -doc """
 Behaviour for custom codecs that extend spectra's encoding, decoding, and
 schema generation for specific types and formats.
@@ -95,24 +97,10 @@ where the reference node is available.
 -optional_callbacks([schema/5]).
 
 -export([
-    try_codec_encode/6,
     try_codec_encode/7,
-    try_codec_decode/6,
     try_codec_decode/7,
-    try_codec_schema/4
+    try_codec_schema/5
 ]).
-
--doc #{equiv => try_codec_encode(Mod, Format, Type, Data, SpType, Codecs, false)}.
--spec try_codec_encode(
-    Mod :: module(),
-    Format :: atom(),
-    Type :: spectra:sp_type(),
-    Data :: dynamic(),
-    SpType :: spectra:sp_type(),
-    Codecs :: #{spectra:codec_key() => module()}
-) -> spectra:codec_encode_result().
-try_codec_encode(Mod, Format, Type, Data, SpType, Codecs) ->
-    try_codec_encode(Mod, Format, Type, Data, SpType, Codecs, false).
 
 -doc "Encodes `Data` via a registered codec for `{Mod, TypeReference}`, or returns `continue`.".
 -spec try_codec_encode(
@@ -133,18 +121,6 @@ try_codec_encode(Mod, Format, Type, Data, SpType, Codecs, UseCache) ->
             continue
     end.
 
--doc #{equiv => try_codec_decode(Mod, Format, Type, Data, SpType, Codecs, false)}.
--spec try_codec_decode(
-    Mod :: module(),
-    Format :: atom(),
-    Type :: spectra:sp_type(),
-    Data :: dynamic(),
-    SpType :: spectra:sp_type(),
-    Codecs :: #{spectra:codec_key() => module()}
-) -> spectra:codec_decode_result().
-try_codec_decode(Mod, Format, Type, Data, SpType, Codecs) ->
-    try_codec_decode(Mod, Format, Type, Data, SpType, Codecs, false).
-
 -doc "Decodes `Data` via a registered codec for `{Mod, TypeReference}`, or returns `continue`.".
 -spec try_codec_decode(
     Mod :: module(),
@@ -164,16 +140,21 @@ try_codec_decode(Mod, Format, Type, Data, SpType, Codecs, UseCache) ->
             continue
     end.
 
+-doc "Returns the schema for `{Mod, TypeReference}` via a registered codec, or `continue`.".
 -spec try_codec_schema(
     Mod :: module(),
     Format :: atom(),
     Type :: spectra:sp_type(),
-    SpType :: spectra:sp_type()
+    SpType :: spectra:sp_type(),
+    Config :: spectra:sp_config()
 ) -> dynamic() | continue.
-try_codec_schema(Mod, Format, Type, SpType) ->
+try_codec_schema(Mod, Format, Type, SpType, Config) ->
     #{name := TypeReference} = spectra_type:get_meta(Type),
-    GlobalCodecs = application:get_env(spectra, codecs, #{}),
-    case spectra_type_info:find_codec(Mod, TypeReference, GlobalCodecs, false) of
+    case
+        spectra_type_info:find_codec(
+            Mod, TypeReference, Config#sp_config.codecs, Config#sp_config.use_module_types_cache
+        )
+    of
         {ok, M} ->
             case erlang:function_exported(M, schema, 5) of
                 true ->

--- a/src/spectra_codec.erl
+++ b/src/spectra_codec.erl
@@ -1,7 +1,5 @@
 -module(spectra_codec).
 
--include("../include/spectra_internal.hrl").
-
 -doc """
 Behaviour for custom codecs that extend spectra's encoding, decoding, and
 schema generation for specific types and formats.

--- a/src/spectra_codec.erl
+++ b/src/spectra_codec.erl
@@ -53,7 +53,7 @@ recursively encode/decode keys and values:
 
 ```erlang
 encode(json, Mod, _TypeRef, Data, SpType, _Params, Config) ->
-    TypeInfo = spectra_module_types:get(Mod, Config#sp_config.module_types_cache),
+    TypeInfo = spectra_module_types:get(Mod, Config),
     [KeyType, ValueType] = spectra_type:type_args(SpType),
     encode_pairs(TypeInfo, KeyType, ValueType, dict:to_list(Data), #{}, Config).
 ```

--- a/src/spectra_dict_codec.erl
+++ b/src/spectra_dict_codec.erl
@@ -37,48 +37,58 @@ D = dict:from_list([{<<"hello">>, 3}, {<<"world">>, 1}]),
 
 -behaviour(spectra_codec).
 
--export([encode/6, decode/6, schema/5]).
+-include("../include/spectra_internal.hrl").
 
--spec encode(atom(), module(), spectra:sp_type_reference(), dynamic(), spectra:sp_type(), term()) ->
+-export([encode/7, decode/7, schema/6]).
+
+-spec encode(
+    atom(), module(), spectra:sp_type_reference(), dynamic(), spectra:sp_type(), term(),
+    spectra:sp_config()
+) ->
     spectra:codec_encode_result().
-encode(json, Mod, {type, dict, 2} = TypeRef, Data, SpType, _Params) ->
+encode(json, Mod, {type, dict, 2} = TypeRef, Data, SpType, _Params, Config) ->
     try dict:to_list(Data) of
         Pairs ->
-            TypeInfo = spectra_module_types:get(Mod),
+            TypeInfo = spectra_module_types:get(Mod, Config#sp_config.module_types_cache),
             [KeyType, ValueType] = spectra_type:type_args(SpType),
-            encode_pairs(TypeInfo, KeyType, ValueType, Pairs, [])
+            encode_pairs(TypeInfo, KeyType, ValueType, Pairs, [], Config)
     catch
         error:badarg ->
             {error, [sp_error:type_mismatch(TypeRef, Data)]}
     end.
 
--spec decode(atom(), module(), spectra:sp_type_reference(), dynamic(), spectra:sp_type(), term()) ->
+-spec decode(
+    atom(), module(), spectra:sp_type_reference(), dynamic(), spectra:sp_type(), term(),
+    spectra:sp_config()
+) ->
     spectra:codec_decode_result().
-decode(json, Mod, {type, dict, 2}, Data, SpType, _Params) when is_map(Data) ->
-    TypeInfo = spectra_module_types:get(Mod),
+decode(json, Mod, {type, dict, 2}, Data, SpType, _Params, Config) when is_map(Data) ->
+    TypeInfo = spectra_module_types:get(Mod, Config#sp_config.module_types_cache),
     [KeyType, ValueType] = spectra_type:type_args(SpType),
-    decode_pairs(TypeInfo, KeyType, ValueType, maps:to_list(Data), []);
-decode(json, _Mod, {type, dict, 2} = TypeRef, Data, _SpType, _Params) ->
+    decode_pairs(TypeInfo, KeyType, ValueType, maps:to_list(Data), [], Config);
+decode(json, _Mod, {type, dict, 2} = TypeRef, Data, _SpType, _Params, _Config) ->
     {error, [sp_error:type_mismatch(TypeRef, Data)]}.
 
--spec schema(atom(), module(), spectra:sp_type_reference(), spectra:sp_type(), term()) ->
+-spec schema(
+    atom(), module(), spectra:sp_type_reference(), spectra:sp_type(), term(), spectra:sp_config()
+) ->
     dynamic().
-schema(json_schema, Mod, {type, dict, 2}, SpType, _Params) ->
-    TypeInfo = spectra_module_types:get(Mod),
+schema(json_schema, Mod, {type, dict, 2}, SpType, _Params, Config) ->
+    TypeInfo = spectra_module_types:get(Mod, Config#sp_config.module_types_cache),
     [_KeyType, ValueType] = spectra_type:type_args(SpType),
-    ValueSchema = spectra_json_schema:to_schema(TypeInfo, ValueType),
+    ValueSchema = spectra_json_schema:to_schema(TypeInfo, ValueType, Config),
     #{type => <<"object">>, additionalProperties => ValueSchema}.
 
 %% Internal helpers
 
-encode_pairs(_TypeInfo, _KeyType, _ValueType, [], Acc) ->
+encode_pairs(_TypeInfo, _KeyType, _ValueType, [], Acc, _Config) ->
     {ok, maps:from_list(Acc)};
-encode_pairs(TypeInfo, KeyType, ValueType, [{Key, Value} | Rest], Acc) ->
-    case spectra_json:to_json(TypeInfo, KeyType, Key) of
+encode_pairs(TypeInfo, KeyType, ValueType, [{Key, Value} | Rest], Acc, Config) ->
+    case spectra_json:to_json(TypeInfo, KeyType, Key, Config) of
         {ok, KeyBin} when is_binary(KeyBin) ->
-            case spectra_json:to_json(TypeInfo, ValueType, Value) of
+            case spectra_json:to_json(TypeInfo, ValueType, Value, Config) of
                 {ok, ValueJson} ->
-                    encode_pairs(TypeInfo, KeyType, ValueType, Rest, [{KeyBin, ValueJson} | Acc]);
+                    encode_pairs(TypeInfo, KeyType, ValueType, Rest, [{KeyBin, ValueJson} | Acc], Config);
                 {error, _} = Err ->
                     Err
             end;
@@ -92,19 +102,20 @@ encode_pairs(TypeInfo, KeyType, ValueType, [{Key, Value} | Rest], Acc) ->
             Err
     end.
 
-decode_pairs(_TypeInfo, _KeyType, _ValueType, [], Acc) ->
+decode_pairs(_TypeInfo, _KeyType, _ValueType, [], Acc, _Config) ->
     {ok, dict:from_list(Acc)};
-decode_pairs(TypeInfo, KeyType, ValueType, [{Key, Value} | Rest], Acc) ->
-    case spectra_json:from_json(TypeInfo, KeyType, Key) of
+decode_pairs(TypeInfo, KeyType, ValueType, [{Key, Value} | Rest], Acc, Config) ->
+    case spectra_json:from_json(TypeInfo, KeyType, Key, Config) of
         {ok, KeyDecoded} ->
-            case spectra_json:from_json(TypeInfo, ValueType, Value) of
+            case spectra_json:from_json(TypeInfo, ValueType, Value, Config) of
                 {ok, ValueDecoded} ->
                     decode_pairs(
                         TypeInfo,
                         KeyType,
                         ValueType,
                         Rest,
-                        [{KeyDecoded, ValueDecoded} | Acc]
+                        [{KeyDecoded, ValueDecoded} | Acc],
+                        Config
                     );
                 {error, _} = Err ->
                     Err

--- a/src/spectra_dict_codec.erl
+++ b/src/spectra_dict_codec.erl
@@ -42,7 +42,12 @@ D = dict:from_list([{<<"hello">>, 3}, {<<"world">>, 1}]),
 -export([encode/7, decode/7, schema/6]).
 
 -spec encode(
-    atom(), module(), spectra:sp_type_reference(), dynamic(), spectra:sp_type(), term(),
+    atom(),
+    module(),
+    spectra:sp_type_reference(),
+    dynamic(),
+    spectra:sp_type(),
+    term(),
     spectra:sp_config()
 ) ->
     spectra:codec_encode_result().
@@ -58,7 +63,12 @@ encode(json, Mod, {type, dict, 2} = TypeRef, Data, SpType, _Params, Config) ->
     end.
 
 -spec decode(
-    atom(), module(), spectra:sp_type_reference(), dynamic(), spectra:sp_type(), term(),
+    atom(),
+    module(),
+    spectra:sp_type_reference(),
+    dynamic(),
+    spectra:sp_type(),
+    term(),
     spectra:sp_config()
 ) ->
     spectra:codec_decode_result().
@@ -88,7 +98,9 @@ encode_pairs(TypeInfo, KeyType, ValueType, [{Key, Value} | Rest], Acc, Config) -
         {ok, KeyBin} when is_binary(KeyBin) ->
             case spectra_json:to_json(TypeInfo, ValueType, Value, Config) of
                 {ok, ValueJson} ->
-                    encode_pairs(TypeInfo, KeyType, ValueType, Rest, [{KeyBin, ValueJson} | Acc], Config);
+                    encode_pairs(
+                        TypeInfo, KeyType, ValueType, Rest, [{KeyBin, ValueJson} | Acc], Config
+                    );
                 {error, _} = Err ->
                     Err
             end;

--- a/src/spectra_dict_codec.erl
+++ b/src/spectra_dict_codec.erl
@@ -37,8 +37,6 @@ D = dict:from_list([{<<"hello">>, 3}, {<<"world">>, 1}]),
 
 -behaviour(spectra_codec).
 
--include("../include/spectra_internal.hrl").
-
 -export([encode/7, decode/7, schema/6]).
 
 -spec encode(
@@ -54,7 +52,7 @@ D = dict:from_list([{<<"hello">>, 3}, {<<"world">>, 1}]),
 encode(json, Mod, {type, dict, 2} = TypeRef, Data, SpType, _Params, Config) ->
     try dict:to_list(Data) of
         Pairs ->
-            TypeInfo = spectra_module_types:get(Mod, Config#sp_config.module_types_cache),
+            TypeInfo = spectra_module_types:get(Mod, Config),
             [KeyType, ValueType] = spectra_type:type_args(SpType),
             encode_pairs(TypeInfo, KeyType, ValueType, Pairs, [], Config)
     catch
@@ -73,7 +71,7 @@ encode(json, Mod, {type, dict, 2} = TypeRef, Data, SpType, _Params, Config) ->
 ) ->
     spectra:codec_decode_result().
 decode(json, Mod, {type, dict, 2}, Data, SpType, _Params, Config) when is_map(Data) ->
-    TypeInfo = spectra_module_types:get(Mod, Config#sp_config.module_types_cache),
+    TypeInfo = spectra_module_types:get(Mod, Config),
     [KeyType, ValueType] = spectra_type:type_args(SpType),
     decode_pairs(TypeInfo, KeyType, ValueType, maps:to_list(Data), [], Config);
 decode(json, _Mod, {type, dict, 2} = TypeRef, Data, _SpType, _Params, _Config) ->
@@ -84,7 +82,7 @@ decode(json, _Mod, {type, dict, 2} = TypeRef, Data, _SpType, _Params, _Config) -
 ) ->
     dynamic().
 schema(json_schema, Mod, {type, dict, 2}, SpType, _Params, Config) ->
-    TypeInfo = spectra_module_types:get(Mod, Config#sp_config.module_types_cache),
+    TypeInfo = spectra_module_types:get(Mod, Config),
     [_KeyType, ValueType] = spectra_type:type_args(SpType),
     ValueSchema = spectra_json_schema:to_schema(TypeInfo, ValueType, Config),
     #{type => <<"object">>, additionalProperties => ValueSchema}.

--- a/src/spectra_json.erl
+++ b/src/spectra_json.erl
@@ -3,9 +3,9 @@
 -moduledoc """
 JSON encode and decode traversal for `sp_type()` values.
 
-`to_json/3` walks an Erlang term against an `sp_type()` and produces a
+`to_json/4` walks an Erlang term against an `sp_type()` and produces a
 `json:encode_value()` (a map/list/scalar tree accepted by `json:encode/1`).
-`from_json/3` does the inverse: it walks a decoded JSON value and produces
+`from_json/4` does the inverse: it walks a decoded JSON value and produces
 the corresponding Erlang term.
 
 Neither function calls `json:encode/1` or `json:decode/1` — that is the
@@ -13,14 +13,52 @@ responsibility of the caller (typically `spectra.erl`).
 
 Codec dispatch is handled mid-traversal at `#sp_user_type_ref{}`,
 `#sp_remote_type{}`, and `#sp_rec_ref{}` nodes via
-`spectra_codec:try_codec_encode/5` and `try_codec_decode/5`.
+`spectra_codec:try_codec_encode/6` and `try_codec_decode/6`.
 """.
 
--export([to_json/3, from_json/3]).
+-export([to_json/3, to_json/4, from_json/3, from_json/4]).
 
--ignore_xref([to_json/3, from_json/3]).
+-ignore_xref([to_json/3, to_json/4, from_json/3, from_json/4]).
 
 -include("../include/spectra_internal.hrl").
+
+-doc """
+Encodes `Data` to a JSON-compatible value according to `Type`.
+
+Equivalent to calling to_json/4 with a default configuration.
+""".
+-doc #{
+    equiv => to_json(TypeInfo, Type, Data, #sp_config{})
+}.
+-spec to_json(
+    TypeInfo :: spectra:type_info(),
+    Type :: spectra:sp_type(),
+    Data :: dynamic()
+) ->
+    {ok, json:encode_value()} | {error, [spectra:error()]}.
+to_json(TypeInfo, Type, Data) ->
+    UseCache = application:get_env(spectra, use_module_types_cache, false),
+    Codecs = application:get_env(spectra, codecs, #{}),
+    to_json(TypeInfo, Type, Data, #sp_config{use_module_types_cache = UseCache, codecs = Codecs}).
+
+-doc """
+Decodes a JSON value to an Erlang value according to `Type`.
+
+Equivalent to calling from_json/4 with a default configuration.
+""".
+-doc #{
+    equiv => from_json(TypeInfo, Type, Json, #sp_config{})
+}.
+-spec from_json(
+    TypeInfo :: spectra:type_info(),
+    Type :: spectra:sp_type(),
+    Json :: json:decode_value()
+) ->
+    {ok, dynamic()} | {error, [spectra:error()]}.
+from_json(TypeInfo, Type, Json) ->
+    UseCache = application:get_env(spectra, use_module_types_cache, false),
+    Codecs = application:get_env(spectra, codecs, #{}),
+    from_json(TypeInfo, Type, Json, #sp_config{use_module_types_cache = UseCache, codecs = Codecs}).
 
 -doc """
 Encodes `Data` to a JSON-compatible value according to `Type`.
@@ -36,57 +74,71 @@ structured `#sp_error{}` values describing every mismatch found.
 -spec to_json(
     TypeInfo :: spectra:type_info(),
     Type :: spectra:sp_type(),
-    Data :: dynamic()
+    Data :: dynamic(),
+    Config :: spectra:sp_config()
 ) ->
     {ok, json:encode_value()} | {error, [spectra:error()]}.
 to_json(
     TypeInfo,
     #sp_user_type_ref{type_name = TypeName, variables = Args, arity = Arity} = UserTypeRef,
-    Data
+    Data,
+    Config
 ) when
     is_atom(TypeName)
 ->
     Mod = spectra_type_info:get_module(TypeInfo),
     Type = spectra_type_info:get_type(TypeInfo, TypeName, Arity),
-    case spectra_codec:try_codec_encode(Mod, json, Type, Data, UserTypeRef) of
+    case
+        spectra_codec:try_codec_encode(Mod, json, Type, Data, UserTypeRef, Config#sp_config.codecs)
+    of
         continue ->
             TypeWithoutVars = apply_args(TypeInfo, Type, Args),
-            to_json(TypeInfo, TypeWithoutVars, Data);
+            to_json(TypeInfo, TypeWithoutVars, Data, Config);
         Result ->
             Result
     end;
 to_json(
     _TypeInfo,
     #sp_remote_type{mfargs = {Module, TypeName, Args}, arity = TypeArity} = RemoteRef,
-    Data
+    Data,
+    Config
 ) ->
-    RemoteTypeInfo = spectra_module_types:get(Module),
+    RemoteTypeInfo = spectra_module_types:get(Module, Config#sp_config.use_module_types_cache),
     RemoteType = spectra_type_info:get_type(RemoteTypeInfo, TypeName, TypeArity),
-    case spectra_codec:try_codec_encode(Module, json, RemoteType, Data, RemoteRef) of
+    case
+        spectra_codec:try_codec_encode(
+            Module, json, RemoteType, Data, RemoteRef, Config#sp_config.codecs
+        )
+    of
         continue ->
             TypeResolved = spectra_type:propagate_params(
                 RemoteRef, apply_args(RemoteTypeInfo, RemoteType, Args)
             ),
-            to_json(RemoteTypeInfo, TypeResolved, Data);
+            to_json(RemoteTypeInfo, TypeResolved, Data, Config);
         Result ->
             Result
     end;
-to_json(TypeInfo, #sp_rec{} = RecordInfo, Record) when is_tuple(Record) ->
-    record_to_json(TypeInfo, RecordInfo, Record, []);
+to_json(TypeInfo, #sp_rec{} = RecordInfo, Record, Config) when is_tuple(Record) ->
+    record_to_json(TypeInfo, RecordInfo, Record, [], Config);
 to_json(
     TypeInfo,
     #sp_rec_ref{record_name = RecordName, field_types = TypeArgs} = RecordRef,
-    Record
+    Record,
+    Config
 ) when
     is_atom(RecordName)
 ->
     Mod = spectra_type_info:get_module(TypeInfo),
     RecordType = spectra_type_info:get_record(TypeInfo, RecordName),
-    case spectra_codec:try_codec_encode(Mod, json, RecordType, Record, RecordRef) of
-        continue -> record_to_json(TypeInfo, RecordType, Record, TypeArgs);
+    case
+        spectra_codec:try_codec_encode(
+            Mod, json, RecordType, Record, RecordRef, Config#sp_config.codecs
+        )
+    of
+        continue -> record_to_json(TypeInfo, RecordType, Record, TypeArgs, Config);
         Result -> Result
     end;
-to_json(_TypeInfo, #sp_simple_type{type = NotSupported} = Type, _Data) when
+to_json(_TypeInfo, #sp_simple_type{type = NotSupported} = Type, _Data, _Config) when
     NotSupported =:= pid orelse
         NotSupported =:= port orelse
         NotSupported =:= reference orelse
@@ -95,7 +147,7 @@ to_json(_TypeInfo, #sp_simple_type{type = NotSupported} = Type, _Data) when
         NotSupported =:= none
 ->
     erlang:error({type_not_supported, Type});
-to_json(_TypeInfo, #sp_simple_type{} = Type, Value) ->
+to_json(_TypeInfo, #sp_simple_type{} = Type, Value, _Config) ->
     prim_type_to_json(Type, Value);
 to_json(
     _TypeInfo,
@@ -104,47 +156,48 @@ to_json(
         lower_bound = Min,
         upper_bound = Max
     },
-    Value
+    Value,
+    _Config
 ) when
     is_integer(Value) andalso Min =< Value, Value =< Max
 ->
     {ok, Value};
-to_json(_TypeInfo, #sp_literal{value = Value, binary_value = BinaryValue}, Value) when
+to_json(_TypeInfo, #sp_literal{value = Value, binary_value = BinaryValue}, Value, _Config) when
     is_atom(Value)
 ->
     {ok, BinaryValue};
-to_json(_TypeInfo, #sp_literal{value = Value}, Value) when
+to_json(_TypeInfo, #sp_literal{value = Value}, Value, _Config) when
     is_integer(Value) orelse Value =:= []
 ->
     {ok, Value};
-to_json(TypeInfo, #sp_union{} = Type, Data) ->
-    union(fun to_json/3, TypeInfo, Type, Data);
-to_json(TypeInfo, #sp_nonempty_list{} = Type, Data) ->
-    nonempty_list_to_json(TypeInfo, Type, Data);
-to_json(TypeInfo, #sp_list{} = ListType, Data) when is_list(Data) ->
-    list_to_json(TypeInfo, ListType, Data);
-to_json(TypeInfo, #sp_map{struct_name = StructName} = Map, Data) ->
+to_json(TypeInfo, #sp_union{} = Type, Data, Config) ->
+    union(fun to_json/4, TypeInfo, Type, Data, Config);
+to_json(TypeInfo, #sp_nonempty_list{} = Type, Data, Config) ->
+    nonempty_list_to_json(TypeInfo, Type, Data, Config);
+to_json(TypeInfo, #sp_list{} = ListType, Data, Config) when is_list(Data) ->
+    list_to_json(TypeInfo, ListType, Data, Config);
+to_json(TypeInfo, #sp_map{struct_name = StructName} = Map, Data, Config) ->
     case StructName of
         undefined ->
-            map_to_json(TypeInfo, Map, Data);
+            map_to_json(TypeInfo, Map, Data, Config);
         _ ->
             %% For Elixir structs, we expect the data to have the __struct__ field
             case maps:get('__struct__', Data, undefined) of
                 StructName ->
-                    map_to_json(TypeInfo, Map, Data);
+                    map_to_json(TypeInfo, Map, Data, Config);
                 _ ->
                     {error, [sp_error:type_mismatch(Map, Data, #{message => "Struct mismatch"})]}
             end
     end;
-to_json(_TypeInfo, #sp_maybe_improper_list{} = Type, _Data) ->
+to_json(_TypeInfo, #sp_maybe_improper_list{} = Type, _Data, _Config) ->
     erlang:error({type_not_supported, Type});
-to_json(_TypeInfo, #sp_nonempty_improper_list{} = Type, _Data) ->
+to_json(_TypeInfo, #sp_nonempty_improper_list{} = Type, _Data, _Config) ->
     erlang:error({type_not_supported, Type});
-to_json(_TypeInfo, #sp_tuple{} = Type, _Data) ->
+to_json(_TypeInfo, #sp_tuple{} = Type, _Data, _Config) ->
     erlang:error({type_not_supported, Type});
-to_json(_TypeInfo, #sp_function{} = Type, _Data) ->
+to_json(_TypeInfo, #sp_function{} = Type, _Data, _Config) ->
     erlang:error({type_not_supported, Type});
-to_json(_TypeInfo, Type, OtherValue) ->
+to_json(_TypeInfo, Type, OtherValue, _Config) ->
     {error, [sp_error:type_mismatch(Type, OtherValue)]}.
 
 -spec prim_type_to_json(Type :: spectra:sp_type(), Value :: dynamic()) ->
@@ -167,25 +220,26 @@ prim_type_to_json(#sp_simple_type{type = Type} = T, Value) ->
             {error, [sp_error:type_mismatch(T, Value)]}
     end.
 
-nonempty_list_to_json(TypeInfo, #sp_nonempty_list{type = Type}, Data) when
+nonempty_list_to_json(TypeInfo, #sp_nonempty_list{type = Type}, Data, Config) when
     is_list(Data) andalso Data =/= []
 ->
-    list_to_json(TypeInfo, #sp_list{type = Type}, Data);
-nonempty_list_to_json(_TypeInfo, Type, Data) ->
+    list_to_json(TypeInfo, #sp_list{type = Type}, Data, Config);
+nonempty_list_to_json(_TypeInfo, Type, Data, _Config) ->
     {error, [sp_error:type_mismatch(Type, Data)]}.
 
 -spec list_to_json(
     TypeInfo :: spectra:type_info(),
     ListType :: #sp_list{},
-    Data :: [dynamic()]
+    Data :: [dynamic()],
+    Config :: spectra:sp_config()
 ) ->
     {ok, [json:encode_value()]} | {error, [spectra:error()]}.
-list_to_json(TypeInfo, #sp_list{type = Type} = ListType, Data) when is_list(Data) ->
+list_to_json(TypeInfo, #sp_list{type = Type} = ListType, Data, Config) when is_list(Data) ->
     case safe_enumerate(Data) of
         {ok, EnumeratedData} ->
             spectra_util:map_until_error(
                 fun({Nr, Item}) ->
-                    case to_json(TypeInfo, Type, Item) of
+                    case to_json(TypeInfo, Type, Item, Config) of
                         {ok, Json} ->
                             {ok, Json};
                         {error, Errs} ->
@@ -206,10 +260,11 @@ list_to_json(TypeInfo, #sp_list{type = Type} = ListType, Data) when is_list(Data
 -spec map_to_json(
     TypeInfo :: spectra:type_info(),
     MapFieldTypes :: #sp_map{},
-    Data :: map()
+    Data :: map(),
+    Config :: spectra:sp_config()
 ) ->
     {ok, json:encode_value()} | {error, [spectra:error()]}.
-map_to_json(TypeInfo, #sp_map{fields = Fields}, Data) when
+map_to_json(TypeInfo, #sp_map{fields = Fields}, Data, Config) when
     is_map(Data)
 ->
     %% Check if this is an Elixir struct and remove __struct__ field for JSON serialization
@@ -220,22 +275,23 @@ map_to_json(TypeInfo, #sp_map{fields = Fields}, Data) when
             error ->
                 Data
         end,
-    case map_fields_to_json(TypeInfo, Fields, DataWithoutStruct) of
+    case map_fields_to_json(TypeInfo, Fields, DataWithoutStruct, Config) of
         {ok, MapFields} ->
             {ok, maps:from_list(MapFields)};
         {error, Errors} ->
             {error, Errors}
     end;
-map_to_json(_TypeInfo, MapType, Data) ->
+map_to_json(_TypeInfo, MapType, Data, _Config) ->
     {error, [sp_error:type_mismatch(MapType, Data)]}.
 
 -spec map_fields_to_json(
     TypeInfo :: spectra:type_info(),
     MapFieldTypes :: [spectra:map_field()],
-    Data :: map()
+    Data :: map(),
+    Config :: spectra:sp_config()
 ) ->
     {ok, [{binary(), json:encode_value()}]} | {error, [spectra:error()]}.
-map_fields_to_json(TypeInfo, MapFieldTypes, Data) ->
+map_fields_to_json(TypeInfo, MapFieldTypes, Data, Config) ->
     Fun = fun
         (
             #literal_map_field{
@@ -249,7 +305,7 @@ map_fields_to_json(TypeInfo, MapFieldTypes, Data) ->
                 {{MissingValue, NewDataAcc}, {true, MissingValue}} ->
                     {ok, {FieldsAcc, NewDataAcc}};
                 {{FieldData, NewDataAcc}, _} ->
-                    case to_json(TypeInfo, FieldType, FieldData) of
+                    case to_json(TypeInfo, FieldType, FieldData, Config) of
                         {ok, FieldJson} ->
                             {ok, {
                                 [{BinaryFieldName, FieldJson}] ++ FieldsAcc,
@@ -270,7 +326,7 @@ map_fields_to_json(TypeInfo, MapFieldTypes, Data) ->
             #typed_map_field{kind = assoc, key_type = KeyType, val_type = ValueType},
             {FieldsAcc, DataAcc}
         ) ->
-            case map_typed_field_to_json(TypeInfo, KeyType, ValueType, DataAcc) of
+            case map_typed_field_to_json(TypeInfo, KeyType, ValueType, DataAcc, Config) of
                 {ok, {NewFields, NewDataAcc}} ->
                     {ok, {NewFields ++ FieldsAcc, NewDataAcc}};
                 {error, _} = Err ->
@@ -280,7 +336,7 @@ map_fields_to_json(TypeInfo, MapFieldTypes, Data) ->
             #typed_map_field{kind = exact, key_type = KeyType, val_type = ValueType} = Type,
             {FieldsAcc, DataAcc}
         ) ->
-            case map_typed_field_to_json(TypeInfo, KeyType, ValueType, DataAcc) of
+            case map_typed_field_to_json(TypeInfo, KeyType, ValueType, DataAcc, Config) of
                 {ok, {[], _}} ->
                     {error, [sp_error:not_matched_fields(Type, DataAcc)]};
                 {ok, {NewFields, NewDataAcc}} ->
@@ -300,7 +356,7 @@ map_fields_to_json(TypeInfo, MapFieldTypes, Data) ->
                 {{MissingValue, NewDataAcc}, {true, MissingValue}} ->
                     {ok, {FieldsAcc, NewDataAcc}};
                 {{FieldData, NewDataAcc}, _} ->
-                    case to_json(TypeInfo, FieldType, FieldData) of
+                    case to_json(TypeInfo, FieldType, FieldData, Config) of
                         {ok, FieldJson} ->
                             {ok, {[{BinaryFieldName, FieldJson}] ++ FieldsAcc, NewDataAcc}};
                         {error, Errs} ->
@@ -348,19 +404,20 @@ map_fields_to_json(TypeInfo, MapFieldTypes, Data) ->
     TypeInfo :: spectra:type_info(),
     KeyType :: spectra:sp_type(),
     ValueType :: spectra:sp_type(),
-    Data :: map()
+    Data :: map(),
+    Config :: spectra:sp_config()
 ) ->
     {ok, {[{json:encode_value(), json:encode_value()}], map()}}
     | {error, [spectra:error()]}.
-map_typed_field_to_json(TypeInfo, KeyType, ValueType, Data) ->
+map_typed_field_to_json(TypeInfo, KeyType, ValueType, Data, Config) ->
     Fun = fun({Key, Value}, {FieldsAcc, DataAcc}) ->
-        case to_json(TypeInfo, KeyType, Key) of
+        case to_json(TypeInfo, KeyType, Key, Config) of
             {ok, KeyJson} ->
                 case {Value, spectra_type:can_be_missing(TypeInfo, ValueType)} of
                     {MissingValue, {true, MissingValue}} ->
                         {ok, {FieldsAcc, maps:remove(Key, DataAcc)}};
                     _ ->
-                        case to_json(TypeInfo, ValueType, Value) of
+                        case to_json(TypeInfo, ValueType, Value, Config) of
                             {ok, ValueJson} ->
                                 {ok, {
                                     FieldsAcc ++ [{KeyJson, ValueJson}], maps:remove(Key, DataAcc)
@@ -382,7 +439,8 @@ map_typed_field_to_json(TypeInfo, KeyType, ValueType, Data) ->
     TypeInfo :: spectra:type_info(),
     RecordType :: #sp_rec{},
     Record :: dynamic(),
-    TypeArgs :: [{atom(), spectra:sp_type()}]
+    TypeArgs :: [{atom(), spectra:sp_type()}],
+    Config :: spectra:sp_config()
 ) ->
     {ok, #{atom() => json:encode_value()}} | {error, [spectra:error()]}.
 record_to_json(
@@ -393,7 +451,8 @@ record_to_json(
         arity = Arity
     },
     Record,
-    TypeArgs
+    TypeArgs,
+    Config
 ) when
     is_tuple(Record) andalso
         element(1, Record) =:= RecordName andalso
@@ -402,16 +461,17 @@ record_to_json(
     [RecordName | FieldsData] = tuple_to_list(Record),
     RecFieldTypes = spectra_util:record_replace_vars(Fields, TypeArgs),
     RecFieldTypesWithData = lists:zip(RecFieldTypes, FieldsData),
-    do_record_to_json(TypeInfo, RecFieldTypesWithData);
-record_to_json(_TypeInfo, RecordType, Record, TypeArgs) ->
+    do_record_to_json(TypeInfo, RecFieldTypesWithData, Config);
+record_to_json(_TypeInfo, RecordType, Record, TypeArgs, _Config) ->
     {error, [sp_error:type_mismatch(RecordType, Record, #{type_args => TypeArgs})]}.
 
 -spec do_record_to_json(
     spectra:type_info(),
-    [{#sp_rec_field{}, Value :: dynamic()}]
+    [{#sp_rec_field{}, Value :: dynamic()}],
+    Config :: spectra:sp_config()
 ) ->
     {ok, #{atom() => json}} | {error, [spectra:error()]}.
-do_record_to_json(TypeInfo, RecFieldTypesWithData) ->
+do_record_to_json(TypeInfo, RecFieldTypesWithData, Config) ->
     Fun = fun(
         {
             #sp_rec_field{name = FieldName, binary_name = BinaryFieldName, type = FieldType},
@@ -423,7 +483,7 @@ do_record_to_json(TypeInfo, RecFieldTypesWithData) ->
             {MissingValue, {true, MissingValue}} ->
                 {ok, FieldsAcc};
             _ ->
-                case to_json(TypeInfo, FieldType, RecordFieldData) of
+                case to_json(TypeInfo, FieldType, RecordFieldData, Config) of
                     {ok, FieldJson} ->
                         {ok, [{BinaryFieldName, FieldJson}] ++ FieldsAcc};
                     {error, Errors} ->
@@ -445,7 +505,7 @@ do_record_to_json(TypeInfo, RecFieldTypesWithData) ->
 -doc """
 Decodes `Json` into an Erlang term according to `Type`.
 
-The inverse of `to_json/3`. Binary map keys become atom keys, binary atom
+The inverse of `to_json/4`. Binary map keys become atom keys, binary atom
 values are converted via `binary_to_existing_atom/2`, JSON `null` maps to
 `nil` or `undefined` where the type allows it, and JSON arrays become lists.
 
@@ -454,72 +514,87 @@ Returns `{ok, Term}` on success or `{error, Errors}` with structured errors.
 -spec from_json(
     TypeInfo :: spectra:type_info(),
     Type :: spectra:sp_type(),
-    Json :: json:decode_value()
+    Json :: json:decode_value(),
+    Config :: spectra:sp_config()
 ) ->
     {ok, dynamic()} | {error, [spectra:error()]}.
-from_json(TypeInfo, Type, Json) ->
-    do_from_json(TypeInfo, Type, Json).
+from_json(TypeInfo, Type, Json, Config) ->
+    do_from_json(TypeInfo, Type, Json, Config).
 
 -spec do_from_json(
     TypeInfo :: spectra:type_info(),
     Type :: spectra:sp_type(),
-    Json :: json:decode_value()
+    Json :: json:decode_value(),
+    Config :: spectra:sp_config()
 ) ->
     {ok, dynamic()} | {error, [spectra:error()]}.
 do_from_json(
     TypeInfo,
     #sp_user_type_ref{type_name = TypeName, variables = Args, arity = Arity} = UserTypeRef,
-    Json
+    Json,
+    Config
 ) when
     is_atom(TypeName)
 ->
     Mod = spectra_type_info:get_module(TypeInfo),
     Type = spectra_type_info:get_type(TypeInfo, TypeName, Arity),
-    case spectra_codec:try_codec_decode(Mod, json, Type, Json, UserTypeRef) of
+    case
+        spectra_codec:try_codec_decode(Mod, json, Type, Json, UserTypeRef, Config#sp_config.codecs)
+    of
         continue ->
             TypeWithoutVars = apply_args(TypeInfo, Type, Args),
-            do_from_json(TypeInfo, TypeWithoutVars, Json);
+            do_from_json(TypeInfo, TypeWithoutVars, Json, Config);
         Result ->
             Result
     end;
 do_from_json(
     _TypeInfo,
     #sp_remote_type{mfargs = {Module, TypeName, Args}, arity = TypeArity} = RemoteRef,
-    Json
+    Json,
+    Config
 ) ->
-    RemoteTypeInfo = spectra_module_types:get(Module),
+    RemoteTypeInfo = spectra_module_types:get(Module, Config#sp_config.use_module_types_cache),
     RemoteType = spectra_type_info:get_type(RemoteTypeInfo, TypeName, TypeArity),
-    case spectra_codec:try_codec_decode(Module, json, RemoteType, Json, RemoteRef) of
+    case
+        spectra_codec:try_codec_decode(
+            Module, json, RemoteType, Json, RemoteRef, Config#sp_config.codecs
+        )
+    of
         continue ->
             TypeResolved = spectra_type:propagate_params(
                 RemoteRef, apply_args(RemoteTypeInfo, RemoteType, Args)
             ),
-            do_from_json(RemoteTypeInfo, TypeResolved, Json);
+            do_from_json(RemoteTypeInfo, TypeResolved, Json, Config);
         Result ->
             Result
     end;
-do_from_json(TypeInfo, #sp_rec{} = Rec, Json) ->
-    record_from_json(TypeInfo, Rec, Json, []);
+do_from_json(TypeInfo, #sp_rec{} = Rec, Json, Config) ->
+    record_from_json(TypeInfo, Rec, Json, [], Config);
 do_from_json(
     TypeInfo,
     #sp_rec_ref{record_name = RecordName, field_types = TypeArgs} = RecordRef,
-    Json
+    Json,
+    Config
 ) when
     is_atom(RecordName)
 ->
     Mod = spectra_type_info:get_module(TypeInfo),
     RecordType = spectra_type_info:get_record(TypeInfo, RecordName),
-    case spectra_codec:try_codec_decode(Mod, json, RecordType, Json, RecordRef) of
-        continue -> record_from_json(TypeInfo, RecordType, Json, TypeArgs);
+    case
+        spectra_codec:try_codec_decode(
+            Mod, json, RecordType, Json, RecordRef, Config#sp_config.codecs
+        )
+    of
+        continue -> record_from_json(TypeInfo, RecordType, Json, TypeArgs, Config);
         Result -> Result
     end;
-do_from_json(TypeInfo, #sp_map{} = Type, Json) ->
-    map_from_json(TypeInfo, Type, Json);
-do_from_json(TypeInfo, #sp_nonempty_list{} = Type, Data) ->
-    nonempty_list_from_json(TypeInfo, Type, Data);
-do_from_json(TypeInfo, #sp_list{type = ListType} = Type, Data) ->
-    list_from_json(TypeInfo, ListType, Data, Type);
-do_from_json(_TypeInfo, #sp_simple_type{type = NotSupported} = T, _Value) when
+do_from_json(TypeInfo, #sp_map{} = Type, Json, Config) ->
+    map_from_json(TypeInfo, Type, Json, Config);
+do_from_json(TypeInfo, #sp_nonempty_list{} = Type, Data, Config) ->
+    nonempty_list_from_json(TypeInfo, Type, Data, Config);
+do_from_json(TypeInfo, #sp_list{type = ListType} = Type, Data, Config) ->
+    list_from_json(TypeInfo, ListType, Data, Type, Config);
+do_from_json(_TypeInfo, #sp_simple_type{type = NotSupported} = T, _Value, _Config) when
     NotSupported =:= pid orelse
         NotSupported =:= port orelse
         NotSupported =:= reference orelse
@@ -528,7 +603,7 @@ do_from_json(_TypeInfo, #sp_simple_type{type = NotSupported} = T, _Value) when
         NotSupported =:= none
 ->
     erlang:error({type_not_supported, T});
-do_from_json(_TypeInfo, #sp_simple_type{type = PrimaryType} = Type, Json) when
+do_from_json(_TypeInfo, #sp_simple_type{type = PrimaryType} = Type, Json, _Config) when
     PrimaryType =:= binary orelse
         PrimaryType =:= nonempty_binary orelse
         PrimaryType =:= string orelse
@@ -543,7 +618,7 @@ do_from_json(_TypeInfo, #sp_simple_type{type = PrimaryType} = Type, Json) when
         false ->
             {error, [sp_error:type_mismatch(Type, Json)]}
     end;
-do_from_json(_TypeInfo, #sp_simple_type{type = PrimaryType} = Type, Json) ->
+do_from_json(_TypeInfo, #sp_simple_type{type = PrimaryType} = Type, Json, _Config) ->
     case check_type_from_json(PrimaryType, Json) of
         {true, NewValue} ->
             {ok, NewValue};
@@ -552,17 +627,17 @@ do_from_json(_TypeInfo, #sp_simple_type{type = PrimaryType} = Type, Json) ->
         false ->
             {error, [sp_error:type_mismatch(Type, Json)]}
     end;
-do_from_json(_TypeInfo, #sp_literal{value = Literal}, Literal) ->
+do_from_json(_TypeInfo, #sp_literal{value = Literal}, Literal, _Config) ->
     {ok, Literal};
-do_from_json(_TypeInfo, #sp_literal{} = Type, Value) ->
+do_from_json(_TypeInfo, #sp_literal{} = Type, Value, _Config) ->
     case try_convert_to_literal(Type, Value) of
         {ok, Literal} ->
             {ok, Literal};
         false ->
             {error, [sp_error:type_mismatch(Type, Value)]}
     end;
-do_from_json(TypeInfo, #sp_union{} = Type, Json) ->
-    union(fun do_from_json/3, TypeInfo, Type, Json);
+do_from_json(TypeInfo, #sp_union{} = Type, Json, Config) ->
+    union(fun do_from_json/4, TypeInfo, Type, Json, Config);
 do_from_json(
     _TypeInfo,
     #sp_range{
@@ -570,7 +645,8 @@ do_from_json(
         lower_bound = Min,
         upper_bound = Max
     },
-    Value
+    Value,
+    _Config
 ) when
     Min =< Value, Value =< Max, is_integer(Value)
 ->
@@ -583,20 +659,21 @@ do_from_json(
         upper_bound = _Max
     } =
         Range,
-    Value
+    Value,
+    _Config
 ) when
     is_integer(Value)
 ->
     {error, [sp_error:type_mismatch(Range, Value)]};
-do_from_json(_TypeInfo, #sp_maybe_improper_list{} = Type, _Value) ->
+do_from_json(_TypeInfo, #sp_maybe_improper_list{} = Type, _Value, _Config) ->
     erlang:error({type_not_supported, Type});
-do_from_json(_TypeInfo, #sp_nonempty_improper_list{} = Type, _Value) ->
+do_from_json(_TypeInfo, #sp_nonempty_improper_list{} = Type, _Value, _Config) ->
     erlang:error({type_not_supported, Type});
-do_from_json(_TypeInfo, #sp_function{} = Type, _Value) ->
+do_from_json(_TypeInfo, #sp_function{} = Type, _Value, _Config) ->
     erlang:error({type_not_supported, Type});
-do_from_json(_TypeInfo, #sp_tuple{} = Type, _Value) ->
+do_from_json(_TypeInfo, #sp_tuple{} = Type, _Value, _Config) ->
     erlang:error({type_not_supported, Type});
-do_from_json(_TypeInfo, Type, Value) ->
+do_from_json(_TypeInfo, Type, Value, _Config) ->
     {error, [sp_error:type_mismatch(Type, Value)]}.
 
 -spec try_convert_to_literal(
@@ -618,18 +695,18 @@ try_convert_to_literal(
 try_convert_to_literal(#sp_literal{}, _Value) ->
     false.
 
-nonempty_list_from_json(TypeInfo, #sp_nonempty_list{type = ListType} = Type, Data) when
+nonempty_list_from_json(TypeInfo, #sp_nonempty_list{type = ListType} = Type, Data, Config) when
     is_list(Data) andalso Data =/= []
 ->
-    list_from_json(TypeInfo, ListType, Data, Type);
-nonempty_list_from_json(_TypeInfo, Type, Data) ->
+    list_from_json(TypeInfo, ListType, Data, Type, Config);
+nonempty_list_from_json(_TypeInfo, Type, Data, _Config) ->
     {error, [sp_error:type_mismatch(Type, Data)]}.
 
-list_from_json(TypeInfo, Type, Data, ListType) when is_list(Data) ->
+list_from_json(TypeInfo, Type, Data, ListType, Config) when is_list(Data) ->
     case safe_enumerate(Data) of
         {ok, EnumeratedData} ->
             Fun = fun({Nr, Item}) ->
-                case do_from_json(TypeInfo, Type, Item) of
+                case do_from_json(TypeInfo, Type, Item, Config) of
                     {ok, Json} ->
                         {ok, Json};
                     {error, Errs} ->
@@ -643,7 +720,7 @@ list_from_json(TypeInfo, Type, Data, ListType) when is_list(Data) ->
             %% Improper lists cannot be decoded from JSON
             {error, [sp_error:type_mismatch(ListType, Data)]}
     end;
-list_from_json(_TypeInfo, _ListType, Data, Type) ->
+list_from_json(_TypeInfo, _ListType, Data, Type, _Config) ->
     {error, [sp_error:type_mismatch(Type, Data)]}.
 
 string_from_json(Type, Json) ->
@@ -795,22 +872,22 @@ safe_enumerate(List) ->
         error:function_clause -> {error, improper_list}
     end.
 
-union(Fun, TypeInfo, #sp_union{types = Types} = T, Json) ->
-    case do_first(Fun, TypeInfo, Types, Json, []) of
+union(Fun, TypeInfo, #sp_union{types = Types} = T, Json, Config) ->
+    case do_first(Fun, TypeInfo, Types, Json, Config, []) of
         {error, UnionErrors} ->
             {error, [sp_error:no_match(T, Json, UnionErrors)]};
         Result ->
             Result
     end.
 
-do_first(_Fun, _TypeInfo, [], _Json, Errors) ->
+do_first(_Fun, _TypeInfo, [], _Json, _Config, Errors) ->
     {error, Errors};
-do_first(Fun, TypeInfo, [Type | Rest], Json, ErrorsAcc) ->
-    case Fun(TypeInfo, Type, Json) of
+do_first(Fun, TypeInfo, [Type | Rest], Json, Config, ErrorsAcc) ->
+    case Fun(TypeInfo, Type, Json, Config) of
         {ok, Result} ->
             {ok, Result};
         {error, Errors} ->
-            do_first(Fun, TypeInfo, Rest, Json, [{Type, Errors} | ErrorsAcc])
+            do_first(Fun, TypeInfo, Rest, Json, Config, [{Type, Errors} | ErrorsAcc])
     end.
 
 apply_args(TypeInfo, Type, TypeArgs) when is_list(TypeArgs) ->
@@ -829,11 +906,12 @@ arg_names(_) ->
 -spec map_from_json(
     spectra:type_info(),
     #sp_map{},
-    json:decode_value()
+    json:decode_value(),
+    spectra:sp_config()
 ) ->
     {ok, #{json:encode_value() => json:encode_value()}}
     | {error, [spectra:error()]}.
-map_from_json(TypeInfo, #sp_map{fields = MapFieldType, struct_name = StructName}, Json) when
+map_from_json(TypeInfo, #sp_map{fields = MapFieldType, struct_name = StructName}, Json, Config) when
     is_map(Json)
 ->
     Defaults =
@@ -861,7 +939,7 @@ map_from_json(TypeInfo, #sp_map{fields = MapFieldType, struct_name = StructName}
         ) ->
             case maps:take(BinaryName, JsonAcc) of
                 {FieldData, NewJsonAcc} ->
-                    case do_from_json(TypeInfo, FieldType, FieldData) of
+                    case do_from_json(TypeInfo, FieldType, FieldData, Config) of
                         {ok, FieldJson} ->
                             {ok, {[{FieldName, FieldJson}] ++ FieldsAcc, NewJsonAcc}};
                         {error, Errs} ->
@@ -883,7 +961,7 @@ map_from_json(TypeInfo, #sp_map{fields = MapFieldType, struct_name = StructName}
         ) ->
             case maps:take(BinaryName, JsonAcc) of
                 {FieldData, NewJsonAcc} ->
-                    case do_from_json(TypeInfo, FieldType, FieldData) of
+                    case do_from_json(TypeInfo, FieldType, FieldData, Config) of
                         {ok, FieldJson} ->
                             {ok, {[{FieldName, FieldJson}] ++ FieldsAcc, NewJsonAcc}};
                         {error, Errs} ->
@@ -913,7 +991,7 @@ map_from_json(TypeInfo, #sp_map{fields = MapFieldType, struct_name = StructName}
             #typed_map_field{kind = assoc, key_type = KeyType, val_type = ValueType},
             {FieldsAcc, JsonAcc}
         ) ->
-            case map_field_type_from_json(TypeInfo, KeyType, ValueType, JsonAcc) of
+            case map_field_type_from_json(TypeInfo, KeyType, ValueType, JsonAcc, Config) of
                 {ok, {NewFields, NewJsonAcc}} ->
                     {ok, {NewFields ++ FieldsAcc, NewJsonAcc}};
                 {error, Reason} ->
@@ -923,7 +1001,7 @@ map_from_json(TypeInfo, #sp_map{fields = MapFieldType, struct_name = StructName}
             #typed_map_field{kind = exact, key_type = KeyType, val_type = ValueType} = Type,
             {FieldsAcc, JsonAcc}
         ) ->
-            case map_field_type_from_json(TypeInfo, KeyType, ValueType, JsonAcc) of
+            case map_field_type_from_json(TypeInfo, KeyType, ValueType, JsonAcc, Config) of
                 {ok, {NewFields, NewJsonAcc}} ->
                     case NewFields of
                         [] ->
@@ -965,7 +1043,7 @@ map_from_json(TypeInfo, #sp_map{fields = MapFieldType, struct_name = StructName}
         {error, _} = Err ->
             Err
     end;
-map_from_json(_TypeInfo, MapType, Json) ->
+map_from_json(_TypeInfo, MapType, Json, _Config) ->
     %% Return error when Json is not a map
     {error, [sp_error:type_mismatch(MapType, Json)]}.
 
@@ -978,12 +1056,12 @@ struct_default_value(Defaults, FieldName) ->
         _ -> error
     end.
 
-map_field_type_from_json(TypeInfo, KeyType, ValueType, Json) ->
+map_field_type_from_json(TypeInfo, KeyType, ValueType, Json, Config) ->
     spectra_util:fold_until_error(
         fun({Key, Value}, {FieldsAcc, JsonAcc}) ->
-            case do_from_json(TypeInfo, KeyType, Key) of
+            case do_from_json(TypeInfo, KeyType, Key, Config) of
                 {ok, KeyJson} ->
-                    case do_from_json(TypeInfo, ValueType, Value) of
+                    case do_from_json(TypeInfo, ValueType, Value, Config) of
                         {ok, ValueJson} ->
                             {ok, {FieldsAcc ++ [{KeyJson, ValueJson}], maps:remove(Key, JsonAcc)}};
                         {error, Errs} ->
@@ -1011,23 +1089,25 @@ map_field_type_from_json(TypeInfo, KeyType, ValueType, Json) ->
     TypeInfo :: spectra:type_info(),
     RecordType :: #sp_rec{},
     Json :: json:decode_value(),
-    TypeArgs :: [spectra:record_field_arg()]
+    TypeArgs :: [spectra:record_field_arg()],
+    Config :: spectra:sp_config()
 ) ->
     {ok, dynamic()} | {error, [spectra:error()]}.
 record_from_json(
-    TypeInfo, #sp_rec{} = ARec, Json, TypeArgs
+    TypeInfo, #sp_rec{} = ARec, Json, TypeArgs, Config
 ) ->
     RecordInfo = spectra_util:record_replace_vars(ARec#sp_rec.fields, TypeArgs),
     NewRec = ARec#sp_rec{fields = RecordInfo},
-    do_record_from_json(TypeInfo, NewRec, Json).
+    do_record_from_json(TypeInfo, NewRec, Json, Config).
 
 -spec do_record_from_json(
     TypeInfo :: spectra:type_info(),
     #sp_rec{},
-    Json :: json:decode_value()
+    Json :: json:decode_value(),
+    Config :: spectra:sp_config()
 ) ->
     {ok, dynamic()} | {error, [spectra:error()]}.
-do_record_from_json(TypeInfo, #sp_rec{name = RecordName, fields = RecordInfo}, Json) when
+do_record_from_json(TypeInfo, #sp_rec{name = RecordName, fields = RecordInfo}, Json, Config) when
     is_map(Json)
 ->
     Fun = fun(
@@ -1036,7 +1116,7 @@ do_record_from_json(TypeInfo, #sp_rec{name = RecordName, fields = RecordInfo}, J
     ) ->
         case maps:take(BinaryName, JsonAcc) of
             {RecordFieldData, NewJsonAcc} ->
-                case do_from_json(TypeInfo, FieldType, RecordFieldData) of
+                case do_from_json(TypeInfo, FieldType, RecordFieldData, Config) of
                     {ok, FieldJson} ->
                         {ok, {[FieldJson | FieldsAcc], NewJsonAcc}};
                     {error, Errs} ->
@@ -1079,5 +1159,5 @@ do_record_from_json(TypeInfo, #sp_rec{name = RecordName, fields = RecordInfo}, J
         {error, Errs} ->
             {error, Errs}
     end;
-do_record_from_json(_TypeInfo, Type, Json) ->
+do_record_from_json(_TypeInfo, Type, Json, _Config) ->
     {error, [sp_error:type_mismatch(Type, Json)]}.

--- a/src/spectra_json.erl
+++ b/src/spectra_json.erl
@@ -89,7 +89,7 @@ to_json(
     Mod = spectra_type_info:get_module(TypeInfo),
     Type = spectra_type_info:get_type(TypeInfo, TypeName, Arity),
     case
-        spectra_codec:try_codec_encode(Mod, json, Type, Data, UserTypeRef, Config#sp_config.codecs)
+        spectra_codec:try_codec_encode(Mod, json, Type, Data, UserTypeRef, Config#sp_config.codecs, Config#sp_config.use_module_types_cache)
     of
         continue ->
             TypeWithoutVars = apply_args(TypeInfo, Type, Args),
@@ -107,7 +107,7 @@ to_json(
     RemoteType = spectra_type_info:get_type(RemoteTypeInfo, TypeName, TypeArity),
     case
         spectra_codec:try_codec_encode(
-            Module, json, RemoteType, Data, RemoteRef, Config#sp_config.codecs
+            Module, json, RemoteType, Data, RemoteRef, Config#sp_config.codecs, Config#sp_config.use_module_types_cache
         )
     of
         continue ->
@@ -132,7 +132,7 @@ to_json(
     RecordType = spectra_type_info:get_record(TypeInfo, RecordName),
     case
         spectra_codec:try_codec_encode(
-            Mod, json, RecordType, Record, RecordRef, Config#sp_config.codecs
+            Mod, json, RecordType, Record, RecordRef, Config#sp_config.codecs, Config#sp_config.use_module_types_cache
         )
     of
         continue -> record_to_json(TypeInfo, RecordType, Record, TypeArgs, Config);
@@ -539,7 +539,7 @@ do_from_json(
     Mod = spectra_type_info:get_module(TypeInfo),
     Type = spectra_type_info:get_type(TypeInfo, TypeName, Arity),
     case
-        spectra_codec:try_codec_decode(Mod, json, Type, Json, UserTypeRef, Config#sp_config.codecs)
+        spectra_codec:try_codec_decode(Mod, json, Type, Json, UserTypeRef, Config#sp_config.codecs, Config#sp_config.use_module_types_cache)
     of
         continue ->
             TypeWithoutVars = apply_args(TypeInfo, Type, Args),
@@ -557,7 +557,7 @@ do_from_json(
     RemoteType = spectra_type_info:get_type(RemoteTypeInfo, TypeName, TypeArity),
     case
         spectra_codec:try_codec_decode(
-            Module, json, RemoteType, Json, RemoteRef, Config#sp_config.codecs
+            Module, json, RemoteType, Json, RemoteRef, Config#sp_config.codecs, Config#sp_config.use_module_types_cache
         )
     of
         continue ->
@@ -582,7 +582,7 @@ do_from_json(
     RecordType = spectra_type_info:get_record(TypeInfo, RecordName),
     case
         spectra_codec:try_codec_decode(
-            Mod, json, RecordType, Json, RecordRef, Config#sp_config.codecs
+            Mod, json, RecordType, Json, RecordRef, Config#sp_config.codecs, Config#sp_config.use_module_types_cache
         )
     of
         continue -> record_from_json(TypeInfo, RecordType, Json, TypeArgs, Config);

--- a/src/spectra_json.erl
+++ b/src/spectra_json.erl
@@ -13,7 +13,7 @@ responsibility of the caller (typically `spectra.erl`).
 
 Codec dispatch is handled mid-traversal at `#sp_user_type_ref{}`,
 `#sp_remote_type{}`, and `#sp_rec_ref{}` nodes via
-`spectra_codec:try_codec_encode/6` and `try_codec_decode/6`.
+`spectra_codec:try_codec_encode/7` and `try_codec_decode/7`.
 """.
 
 -export([to_json/3, to_json/4, from_json/3, from_json/4]).

--- a/src/spectra_json.erl
+++ b/src/spectra_json.erl
@@ -89,7 +89,15 @@ to_json(
     Mod = spectra_type_info:get_module(TypeInfo),
     Type = spectra_type_info:get_type(TypeInfo, TypeName, Arity),
     case
-        spectra_codec:try_codec_encode(Mod, json, Type, Data, UserTypeRef, Config#sp_config.codecs, Config#sp_config.use_module_types_cache)
+        spectra_codec:try_codec_encode(
+            Mod,
+            json,
+            Type,
+            Data,
+            UserTypeRef,
+            Config#sp_config.codecs,
+            Config#sp_config.use_module_types_cache
+        )
     of
         continue ->
             TypeWithoutVars = apply_args(TypeInfo, Type, Args),
@@ -107,7 +115,13 @@ to_json(
     RemoteType = spectra_type_info:get_type(RemoteTypeInfo, TypeName, TypeArity),
     case
         spectra_codec:try_codec_encode(
-            Module, json, RemoteType, Data, RemoteRef, Config#sp_config.codecs, Config#sp_config.use_module_types_cache
+            Module,
+            json,
+            RemoteType,
+            Data,
+            RemoteRef,
+            Config#sp_config.codecs,
+            Config#sp_config.use_module_types_cache
         )
     of
         continue ->
@@ -132,7 +146,13 @@ to_json(
     RecordType = spectra_type_info:get_record(TypeInfo, RecordName),
     case
         spectra_codec:try_codec_encode(
-            Mod, json, RecordType, Record, RecordRef, Config#sp_config.codecs, Config#sp_config.use_module_types_cache
+            Mod,
+            json,
+            RecordType,
+            Record,
+            RecordRef,
+            Config#sp_config.codecs,
+            Config#sp_config.use_module_types_cache
         )
     of
         continue -> record_to_json(TypeInfo, RecordType, Record, TypeArgs, Config);
@@ -539,7 +559,15 @@ do_from_json(
     Mod = spectra_type_info:get_module(TypeInfo),
     Type = spectra_type_info:get_type(TypeInfo, TypeName, Arity),
     case
-        spectra_codec:try_codec_decode(Mod, json, Type, Json, UserTypeRef, Config#sp_config.codecs, Config#sp_config.use_module_types_cache)
+        spectra_codec:try_codec_decode(
+            Mod,
+            json,
+            Type,
+            Json,
+            UserTypeRef,
+            Config#sp_config.codecs,
+            Config#sp_config.use_module_types_cache
+        )
     of
         continue ->
             TypeWithoutVars = apply_args(TypeInfo, Type, Args),
@@ -557,7 +585,13 @@ do_from_json(
     RemoteType = spectra_type_info:get_type(RemoteTypeInfo, TypeName, TypeArity),
     case
         spectra_codec:try_codec_decode(
-            Module, json, RemoteType, Json, RemoteRef, Config#sp_config.codecs, Config#sp_config.use_module_types_cache
+            Module,
+            json,
+            RemoteType,
+            Json,
+            RemoteRef,
+            Config#sp_config.codecs,
+            Config#sp_config.use_module_types_cache
         )
     of
         continue ->
@@ -582,7 +616,13 @@ do_from_json(
     RecordType = spectra_type_info:get_record(TypeInfo, RecordName),
     case
         spectra_codec:try_codec_decode(
-            Mod, json, RecordType, Json, RecordRef, Config#sp_config.codecs, Config#sp_config.use_module_types_cache
+            Mod,
+            json,
+            RecordType,
+            Json,
+            RecordRef,
+            Config#sp_config.codecs,
+            Config#sp_config.use_module_types_cache
         )
     of
         continue -> record_from_json(TypeInfo, RecordType, Json, TypeArgs, Config);

--- a/src/spectra_json.erl
+++ b/src/spectra_json.erl
@@ -72,7 +72,7 @@ to_json(
     Data,
     Config
 ) ->
-    RemoteTypeInfo = spectra_module_types:get(Module, Config#sp_config.module_types_cache),
+    RemoteTypeInfo = spectra_module_types:get(Module, Config),
     RemoteType = spectra_type_info:get_type(RemoteTypeInfo, TypeName, TypeArity),
     case
         spectra_codec:try_codec_encode(
@@ -539,7 +539,7 @@ do_from_json(
     Json,
     Config
 ) ->
-    RemoteTypeInfo = spectra_module_types:get(Module, Config#sp_config.module_types_cache),
+    RemoteTypeInfo = spectra_module_types:get(Module, Config),
     RemoteType = spectra_type_info:get_type(RemoteTypeInfo, TypeName, TypeArity),
     case
         spectra_codec:try_codec_decode(

--- a/src/spectra_json.erl
+++ b/src/spectra_json.erl
@@ -48,11 +48,10 @@ to_json(
 ) when
     is_atom(TypeName)
 ->
-    Mod = spectra_type_info:get_module(TypeInfo),
     Type = spectra_type_info:get_type(TypeInfo, TypeName, Arity),
     case
         spectra_codec:try_codec_encode(
-            Mod,
+            TypeInfo,
             json,
             Type,
             Data,
@@ -76,7 +75,7 @@ to_json(
     RemoteType = spectra_type_info:get_type(RemoteTypeInfo, TypeName, TypeArity),
     case
         spectra_codec:try_codec_encode(
-            Module,
+            RemoteTypeInfo,
             json,
             RemoteType,
             Data,
@@ -102,11 +101,10 @@ to_json(
 ) when
     is_atom(RecordName)
 ->
-    Mod = spectra_type_info:get_module(TypeInfo),
     RecordType = spectra_type_info:get_record(TypeInfo, RecordName),
     case
         spectra_codec:try_codec_encode(
-            Mod,
+            TypeInfo,
             json,
             RecordType,
             Record,
@@ -515,11 +513,10 @@ do_from_json(
 ) when
     is_atom(TypeName)
 ->
-    Mod = spectra_type_info:get_module(TypeInfo),
     Type = spectra_type_info:get_type(TypeInfo, TypeName, Arity),
     case
         spectra_codec:try_codec_decode(
-            Mod,
+            TypeInfo,
             json,
             Type,
             Json,
@@ -543,7 +540,7 @@ do_from_json(
     RemoteType = spectra_type_info:get_type(RemoteTypeInfo, TypeName, TypeArity),
     case
         spectra_codec:try_codec_decode(
-            Module,
+            RemoteTypeInfo,
             json,
             RemoteType,
             Json,
@@ -569,11 +566,10 @@ do_from_json(
 ) when
     is_atom(RecordName)
 ->
-    Mod = spectra_type_info:get_module(TypeInfo),
     RecordType = spectra_type_info:get_record(TypeInfo, RecordName),
     case
         spectra_codec:try_codec_decode(
-            Mod,
+            TypeInfo,
             json,
             RecordType,
             Json,

--- a/src/spectra_json.erl
+++ b/src/spectra_json.erl
@@ -16,49 +16,11 @@ Codec dispatch is handled mid-traversal at `#sp_user_type_ref{}`,
 `spectra_codec:try_codec_encode/7` and `try_codec_decode/7`.
 """.
 
--export([to_json/3, to_json/4, from_json/3, from_json/4]).
+-export([to_json/4, from_json/4]).
 
--ignore_xref([to_json/3, to_json/4, from_json/3, from_json/4]).
+-ignore_xref([to_json/4, from_json/4]).
 
 -include("../include/spectra_internal.hrl").
-
--doc """
-Encodes `Data` to a JSON-compatible value according to `Type`.
-
-Equivalent to calling to_json/4 with a default configuration.
-""".
--doc #{
-    equiv => to_json(TypeInfo, Type, Data, #sp_config{})
-}.
--spec to_json(
-    TypeInfo :: spectra:type_info(),
-    Type :: spectra:sp_type(),
-    Data :: dynamic()
-) ->
-    {ok, json:encode_value()} | {error, [spectra:error()]}.
-to_json(TypeInfo, Type, Data) ->
-    CacheMode = application:get_env(spectra, module_types_cache, local),
-    Codecs = application:get_env(spectra, codecs, #{}),
-    to_json(TypeInfo, Type, Data, #sp_config{module_types_cache = CacheMode, codecs = Codecs}).
-
--doc """
-Decodes a JSON value to an Erlang value according to `Type`.
-
-Equivalent to calling from_json/4 with a default configuration.
-""".
--doc #{
-    equiv => from_json(TypeInfo, Type, Json, #sp_config{})
-}.
--spec from_json(
-    TypeInfo :: spectra:type_info(),
-    Type :: spectra:sp_type(),
-    Json :: json:decode_value()
-) ->
-    {ok, dynamic()} | {error, [spectra:error()]}.
-from_json(TypeInfo, Type, Json) ->
-    CacheMode = application:get_env(spectra, module_types_cache, local),
-    Codecs = application:get_env(spectra, codecs, #{}),
-    from_json(TypeInfo, Type, Json, #sp_config{module_types_cache = CacheMode, codecs = Codecs}).
 
 -doc """
 Encodes `Data` to a JSON-compatible value according to `Type`.

--- a/src/spectra_json.erl
+++ b/src/spectra_json.erl
@@ -57,8 +57,7 @@ to_json(
             Type,
             Data,
             UserTypeRef,
-            Config#sp_config.codecs,
-            Config#sp_config.module_types_cache
+            Config
         )
     of
         continue ->
@@ -82,8 +81,7 @@ to_json(
             RemoteType,
             Data,
             RemoteRef,
-            Config#sp_config.codecs,
-            Config#sp_config.module_types_cache
+            Config
         )
     of
         continue ->
@@ -113,8 +111,7 @@ to_json(
             RecordType,
             Record,
             RecordRef,
-            Config#sp_config.codecs,
-            Config#sp_config.module_types_cache
+            Config
         )
     of
         continue -> record_to_json(TypeInfo, RecordType, Record, TypeArgs, Config);
@@ -527,8 +524,7 @@ do_from_json(
             Type,
             Json,
             UserTypeRef,
-            Config#sp_config.codecs,
-            Config#sp_config.module_types_cache
+            Config
         )
     of
         continue ->
@@ -552,8 +548,7 @@ do_from_json(
             RemoteType,
             Json,
             RemoteRef,
-            Config#sp_config.codecs,
-            Config#sp_config.module_types_cache
+            Config
         )
     of
         continue ->
@@ -583,8 +578,7 @@ do_from_json(
             RecordType,
             Json,
             RecordRef,
-            Config#sp_config.codecs,
-            Config#sp_config.module_types_cache
+            Config
         )
     of
         continue -> record_from_json(TypeInfo, RecordType, Json, TypeArgs, Config);

--- a/src/spectra_json.erl
+++ b/src/spectra_json.erl
@@ -60,7 +60,7 @@ to_json(
         )
     of
         continue ->
-            TypeWithoutVars = apply_args(TypeInfo, Type, Args),
+            TypeWithoutVars = spectra_util:apply_args(TypeInfo, Type, Args),
             to_json(TypeInfo, TypeWithoutVars, Data, Config);
         Result ->
             Result
@@ -85,7 +85,7 @@ to_json(
     of
         continue ->
             TypeResolved = spectra_type:propagate_params(
-                RemoteRef, apply_args(RemoteTypeInfo, RemoteType, Args)
+                RemoteRef, spectra_util:apply_args(RemoteTypeInfo, RemoteType, Args)
             ),
             to_json(RemoteTypeInfo, TypeResolved, Data, Config);
         Result ->
@@ -525,7 +525,7 @@ do_from_json(
         )
     of
         continue ->
-            TypeWithoutVars = apply_args(TypeInfo, Type, Args),
+            TypeWithoutVars = spectra_util:apply_args(TypeInfo, Type, Args),
             do_from_json(TypeInfo, TypeWithoutVars, Json, Config);
         Result ->
             Result
@@ -550,7 +550,7 @@ do_from_json(
     of
         continue ->
             TypeResolved = spectra_type:propagate_params(
-                RemoteRef, apply_args(RemoteTypeInfo, RemoteType, Args)
+                RemoteRef, spectra_util:apply_args(RemoteTypeInfo, RemoteType, Args)
             ),
             do_from_json(RemoteTypeInfo, TypeResolved, Json, Config);
         Result ->
@@ -881,19 +881,6 @@ do_first(Fun, TypeInfo, [Type | Rest], Json, Config, ErrorsAcc) ->
         {error, Errors} ->
             do_first(Fun, TypeInfo, Rest, Json, Config, [{Type, Errors} | ErrorsAcc])
     end.
-
-apply_args(TypeInfo, Type, TypeArgs) when is_list(TypeArgs) ->
-    ArgNames = arg_names(Type),
-    NamedTypes =
-        maps:from_list(
-            lists:zip(ArgNames, TypeArgs)
-        ),
-    spectra_util:type_replace_vars(TypeInfo, Type, NamedTypes).
-
-arg_names(#sp_type_with_variables{vars = Args}) ->
-    Args;
-arg_names(_) ->
-    [].
 
 -spec map_from_json(
     spectra:type_info(),

--- a/src/spectra_json.erl
+++ b/src/spectra_json.erl
@@ -37,9 +37,9 @@ Equivalent to calling to_json/4 with a default configuration.
 ) ->
     {ok, json:encode_value()} | {error, [spectra:error()]}.
 to_json(TypeInfo, Type, Data) ->
-    UseCache = application:get_env(spectra, use_module_types_cache, false),
+    CacheMode = application:get_env(spectra, module_types_cache, local),
     Codecs = application:get_env(spectra, codecs, #{}),
-    to_json(TypeInfo, Type, Data, #sp_config{use_module_types_cache = UseCache, codecs = Codecs}).
+    to_json(TypeInfo, Type, Data, #sp_config{module_types_cache = CacheMode, codecs = Codecs}).
 
 -doc """
 Decodes a JSON value to an Erlang value according to `Type`.
@@ -56,9 +56,9 @@ Equivalent to calling from_json/4 with a default configuration.
 ) ->
     {ok, dynamic()} | {error, [spectra:error()]}.
 from_json(TypeInfo, Type, Json) ->
-    UseCache = application:get_env(spectra, use_module_types_cache, false),
+    CacheMode = application:get_env(spectra, module_types_cache, local),
     Codecs = application:get_env(spectra, codecs, #{}),
-    from_json(TypeInfo, Type, Json, #sp_config{use_module_types_cache = UseCache, codecs = Codecs}).
+    from_json(TypeInfo, Type, Json, #sp_config{module_types_cache = CacheMode, codecs = Codecs}).
 
 -doc """
 Encodes `Data` to a JSON-compatible value according to `Type`.
@@ -96,7 +96,7 @@ to_json(
             Data,
             UserTypeRef,
             Config#sp_config.codecs,
-            Config#sp_config.use_module_types_cache
+            Config#sp_config.module_types_cache
         )
     of
         continue ->
@@ -111,7 +111,7 @@ to_json(
     Data,
     Config
 ) ->
-    RemoteTypeInfo = spectra_module_types:get(Module, Config#sp_config.use_module_types_cache),
+    RemoteTypeInfo = spectra_module_types:get(Module, Config#sp_config.module_types_cache),
     RemoteType = spectra_type_info:get_type(RemoteTypeInfo, TypeName, TypeArity),
     case
         spectra_codec:try_codec_encode(
@@ -121,7 +121,7 @@ to_json(
             Data,
             RemoteRef,
             Config#sp_config.codecs,
-            Config#sp_config.use_module_types_cache
+            Config#sp_config.module_types_cache
         )
     of
         continue ->
@@ -152,7 +152,7 @@ to_json(
             Record,
             RecordRef,
             Config#sp_config.codecs,
-            Config#sp_config.use_module_types_cache
+            Config#sp_config.module_types_cache
         )
     of
         continue -> record_to_json(TypeInfo, RecordType, Record, TypeArgs, Config);
@@ -566,7 +566,7 @@ do_from_json(
             Json,
             UserTypeRef,
             Config#sp_config.codecs,
-            Config#sp_config.use_module_types_cache
+            Config#sp_config.module_types_cache
         )
     of
         continue ->
@@ -581,7 +581,7 @@ do_from_json(
     Json,
     Config
 ) ->
-    RemoteTypeInfo = spectra_module_types:get(Module, Config#sp_config.use_module_types_cache),
+    RemoteTypeInfo = spectra_module_types:get(Module, Config#sp_config.module_types_cache),
     RemoteType = spectra_type_info:get_type(RemoteTypeInfo, TypeName, TypeArity),
     case
         spectra_codec:try_codec_decode(
@@ -591,7 +591,7 @@ do_from_json(
             Json,
             RemoteRef,
             Config#sp_config.codecs,
-            Config#sp_config.use_module_types_cache
+            Config#sp_config.module_types_cache
         )
     of
         continue ->
@@ -622,7 +622,7 @@ do_from_json(
             Json,
             RecordRef,
             Config#sp_config.codecs,
-            Config#sp_config.use_module_types_cache
+            Config#sp_config.module_types_cache
         )
     of
         continue -> record_from_json(TypeInfo, RecordType, Json, TypeArgs, Config);

--- a/src/spectra_json_schema.erl
+++ b/src/spectra_json_schema.erl
@@ -90,7 +90,7 @@ do_to_schema(
     #sp_remote_type{mfargs = {Mod, TypeName, Args}, arity = Arity} = RemoteRef,
     Config
 ) ->
-    RemoteTypeInfo = spectra_module_types:get(Mod, Config#sp_config.module_types_cache),
+    RemoteTypeInfo = spectra_module_types:get(Mod, Config),
     RemoteType = spectra_type_info:get_type(RemoteTypeInfo, TypeName, Arity),
     case spectra_codec:try_codec_schema(Mod, json_schema, RemoteType, RemoteRef, Config) of
         continue ->
@@ -448,7 +448,7 @@ expand_to_literals(#sp_literal{} = Literal, _TypeInfo, _Config) ->
 expand_to_literals(
     #sp_remote_type{mfargs = {Module, TypeName, Args}, arity = TypeArity}, _TypeInfo, Config
 ) ->
-    RemoteTypeInfo = spectra_module_types:get(Module, Config#sp_config.module_types_cache),
+    RemoteTypeInfo = spectra_module_types:get(Module, Config),
     Type = spectra_type_info:get_type(RemoteTypeInfo, TypeName, TypeArity),
     TypeWithoutVars = apply_args(RemoteTypeInfo, Type, Args),
     expand_to_literals(TypeWithoutVars, RemoteTypeInfo, Config);

--- a/src/spectra_json_schema.erl
+++ b/src/spectra_json_schema.erl
@@ -95,7 +95,7 @@ do_to_schema(
     #sp_remote_type{mfargs = {Mod, TypeName, Args}, arity = Arity} = RemoteRef,
     Config
 ) ->
-    RemoteTypeInfo = spectra_module_types:get(Mod, Config#sp_config.use_module_types_cache),
+    RemoteTypeInfo = spectra_module_types:get(Mod, Config#sp_config.module_types_cache),
     RemoteType = spectra_type_info:get_type(RemoteTypeInfo, TypeName, Arity),
     case spectra_codec:try_codec_schema(Mod, json_schema, RemoteType, RemoteRef, Config) of
         continue ->
@@ -453,7 +453,7 @@ expand_to_literals(#sp_literal{} = Literal, _TypeInfo, _Config) ->
 expand_to_literals(
     #sp_remote_type{mfargs = {Module, TypeName, Args}, arity = TypeArity}, _TypeInfo, Config
 ) ->
-    RemoteTypeInfo = spectra_module_types:get(Module, Config#sp_config.use_module_types_cache),
+    RemoteTypeInfo = spectra_module_types:get(Module, Config#sp_config.module_types_cache),
     Type = spectra_type_info:get_type(RemoteTypeInfo, TypeName, TypeArity),
     TypeWithoutVars = apply_args(RemoteTypeInfo, Type, Args),
     expand_to_literals(TypeWithoutVars, RemoteTypeInfo, Config);

--- a/src/spectra_json_schema.erl
+++ b/src/spectra_json_schema.erl
@@ -1,8 +1,8 @@
 -module(spectra_json_schema).
 
--export([to_schema/2, add_schema_version/1]).
+-export([to_schema/2, to_schema/3, add_schema_version/1]).
 
--ignore_xref([to_schema/2, add_schema_version/1]).
+-ignore_xref([to_schema/2, to_schema/3, add_schema_version/1]).
 
 -include("../include/spectra_internal.hrl").
 
@@ -53,87 +53,100 @@
 
 %% API
 
+-doc #{equiv => to_schema(TypeInfo, Type, #sp_config{})}.
 -spec to_schema(spectra:type_info(), spectra:sp_type()) -> json_schema_object().
 to_schema(TypeInfo, Type) ->
-    to_schema_for_sp_type(TypeInfo, Type).
+    to_schema(TypeInfo, Type, #sp_config{}).
 
--spec to_schema_for_sp_type(spectra:type_info(), spectra:sp_type()) -> json_schema_object().
-to_schema_for_sp_type(TypeInfo, Type) ->
-    Schema = do_to_schema(TypeInfo, Type),
-    merge_type_doc_into_schema(TypeInfo, Type, Schema).
+-doc "Generates a JSON Schema object for `Type` using `Config` for codec and cache settings.".
+-spec to_schema(spectra:type_info(), spectra:sp_type(), spectra:sp_config()) ->
+    json_schema_object().
+to_schema(TypeInfo, Type, Config) ->
+    to_schema_for_sp_type(TypeInfo, Type, Config).
+
+-spec to_schema_for_sp_type(spectra:type_info(), spectra:sp_type(), spectra:sp_config()) ->
+    json_schema_object().
+to_schema_for_sp_type(TypeInfo, Type, Config) ->
+    Schema = do_to_schema(TypeInfo, Type, Config),
+    merge_type_doc_into_schema(TypeInfo, Type, Schema, Config).
 
 -spec do_to_schema(
     TypeInfo :: spectra:type_info(),
-    Type :: spectra:sp_type()
+    Type :: spectra:sp_type(),
+    Config :: spectra:sp_config()
 ) ->
     json_schema_object().
 do_to_schema(
-    TypeInfo, #sp_user_type_ref{type_name = N, variables = Args, arity = Arity} = UserTypeRef
+    TypeInfo, #sp_user_type_ref{type_name = N, variables = Args, arity = Arity} = UserTypeRef, Config
 ) ->
     Mod = spectra_type_info:get_module(TypeInfo),
     Type = spectra_type_info:get_type(TypeInfo, N, Arity),
-    case spectra_codec:try_codec_schema(Mod, json_schema, Type, UserTypeRef) of
+    case spectra_codec:try_codec_schema(Mod, json_schema, Type, UserTypeRef, Config) of
         continue ->
             TypeWithoutVars = apply_args(TypeInfo, Type, Args),
-            do_to_schema(TypeInfo, TypeWithoutVars);
+            do_to_schema(TypeInfo, TypeWithoutVars, Config);
         Schema ->
             Schema
     end;
-do_to_schema(_TypeInfo, #sp_remote_type{mfargs = {Mod, TypeName, Args}, arity = Arity} = RemoteRef) ->
-    RemoteTypeInfo = spectra_module_types:get(Mod),
+do_to_schema(
+    _TypeInfo,
+    #sp_remote_type{mfargs = {Mod, TypeName, Args}, arity = Arity} = RemoteRef,
+    Config
+) ->
+    RemoteTypeInfo = spectra_module_types:get(Mod, Config#sp_config.use_module_types_cache),
     RemoteType = spectra_type_info:get_type(RemoteTypeInfo, TypeName, Arity),
-    case spectra_codec:try_codec_schema(Mod, json_schema, RemoteType, RemoteRef) of
+    case spectra_codec:try_codec_schema(Mod, json_schema, RemoteType, RemoteRef, Config) of
         continue ->
             TypeResolved = spectra_type:propagate_params(
                 RemoteRef, apply_args(RemoteTypeInfo, RemoteType, Args)
             ),
-            do_to_schema(RemoteTypeInfo, TypeResolved);
+            do_to_schema(RemoteTypeInfo, TypeResolved, Config);
         Schema ->
             Schema
     end;
-do_to_schema(TypeInfo, #sp_rec_ref{record_name = N} = RecordRef) ->
+do_to_schema(TypeInfo, #sp_rec_ref{record_name = N} = RecordRef, Config) ->
     Mod = spectra_type_info:get_module(TypeInfo),
     RecordType = spectra_type_info:get_record(TypeInfo, N),
-    case spectra_codec:try_codec_schema(Mod, json_schema, RecordType, RecordRef) of
+    case spectra_codec:try_codec_schema(Mod, json_schema, RecordType, RecordRef, Config) of
         continue ->
-            Schema = record_to_schema_internal(TypeInfo, RecordType),
-            merge_type_doc_into_schema(TypeInfo, RecordType, Schema);
+            Schema = record_to_schema_internal(TypeInfo, RecordType, Config),
+            merge_type_doc_into_schema(TypeInfo, RecordType, Schema, Config);
         Schema ->
             Schema
     end;
 %% Simple types
-do_to_schema(_TypeInfo, #sp_simple_type{type = integer}) ->
+do_to_schema(_TypeInfo, #sp_simple_type{type = integer}, _Config) ->
     #{type => <<"integer">>};
-do_to_schema(_TypeInfo, #sp_simple_type{type = string} = Type) ->
+do_to_schema(_TypeInfo, #sp_simple_type{type = string} = Type, _Config) ->
     apply_string_constraints(#{type => <<"string">>}, Type);
-do_to_schema(_TypeInfo, #sp_simple_type{type = iodata}) ->
+do_to_schema(_TypeInfo, #sp_simple_type{type = iodata}, _Config) ->
     #{type => <<"string">>};
-do_to_schema(_TypeInfo, #sp_simple_type{type = iolist}) ->
+do_to_schema(_TypeInfo, #sp_simple_type{type = iolist}, _Config) ->
     #{type => <<"string">>};
-do_to_schema(_TypeInfo, #sp_simple_type{type = boolean}) ->
+do_to_schema(_TypeInfo, #sp_simple_type{type = boolean}, _Config) ->
     #{type => <<"boolean">>};
-do_to_schema(_TypeInfo, #sp_simple_type{type = number}) ->
+do_to_schema(_TypeInfo, #sp_simple_type{type = number}, _Config) ->
     #{type => <<"number">>};
-do_to_schema(_TypeInfo, #sp_simple_type{type = float}) ->
+do_to_schema(_TypeInfo, #sp_simple_type{type = float}, _Config) ->
     #{type => <<"number">>, format => <<"float">>};
-do_to_schema(_TypeInfo, #sp_simple_type{type = atom}) ->
+do_to_schema(_TypeInfo, #sp_simple_type{type = atom}, _Config) ->
     #{type => <<"string">>};
-do_to_schema(_TypeInfo, #sp_simple_type{type = binary} = Type) ->
+do_to_schema(_TypeInfo, #sp_simple_type{type = binary} = Type, _Config) ->
     apply_string_constraints(#{type => <<"string">>}, Type);
-do_to_schema(_TypeInfo, #sp_simple_type{type = nonempty_binary} = Type) ->
+do_to_schema(_TypeInfo, #sp_simple_type{type = nonempty_binary} = Type, _Config) ->
     apply_string_constraints(#{type => <<"string">>, minLength => 1}, Type);
-do_to_schema(_TypeInfo, #sp_simple_type{type = nonempty_string} = Type) ->
+do_to_schema(_TypeInfo, #sp_simple_type{type = nonempty_string} = Type, _Config) ->
     apply_string_constraints(#{type => <<"string">>, minLength => 1}, Type);
-do_to_schema(_TypeInfo, #sp_simple_type{type = pos_integer}) ->
+do_to_schema(_TypeInfo, #sp_simple_type{type = pos_integer}, _Config) ->
     #{type => <<"integer">>, minimum => 1};
-do_to_schema(_TypeInfo, #sp_simple_type{type = non_neg_integer}) ->
+do_to_schema(_TypeInfo, #sp_simple_type{type = non_neg_integer}, _Config) ->
     #{type => <<"integer">>, minimum => 0};
-do_to_schema(_TypeInfo, #sp_simple_type{type = neg_integer}) ->
+do_to_schema(_TypeInfo, #sp_simple_type{type = neg_integer}, _Config) ->
     #{type => <<"integer">>, maximum => -1};
-do_to_schema(_TypeInfo, #sp_simple_type{type = term}) ->
+do_to_schema(_TypeInfo, #sp_simple_type{type = term}, _Config) ->
     % any type
     #{};
-do_to_schema(_TypeInfo, #sp_simple_type{type = map}) ->
+do_to_schema(_TypeInfo, #sp_simple_type{type = map}, _Config) ->
     % generic map type - allows any keys and values
     #{type => <<"object">>};
 %% Range types
@@ -143,7 +156,8 @@ do_to_schema(
         type = integer,
         lower_bound = Min,
         upper_bound = Max
-    }
+    },
+    _Config
 ) ->
     #{
         type => <<"integer">>,
@@ -151,35 +165,35 @@ do_to_schema(
         maximum => Max
     };
 %% Literal types
-do_to_schema(_TypeInfo, #sp_literal{value = Value}) when
+do_to_schema(_TypeInfo, #sp_literal{value = Value}, _Config) when
     Value =:= undefined orelse Value =:= nil
 ->
     #{enum => [null]};
-do_to_schema(_TypeInfo, #sp_literal{value = Value, binary_value = BinaryValue}) when
+do_to_schema(_TypeInfo, #sp_literal{value = Value, binary_value = BinaryValue}, _Config) when
     is_atom(Value)
 ->
     #{enum => [BinaryValue]};
-do_to_schema(_TypeInfo, #sp_literal{value = Value}) when
+do_to_schema(_TypeInfo, #sp_literal{value = Value}, _Config) when
     is_integer(Value)
 ->
     #{enum => [Value]};
-do_to_schema(_TypeInfo, #sp_literal{value = []}) ->
+do_to_schema(_TypeInfo, #sp_literal{value = []}, _Config) ->
     #{enum => [[]]};
-do_to_schema(_TypeInfo, #sp_literal{} = Type) ->
+do_to_schema(_TypeInfo, #sp_literal{} = Type, _Config) ->
     erlang:error({type_not_supported, Type});
 %% List types
-do_to_schema(TypeInfo, #sp_list{type = ItemType}) ->
-    ItemSchema = do_to_schema(TypeInfo, ItemType),
+do_to_schema(TypeInfo, #sp_list{type = ItemType}, Config) ->
+    ItemSchema = do_to_schema(TypeInfo, ItemType, Config),
     #{type => <<"array">>, items => ItemSchema};
-do_to_schema(TypeInfo, #sp_nonempty_list{type = ItemType}) ->
-    ItemSchema = do_to_schema(TypeInfo, ItemType),
+do_to_schema(TypeInfo, #sp_nonempty_list{type = ItemType}, Config) ->
+    ItemSchema = do_to_schema(TypeInfo, ItemType, Config),
     #{
         type => <<"array">>,
         items => ItemSchema,
         minItems => 1
     };
 %% Union types
-do_to_schema(TypeInfo, #sp_union{types = Types}) ->
+do_to_schema(TypeInfo, #sp_union{types = Types}, Config) ->
     case
         lists:partition(
             fun
@@ -192,30 +206,30 @@ do_to_schema(TypeInfo, #sp_union{types = Types}) ->
         )
     of
         {[_MissingLiteral], [SingleType]} ->
-            do_to_schema(TypeInfo, SingleType);
+            do_to_schema(TypeInfo, SingleType, Config);
         {[], NonMissingTypes} ->
-            case try_generate_enum_schema(NonMissingTypes, TypeInfo) of
+            case try_generate_enum_schema(NonMissingTypes, TypeInfo, Config) of
                 not_all_literals ->
-                    generate_oneof_schema(TypeInfo, NonMissingTypes);
+                    generate_oneof_schema(TypeInfo, NonMissingTypes, Config);
                 EnumSchema ->
                     EnumSchema
             end;
         {[_MissingLiteral], OtherTypes} when length(OtherTypes) > 1 ->
-            case try_generate_enum_schema(OtherTypes, TypeInfo) of
+            case try_generate_enum_schema(OtherTypes, TypeInfo, Config) of
                 not_all_literals ->
-                    generate_oneof_schema(TypeInfo, Types);
+                    generate_oneof_schema(TypeInfo, Types, Config);
                 EnumSchema ->
                     EnumSchema
             end
     end;
 %% Map types
-do_to_schema(TypeInfo, #sp_map{fields = Fields}) ->
-    map_fields_to_schema(TypeInfo, Fields);
+do_to_schema(TypeInfo, #sp_map{fields = Fields}, Config) ->
+    map_fields_to_schema(TypeInfo, Fields, Config);
 %% Record types
-do_to_schema(TypeInfo, #sp_rec{} = RecordInfo) ->
-    record_to_schema_internal(TypeInfo, RecordInfo);
+do_to_schema(TypeInfo, #sp_rec{} = RecordInfo, Config) ->
+    record_to_schema_internal(TypeInfo, RecordInfo, Config);
 %% Unsupported types
-do_to_schema(_TypeInfo, #sp_simple_type{type = NotSupported} = Type) when
+do_to_schema(_TypeInfo, #sp_simple_type{type = NotSupported} = Type, _Config) when
     NotSupported =:= pid orelse
         NotSupported =:= port orelse
         NotSupported =:= reference orelse
@@ -224,13 +238,13 @@ do_to_schema(_TypeInfo, #sp_simple_type{type = NotSupported} = Type) when
         NotSupported =:= none
 ->
     erlang:error({type_not_supported, Type});
-do_to_schema(_TypeInfo, #sp_tuple{} = Type) ->
+do_to_schema(_TypeInfo, #sp_tuple{} = Type, _Config) ->
     erlang:error({type_not_supported, Type});
-do_to_schema(_TypeInfo, #sp_function{} = Type) ->
+do_to_schema(_TypeInfo, #sp_function{} = Type, _Config) ->
     erlang:error({type_not_supported, Type});
-do_to_schema(_TypeInfo, #sp_maybe_improper_list{} = Type) ->
+do_to_schema(_TypeInfo, #sp_maybe_improper_list{} = Type, _Config) ->
     erlang:error({type_not_supported, Type});
-do_to_schema(_TypeInfo, #sp_nonempty_improper_list{} = Type) ->
+do_to_schema(_TypeInfo, #sp_nonempty_improper_list{} = Type, _Config) ->
     erlang:error({type_not_supported, Type}).
 
 %% Helper functions
@@ -276,10 +290,10 @@ apply_args(TypeInfo, Type, TypeArgs) when is_list(TypeArgs) ->
         ),
     spectra_util:type_replace_vars(TypeInfo, Type, NamedTypes).
 
--spec map_fields_to_schema(spectra:type_info(), [spectra:map_field()]) ->
+-spec map_fields_to_schema(spectra:type_info(), [spectra:map_field()], spectra:sp_config()) ->
     json_schema_object().
-map_fields_to_schema(TypeInfo, Fields) ->
-    {Properties, Required, HasAdditional} = process_map_fields(TypeInfo, Fields, #{}, [], false),
+map_fields_to_schema(TypeInfo, Fields, Config) ->
+    {Properties, Required, HasAdditional} = process_map_fields(TypeInfo, Fields, #{}, [], false, Config),
     lists:foldl(
         fun({Key, Value, SkipValue}, Acc) ->
             map_add_if_not_value(Acc, Key, Value, SkipValue)
@@ -293,51 +307,55 @@ map_fields_to_schema(TypeInfo, Fields) ->
     [spectra:map_field()],
     map(),
     [binary()],
-    boolean()
+    boolean(),
+    spectra:sp_config()
 ) ->
     {map(), [binary()], boolean()}.
-process_map_fields(_TypeInfo, [], Properties, Required, HasAdditional) ->
+process_map_fields(_TypeInfo, [], Properties, Required, HasAdditional, _Config) ->
     {Properties, Required, HasAdditional};
 process_map_fields(
     TypeInfo,
     [#literal_map_field{kind = Kind, binary_name = BinaryName, val_type = FieldType} | Rest],
     Properties,
     Required,
-    HasAdditional
+    HasAdditional,
+    Config
 ) ->
-    FieldSchema = do_to_schema(TypeInfo, FieldType),
+    FieldSchema = do_to_schema(TypeInfo, FieldType, Config),
     NewProperties = Properties#{BinaryName => FieldSchema},
     NewRequired =
         case Kind of
             exact -> [BinaryName | Required];
             assoc -> Required
         end,
-    process_map_fields(TypeInfo, Rest, NewProperties, NewRequired, HasAdditional);
+    process_map_fields(TypeInfo, Rest, NewProperties, NewRequired, HasAdditional, Config);
 process_map_fields(
     TypeInfo,
     [#typed_map_field{key_type = KeyType, val_type = ValType} = Field | Rest],
     Properties,
     Required,
-    _HasAdditional
+    _HasAdditional,
+    Config
 ) ->
     case can_be_json_key(TypeInfo, KeyType) of
         false ->
             erlang:error({type_not_supported, Field});
         true ->
             %% Validate that key and value types can generate JSON schemas (will crash if not)
-            _ = do_to_schema(TypeInfo, KeyType),
-            _ = do_to_schema(TypeInfo, ValType),
-            process_map_fields(TypeInfo, Rest, Properties, Required, true)
+            _ = do_to_schema(TypeInfo, KeyType, Config),
+            _ = do_to_schema(TypeInfo, ValType, Config),
+            process_map_fields(TypeInfo, Rest, Properties, Required, true, Config)
     end.
 
--spec record_to_schema_internal(spectra:type_info(), #sp_rec{}) ->
+-spec record_to_schema_internal(spectra:type_info(), #sp_rec{}, spectra:sp_config()) ->
     json_schema_object().
-record_to_schema_internal(TypeInfo, #sp_rec{} = Record) ->
-    record_fields_to_schema(TypeInfo, Record).
+record_to_schema_internal(TypeInfo, #sp_rec{} = Record, Config) ->
+    record_fields_to_schema(TypeInfo, Record, Config).
 
--spec record_fields_to_schema(spectra:type_info(), #sp_rec{}) -> json_schema_object().
-record_fields_to_schema(TypeInfo, #sp_rec{fields = Fields}) ->
-    {Properties, Required} = process_record_fields(TypeInfo, Fields, #{}, []),
+-spec record_fields_to_schema(spectra:type_info(), #sp_rec{}, spectra:sp_config()) ->
+    json_schema_object().
+record_fields_to_schema(TypeInfo, #sp_rec{fields = Fields}, Config) ->
+    {Properties, Required} = process_record_fields(TypeInfo, Fields, #{}, [], Config),
     #{
         type => <<"object">>,
         properties => Properties,
@@ -348,18 +366,20 @@ record_fields_to_schema(TypeInfo, #sp_rec{fields = Fields}) ->
     spectra:type_info(),
     [#sp_rec_field{}],
     map(),
-    [binary()]
+    [binary()],
+    spectra:sp_config()
 ) ->
     {map(), [binary()]}.
-process_record_fields(_TypeInfo, [], Properties, Required) ->
+process_record_fields(_TypeInfo, [], Properties, Required, _Config) ->
     {Properties, lists:reverse(Required)};
 process_record_fields(
     TypeInfo,
     [#sp_rec_field{binary_name = BinaryName, type = FieldType} | Rest],
     Properties,
-    Required
+    Required,
+    Config
 ) ->
-    FieldSchema = do_to_schema(TypeInfo, FieldType),
+    FieldSchema = do_to_schema(TypeInfo, FieldType, Config),
     NewProperties = Properties#{BinaryName => FieldSchema},
     NewRequired =
         case spectra_type:can_be_missing(TypeInfo, FieldType) of
@@ -368,16 +388,16 @@ process_record_fields(
             false ->
                 [BinaryName | Required]
         end,
-    process_record_fields(TypeInfo, Rest, NewProperties, NewRequired).
+    process_record_fields(TypeInfo, Rest, NewProperties, NewRequired, Config).
 
 %% Helper function to generate oneOf schemas
-generate_oneof_schema(TypeInfo, Types) ->
-    Schemas = lists:map(fun(T) -> do_to_schema(TypeInfo, T) end, Types),
+generate_oneof_schema(TypeInfo, Types, Config) ->
+    Schemas = lists:map(fun(T) -> do_to_schema(TypeInfo, T, Config) end, Types),
     #{oneOf => Schemas}.
 
-try_generate_enum_schema(Types, TypeInfo) ->
+try_generate_enum_schema(Types, TypeInfo, Config) ->
     %% First, expand all types to their base forms (resolving references)
-    ExpandResults = lists:map(fun(T) -> expand_to_literals(T, TypeInfo) end, Types),
+    ExpandResults = lists:map(fun(T) -> expand_to_literals(T, TypeInfo, Config) end, Types),
     %% Check if all types could be expanded to literals
     case
         lists:all(
@@ -419,30 +439,32 @@ try_generate_enum_schema(Types, TypeInfo) ->
     end.
 
 %% Expand a type to a list of literal types, resolving references and unions
--spec expand_to_literals(spectra:sp_type(), spectra:type_info() | undefined) ->
+-spec expand_to_literals(
+    spectra:sp_type(), spectra:type_info() | undefined, spectra:sp_config()
+) ->
     {ok, [spectra:sp_type()]} | {error, not_all_literals}.
-expand_to_literals(#sp_literal{} = Literal, _TypeInfo) ->
+expand_to_literals(#sp_literal{} = Literal, _TypeInfo, _Config) ->
     {ok, [Literal]};
 %% Resolve remote types
 expand_to_literals(
-    #sp_remote_type{mfargs = {Module, TypeName, Args}, arity = TypeArity}, _TypeInfo
+    #sp_remote_type{mfargs = {Module, TypeName, Args}, arity = TypeArity}, _TypeInfo, Config
 ) ->
-    RemoteTypeInfo = spectra_module_types:get(Module),
+    RemoteTypeInfo = spectra_module_types:get(Module, Config#sp_config.use_module_types_cache),
     Type = spectra_type_info:get_type(RemoteTypeInfo, TypeName, TypeArity),
     TypeWithoutVars = apply_args(RemoteTypeInfo, Type, Args),
-    expand_to_literals(TypeWithoutVars, RemoteTypeInfo);
+    expand_to_literals(TypeWithoutVars, RemoteTypeInfo, Config);
 %% Resolve user type references
 expand_to_literals(
-    #sp_user_type_ref{type_name = TypeName, variables = TypeArgs, arity = TypeArity}, TypeInfo
+    #sp_user_type_ref{type_name = TypeName, variables = TypeArgs, arity = TypeArity}, TypeInfo, Config
 ) when
     TypeInfo =/= undefined
 ->
     Type = spectra_type_info:get_type(TypeInfo, TypeName, TypeArity),
     TypeWithoutVars = apply_args(TypeInfo, Type, TypeArgs),
-    expand_to_literals(TypeWithoutVars, TypeInfo);
+    expand_to_literals(TypeWithoutVars, TypeInfo, Config);
 %% Flatten unions - all members must expand to literals
-expand_to_literals(#sp_union{types = UnionTypes}, TypeInfo) ->
-    Results = lists:map(fun(T) -> expand_to_literals(T, TypeInfo) end, UnionTypes),
+expand_to_literals(#sp_union{types = UnionTypes}, TypeInfo, Config) ->
+    Results = lists:map(fun(T) -> expand_to_literals(T, TypeInfo, Config) end, UnionTypes),
     case
         lists:all(
             fun
@@ -465,7 +487,7 @@ expand_to_literals(#sp_union{types = UnionTypes}, TypeInfo) ->
             {error, not_all_literals}
     end;
 %% Anything else cannot be expanded to literals
-expand_to_literals(_Type, _TypeInfo) ->
+expand_to_literals(_Type, _TypeInfo, _Config) ->
     {error, not_all_literals}.
 
 %% Helper to extract literal value from a type (non-recursive, only handles direct literals)
@@ -516,20 +538,22 @@ get_inline_doc(Type) ->
         #{} -> error
     end.
 
--spec merge_type_doc_into_schema(spectra:type_info(), spectra:sp_type(), json_schema_object()) ->
+-spec merge_type_doc_into_schema(
+    spectra:type_info(), spectra:sp_type(), json_schema_object(), spectra:sp_config()
+) ->
     json_schema_object().
-merge_type_doc_into_schema(TypeInfo, Type, Schema) ->
+merge_type_doc_into_schema(TypeInfo, Type, Schema, Config) ->
     case get_inline_doc(Type) of
         {ok, Doc} ->
-            maps:merge(Schema, normalize_doc_for_json_schema(TypeInfo, Type, Doc));
+            maps:merge(Schema, normalize_doc_for_json_schema(TypeInfo, Type, Doc, Config));
         error ->
             Schema
     end.
 
 -spec normalize_doc_for_json_schema(
-    spectra:type_info(), spectra:sp_type(), spectra:type_doc()
+    spectra:type_info(), spectra:sp_type(), spectra:type_doc(), spectra:sp_config()
 ) -> json_schema_object().
-normalize_doc_for_json_schema(TypeInfo, Type, Doc) ->
+normalize_doc_for_json_schema(TypeInfo, Type, Doc, Config) ->
     maps:fold(
         fun
             (title, Value, Acc) when is_binary(Value) ->
@@ -539,10 +563,10 @@ normalize_doc_for_json_schema(TypeInfo, Type, Doc) ->
             (deprecated, Value, Acc) when is_boolean(Value) ->
                 Acc#{deprecated => Value};
             (examples, ExampleTerms, Acc) when is_list(ExampleTerms) ->
-                Acc#{examples => convert_examples(TypeInfo, Type, ExampleTerms)};
+                Acc#{examples => convert_examples(TypeInfo, Type, ExampleTerms, Config)};
             (examples_function, {Module, Function, Args}, Acc) ->
                 ExampleTerms = erlang:apply(Module, Function, Args),
-                Acc#{examples => convert_examples(TypeInfo, Type, ExampleTerms)}
+                Acc#{examples => convert_examples(TypeInfo, Type, ExampleTerms, Config)}
         end,
         #{},
         Doc
@@ -577,10 +601,10 @@ apply_string_params(Base, Params) when is_map(Params) ->
 apply_string_params(_Base, Params) ->
     erlang:error({invalid_string_constraints, Params}).
 
-convert_examples(TypeInfo, Type, ExampleTerms) ->
+convert_examples(TypeInfo, Type, ExampleTerms, Config) ->
     lists:map(
         fun(Term) ->
-            case spectra_json:to_json(TypeInfo, Type, Term) of
+            case spectra_json:to_json(TypeInfo, Type, Term, Config) of
                 {ok, JsonValue} ->
                     JsonValue;
                 {error, Errs} ->

--- a/src/spectra_json_schema.erl
+++ b/src/spectra_json_schema.erl
@@ -91,7 +91,9 @@ do_to_schema(
 ) ->
     RemoteTypeInfo = spectra_module_types:get(Mod, Config),
     RemoteType = spectra_type_info:get_type(RemoteTypeInfo, TypeName, Arity),
-    case spectra_codec:try_codec_schema(RemoteTypeInfo, json_schema, RemoteType, RemoteRef, Config) of
+    case
+        spectra_codec:try_codec_schema(RemoteTypeInfo, json_schema, RemoteType, RemoteRef, Config)
+    of
         continue ->
             TypeResolved = spectra_type:propagate_params(
                 RemoteRef, apply_args(RemoteTypeInfo, RemoteType, Args)

--- a/src/spectra_json_schema.erl
+++ b/src/spectra_json_schema.erl
@@ -1,8 +1,8 @@
 -module(spectra_json_schema).
 
--export([to_schema/2, to_schema/3, add_schema_version/1]).
+-export([to_schema/3, add_schema_version/1]).
 
--ignore_xref([to_schema/2, to_schema/3, add_schema_version/1]).
+-ignore_xref([to_schema/3, add_schema_version/1]).
 
 -include("../include/spectra_internal.hrl").
 
@@ -52,11 +52,6 @@
 -export_type([json_schema/0, json_schema_object/0]).
 
 %% API
-
--doc #{equiv => to_schema(TypeInfo, Type, #sp_config{})}.
--spec to_schema(spectra:type_info(), spectra:sp_type()) -> json_schema_object().
-to_schema(TypeInfo, Type) ->
-    to_schema(TypeInfo, Type, #sp_config{}).
 
 -doc "Generates a JSON Schema object for `Type` using `Config` for codec and cache settings.".
 -spec to_schema(spectra:type_info(), spectra:sp_type(), spectra:sp_config()) ->

--- a/src/spectra_json_schema.erl
+++ b/src/spectra_json_schema.erl
@@ -76,9 +76,8 @@ do_to_schema(
     #sp_user_type_ref{type_name = N, variables = Args, arity = Arity} = UserTypeRef,
     Config
 ) ->
-    Mod = spectra_type_info:get_module(TypeInfo),
     Type = spectra_type_info:get_type(TypeInfo, N, Arity),
-    case spectra_codec:try_codec_schema(Mod, json_schema, Type, UserTypeRef, Config) of
+    case spectra_codec:try_codec_schema(TypeInfo, json_schema, Type, UserTypeRef, Config) of
         continue ->
             TypeWithoutVars = apply_args(TypeInfo, Type, Args),
             do_to_schema(TypeInfo, TypeWithoutVars, Config);
@@ -92,7 +91,7 @@ do_to_schema(
 ) ->
     RemoteTypeInfo = spectra_module_types:get(Mod, Config),
     RemoteType = spectra_type_info:get_type(RemoteTypeInfo, TypeName, Arity),
-    case spectra_codec:try_codec_schema(Mod, json_schema, RemoteType, RemoteRef, Config) of
+    case spectra_codec:try_codec_schema(RemoteTypeInfo, json_schema, RemoteType, RemoteRef, Config) of
         continue ->
             TypeResolved = spectra_type:propagate_params(
                 RemoteRef, apply_args(RemoteTypeInfo, RemoteType, Args)
@@ -102,9 +101,8 @@ do_to_schema(
             Schema
     end;
 do_to_schema(TypeInfo, #sp_rec_ref{record_name = N} = RecordRef, Config) ->
-    Mod = spectra_type_info:get_module(TypeInfo),
     RecordType = spectra_type_info:get_record(TypeInfo, N),
-    case spectra_codec:try_codec_schema(Mod, json_schema, RecordType, RecordRef, Config) of
+    case spectra_codec:try_codec_schema(TypeInfo, json_schema, RecordType, RecordRef, Config) of
         continue ->
             Schema = record_to_schema_internal(TypeInfo, RecordType, Config),
             merge_type_doc_into_schema(TypeInfo, RecordType, Schema, Config);

--- a/src/spectra_json_schema.erl
+++ b/src/spectra_json_schema.erl
@@ -77,7 +77,9 @@ to_schema_for_sp_type(TypeInfo, Type, Config) ->
 ) ->
     json_schema_object().
 do_to_schema(
-    TypeInfo, #sp_user_type_ref{type_name = N, variables = Args, arity = Arity} = UserTypeRef, Config
+    TypeInfo,
+    #sp_user_type_ref{type_name = N, variables = Args, arity = Arity} = UserTypeRef,
+    Config
 ) ->
     Mod = spectra_type_info:get_module(TypeInfo),
     Type = spectra_type_info:get_type(TypeInfo, N, Arity),
@@ -293,7 +295,9 @@ apply_args(TypeInfo, Type, TypeArgs) when is_list(TypeArgs) ->
 -spec map_fields_to_schema(spectra:type_info(), [spectra:map_field()], spectra:sp_config()) ->
     json_schema_object().
 map_fields_to_schema(TypeInfo, Fields, Config) ->
-    {Properties, Required, HasAdditional} = process_map_fields(TypeInfo, Fields, #{}, [], false, Config),
+    {Properties, Required, HasAdditional} = process_map_fields(
+        TypeInfo, Fields, #{}, [], false, Config
+    ),
     lists:foldl(
         fun({Key, Value, SkipValue}, Acc) ->
             map_add_if_not_value(Acc, Key, Value, SkipValue)
@@ -455,7 +459,9 @@ expand_to_literals(
     expand_to_literals(TypeWithoutVars, RemoteTypeInfo, Config);
 %% Resolve user type references
 expand_to_literals(
-    #sp_user_type_ref{type_name = TypeName, variables = TypeArgs, arity = TypeArity}, TypeInfo, Config
+    #sp_user_type_ref{type_name = TypeName, variables = TypeArgs, arity = TypeArity},
+    TypeInfo,
+    Config
 ) when
     TypeInfo =/= undefined
 ->

--- a/src/spectra_json_schema.erl
+++ b/src/spectra_json_schema.erl
@@ -79,7 +79,7 @@ do_to_schema(
     Type = spectra_type_info:get_type(TypeInfo, N, Arity),
     case spectra_codec:try_codec_schema(TypeInfo, json_schema, Type, UserTypeRef, Config) of
         continue ->
-            TypeWithoutVars = apply_args(TypeInfo, Type, Args),
+            TypeWithoutVars = spectra_util:apply_args(TypeInfo, Type, Args),
             do_to_schema(TypeInfo, TypeWithoutVars, Config);
         Schema ->
             Schema
@@ -96,7 +96,7 @@ do_to_schema(
     of
         continue ->
             TypeResolved = spectra_type:propagate_params(
-                RemoteRef, apply_args(RemoteTypeInfo, RemoteType, Args)
+                RemoteRef, spectra_util:apply_args(RemoteTypeInfo, RemoteType, Args)
             ),
             do_to_schema(RemoteTypeInfo, TypeResolved, Config);
         Schema ->
@@ -264,7 +264,7 @@ can_be_json_key(TypeInfo, #sp_user_type_ref{
     type_name = TypeName, variables = TypeArgs, arity = TypeArity
 }) ->
     Type = spectra_type_info:get_type(TypeInfo, TypeName, TypeArity),
-    TypeWithoutVars = apply_args(TypeInfo, Type, TypeArgs),
+    TypeWithoutVars = spectra_util:apply_args(TypeInfo, Type, TypeArgs),
     can_be_json_key(TypeInfo, TypeWithoutVars);
 can_be_json_key(_TypeInfo, _Type) ->
     false.
@@ -273,19 +273,6 @@ can_be_json_key(_TypeInfo, _Type) ->
 -spec add_schema_version(json_schema_object()) -> json_schema().
 add_schema_version(Schema) ->
     Schema#{'$schema' => <<"https://json-schema.org/draft/2020-12/schema">>}.
-
-arg_names(#sp_type_with_variables{vars = Args}) ->
-    Args;
-arg_names(_) ->
-    [].
-
-apply_args(TypeInfo, Type, TypeArgs) when is_list(TypeArgs) ->
-    ArgNames = arg_names(Type),
-    NamedTypes =
-        maps:from_list(
-            lists:zip(ArgNames, TypeArgs)
-        ),
-    spectra_util:type_replace_vars(TypeInfo, Type, NamedTypes).
 
 -spec map_fields_to_schema(spectra:type_info(), [spectra:map_field()], spectra:sp_config()) ->
     json_schema_object().
@@ -450,7 +437,7 @@ expand_to_literals(
 ) ->
     RemoteTypeInfo = spectra_module_types:get(Module, Config),
     Type = spectra_type_info:get_type(RemoteTypeInfo, TypeName, TypeArity),
-    TypeWithoutVars = apply_args(RemoteTypeInfo, Type, Args),
+    TypeWithoutVars = spectra_util:apply_args(RemoteTypeInfo, Type, Args),
     expand_to_literals(TypeWithoutVars, RemoteTypeInfo, Config);
 %% Resolve user type references
 expand_to_literals(
@@ -461,7 +448,7 @@ expand_to_literals(
     TypeInfo =/= undefined
 ->
     Type = spectra_type_info:get_type(TypeInfo, TypeName, TypeArity),
-    TypeWithoutVars = apply_args(TypeInfo, Type, TypeArgs),
+    TypeWithoutVars = spectra_util:apply_args(TypeInfo, Type, TypeArgs),
     expand_to_literals(TypeWithoutVars, TypeInfo, Config);
 %% Flatten unions - all members must expand to literals
 expand_to_literals(#sp_union{types = UnionTypes}, TypeInfo, Config) ->

--- a/src/spectra_module_types.erl
+++ b/src/spectra_module_types.erl
@@ -1,9 +1,11 @@
 -module(spectra_module_types).
 
--export([get/1, get/2, clear/1, clear_local/0]).
+-include("../include/spectra_internal.hrl").
+
+-export([get/2, clear/1, clear_local/0]).
 
 %% Meant to be used when doing manual testing.
--ignore_xref([get/1, clear/1, clear_local/0]).
+-ignore_xref([clear/1, clear_local/0]).
 
 -define(TYPE_INFO_FUNCTION, '__spectra_type_info__').
 -define(LOCAL_CACHE_KEY, {?MODULE, local_cache}).
@@ -11,34 +13,25 @@
 %% API
 
 -doc """
-Resolves type information for `Module`.
+Resolves type information for `Module` using the cache mode from `Config`.
 
-Equivalent to calling `get/2` with the default application environment config.
-""".
--spec get(Module :: module()) -> spectra:type_info().
-get(Module) ->
-    CacheMode = application:get_env(spectra, module_types_cache, local),
-    get(Module, CacheMode).
+When `Config#sp_config.module_types_cache` is `persistent` the result is
+cached in `persistent_term` and returned on subsequent calls without
+re-extracting the abstract code.
 
--doc """
-Resolves type information for `Module`.
-
-When `CacheMode` is `persistent` the result is cached in `persistent_term` and
-returned on subsequent calls without re-extracting the abstract code.
-
-When `CacheMode` is `local` the result is cached in the process dictionary
+When the cache mode is `local` the result is cached in the process dictionary
 under a single key `{spectra_module_types, local_cache}` which holds a map of
 `#{module() => type_info()}`. The caller is responsible for clearing the cache
 via `clear_local/0` when the top-level operation completes.
 
-When `CacheMode` is `none` type information is always re-extracted.
+When the cache mode is `none` type information is always re-extracted.
 """.
--spec get(Module :: module(), CacheMode :: spectra:module_types_cache()) -> spectra:type_info().
-get(Module, persistent) ->
+-spec get(Module :: module(), Config :: spectra:sp_config()) -> spectra:type_info().
+get(Module, #sp_config{module_types_cache = persistent}) ->
     persistent_cached_type_info(Module);
-get(Module, local) ->
+get(Module, #sp_config{module_types_cache = local}) ->
     local_cached_type_info(Module);
-get(Module, none) ->
+get(Module, #sp_config{module_types_cache = none}) ->
     fetch_type_info(Module).
 
 -doc "Removes the persistent cache entry for `Module`.".

--- a/src/spectra_module_types.erl
+++ b/src/spectra_module_types.erl
@@ -1,17 +1,32 @@
 -module(spectra_module_types).
 
--export([get/1, clear/1]).
+-export([get/1, get/2, clear/1]).
 
 %% Meant to be used when doing manual testing.
 -ignore_xref([clear/1]).
 
--type module_version() :: term().
-
--define(APPLICATION, spectra).
 -define(TYPE_INFO_FUNCTION, '__spectra_type_info__').
+
 %% API
+
+-doc """
+Resolves type information for `Module`.
+
+Equivalent to calling `get/2` with the default application environment config.
+""".
 -spec get(Module :: module()) -> spectra:type_info().
 get(Module) ->
+    UseCache = application:get_env(spectra, use_module_types_cache, false),
+    get(Module, UseCache).
+
+-doc """
+Resolves type information for `Module`.
+
+When `UseCache` is `true` the result is cached in `persistent_term` and
+returned on subsequent calls without re-extracting the abstract code.
+""".
+-spec get(Module :: module(), UseCache :: boolean()) -> spectra:type_info().
+get(Module, UseCache) ->
     case code:ensure_loaded(Module) of
         {module, Module} ->
             ok;
@@ -19,7 +34,7 @@ get(Module) ->
             erlang:error({module_types_not_found, Module, Reason})
     end,
     HasTypeInfoFun = erlang:function_exported(Module, ?TYPE_INFO_FUNCTION, 0),
-    case application:get_env(?APPLICATION, use_module_types_cache, false) of
+    case UseCache of
         true ->
             cached_type_info(Module, HasTypeInfoFun);
         false ->
@@ -36,21 +51,21 @@ clear(Module) ->
 -spec cached_type_info(Module :: module(), HasTypeInfoFun :: boolean()) ->
     spectra:type_info().
 cached_type_info(Module, true) ->
-    Vsn = module_vsn(Module),
     TypeInfoFun = fun() -> apply(Module, ?TYPE_INFO_FUNCTION, []) end,
-    do_cached_type_info(Module, Vsn, TypeInfoFun);
+    do_cached_type_info(Module, TypeInfoFun);
 cached_type_info(Module, false) ->
-    Vsn = module_vsn(Module),
     TypeInfoFun = fun() -> spectra_abstract_code:types_in_module(Module) end,
-    do_cached_type_info(Module, Vsn, TypeInfoFun).
+    do_cached_type_info(Module, TypeInfoFun).
 
-do_cached_type_info(Module, Vsn, TypeInfoFun) ->
+-spec do_cached_type_info(Module :: module(), TypeInfoFun :: fun(() -> spectra:type_info())) ->
+    spectra:type_info().
+do_cached_type_info(Module, TypeInfoFun) ->
     case pers_type(Module) of
-        {Vsn, TypeInfo} ->
+        {ok, TypeInfo} ->
             TypeInfo;
-        _ ->
+        error ->
             TypeInfo = TypeInfoFun(),
-            pers_types_set(Module, Vsn, TypeInfo),
+            pers_types_set(Module, TypeInfo),
             TypeInfo
     end.
 
@@ -61,25 +76,13 @@ fetch_type_info(Module, true) ->
 fetch_type_info(Module, false) ->
     spectra_abstract_code:types_in_module(Module).
 
--spec pers_type(Module :: module()) ->
-    {module_version(), spectra:type_info()} | undefined.
+-spec pers_type(Module :: module()) -> {ok, spectra:type_info()} | error.
 pers_type(Module) ->
-    persistent_term:get({?MODULE, pers_types, Module}, undefined).
-
--spec pers_types_set(
-    Module :: module(),
-    Vsn :: module_version(),
-    TypeInfo :: spectra:type_info()
-) ->
-    ok.
-pers_types_set(Module, Vsn, TypeInfo) ->
-    persistent_term:put({?MODULE, pers_types, Module}, {Vsn, TypeInfo}).
-
--spec module_vsn(Module :: module()) ->
-    Version :: module_version().
-module_vsn(Module) ->
-    case erlang:get_module_info(Module, attributes) of
-        Attrs when is_list(Attrs) ->
-            {vsn, Vsn} = lists:keyfind(vsn, 1, Attrs),
-            Vsn
+    case persistent_term:get({?MODULE, pers_types, Module}, undefined) of
+        undefined -> error;
+        TypeInfo -> {ok, TypeInfo}
     end.
+
+-spec pers_types_set(Module :: module(), TypeInfo :: spectra:type_info()) -> ok.
+pers_types_set(Module, TypeInfo) ->
+    persistent_term:put({?MODULE, pers_types, Module}, TypeInfo).

--- a/src/spectra_module_types.erl
+++ b/src/spectra_module_types.erl
@@ -3,7 +3,7 @@
 -export([get/1, get/2, clear/1, clear_local/0]).
 
 %% Meant to be used when doing manual testing.
--ignore_xref([clear/1, clear_local/0]).
+-ignore_xref([get/1, clear/1, clear_local/0]).
 
 -define(TYPE_INFO_FUNCTION, '__spectra_type_info__').
 -define(LOCAL_CACHE_KEY, {?MODULE, local_cache}).

--- a/src/spectra_module_types.erl
+++ b/src/spectra_module_types.erl
@@ -1,11 +1,12 @@
 -module(spectra_module_types).
 
--export([get/1, get/2, clear/1]).
+-export([get/1, get/2, clear/1, clear_local/0]).
 
 %% Meant to be used when doing manual testing.
--ignore_xref([clear/1]).
+-ignore_xref([clear/1, clear_local/0]).
 
 -define(TYPE_INFO_FUNCTION, '__spectra_type_info__').
+-define(LOCAL_CACHE_KEY, {?MODULE, local_cache}).
 
 %% API
 
@@ -16,31 +17,46 @@ Equivalent to calling `get/2` with the default application environment config.
 """.
 -spec get(Module :: module()) -> spectra:type_info().
 get(Module) ->
-    UseCache = application:get_env(spectra, use_module_types_cache, false),
-    get(Module, UseCache).
+    CacheMode = application:get_env(spectra, module_types_cache, local),
+    get(Module, CacheMode).
 
 -doc """
 Resolves type information for `Module`.
 
-When `UseCache` is `true` the result is cached in `persistent_term` and
+When `CacheMode` is `persistent` the result is cached in `persistent_term` and
 returned on subsequent calls without re-extracting the abstract code.
+
+When `CacheMode` is `local` the result is cached in the process dictionary
+under a single key `{spectra_module_types, local_cache}` which holds a map of
+`#{module() => type_info()}`. The caller is responsible for clearing the cache
+via `clear_local/0` when the top-level operation completes.
+
+When `CacheMode` is `none` type information is always re-extracted.
 """.
--spec get(Module :: module(), UseCache :: boolean()) -> spectra:type_info().
-get(Module, true) ->
-    cached_type_info(Module);
-get(Module, false) ->
+-spec get(Module :: module(), CacheMode :: spectra:module_types_cache()) -> spectra:type_info().
+get(Module, persistent) ->
+    persistent_cached_type_info(Module);
+get(Module, local) ->
+    local_cached_type_info(Module);
+get(Module, none) ->
     fetch_type_info(Module).
 
+-doc "Removes the persistent cache entry for `Module`.".
 -spec clear(Module :: module()) -> ok.
 clear(Module) ->
     persistent_term:erase({?MODULE, pers_types, Module}),
     ok.
 
+-doc "Removes all local (process-dictionary) cache entries for the calling process.".
+-spec clear_local() -> ok.
+clear_local() ->
+    erlang:erase(?LOCAL_CACHE_KEY),
+    ok.
+
 %% INTERNAL
 
--spec cached_type_info(Module :: module()) ->
-    spectra:type_info().
-cached_type_info(Module) ->
+-spec persistent_cached_type_info(Module :: module()) -> spectra:type_info().
+persistent_cached_type_info(Module) ->
     case pers_type(Module) of
         {ok, TypeInfo} ->
             TypeInfo;
@@ -50,6 +66,23 @@ cached_type_info(Module) ->
             TypeInfo
     end.
 
+-spec local_cached_type_info(Module :: module()) -> spectra:type_info().
+local_cached_type_info(Module) ->
+    Cache =
+        case erlang:get(?LOCAL_CACHE_KEY) of
+            undefined -> #{};
+            Map -> Map
+        end,
+    case Cache of
+        #{Module := TypeInfo} ->
+            TypeInfo;
+        #{} ->
+            TypeInfo = fetch_type_info(Module),
+            erlang:put(?LOCAL_CACHE_KEY, Cache#{Module => TypeInfo}),
+            TypeInfo
+    end.
+
+-spec fetch_type_info(Module :: module()) -> spectra:type_info().
 fetch_type_info(Module) ->
     case code:ensure_loaded(Module) of
         {module, Module} ->

--- a/src/spectra_module_types.erl
+++ b/src/spectra_module_types.erl
@@ -57,12 +57,12 @@ fetch_type_info(Module) ->
         {error, Reason} ->
             erlang:error({module_types_not_found, Module, Reason})
     end,
-        case erlang:function_exported(Module, ?TYPE_INFO_FUNCTION, 0) of
-            true ->
-                apply(Module, ?TYPE_INFO_FUNCTION, []);
-            false ->
-                spectra_abstract_code:types_in_module(Module)
-        end.
+    case erlang:function_exported(Module, ?TYPE_INFO_FUNCTION, 0) of
+        true ->
+            apply(Module, ?TYPE_INFO_FUNCTION, []);
+        false ->
+            spectra_abstract_code:types_in_module(Module)
+    end.
 
 -spec pers_type(Module :: module()) -> {ok, spectra:type_info()} | error.
 pers_type(Module) ->

--- a/src/spectra_module_types.erl
+++ b/src/spectra_module_types.erl
@@ -26,20 +26,10 @@ When `UseCache` is `true` the result is cached in `persistent_term` and
 returned on subsequent calls without re-extracting the abstract code.
 """.
 -spec get(Module :: module(), UseCache :: boolean()) -> spectra:type_info().
-get(Module, UseCache) ->
-    case code:ensure_loaded(Module) of
-        {module, Module} ->
-            ok;
-        {error, Reason} ->
-            erlang:error({module_types_not_found, Module, Reason})
-    end,
-    HasTypeInfoFun = erlang:function_exported(Module, ?TYPE_INFO_FUNCTION, 0),
-    case UseCache of
-        true ->
-            cached_type_info(Module, HasTypeInfoFun);
-        false ->
-            fetch_type_info(Module, HasTypeInfoFun)
-    end.
+get(Module, true) ->
+    cached_type_info(Module);
+get(Module, false) ->
+    fetch_type_info(Module).
 
 -spec clear(Module :: module()) -> ok.
 clear(Module) ->
@@ -48,33 +38,31 @@ clear(Module) ->
 
 %% INTERNAL
 
--spec cached_type_info(Module :: module(), HasTypeInfoFun :: boolean()) ->
+-spec cached_type_info(Module :: module()) ->
     spectra:type_info().
-cached_type_info(Module, true) ->
-    TypeInfoFun = fun() -> apply(Module, ?TYPE_INFO_FUNCTION, []) end,
-    do_cached_type_info(Module, TypeInfoFun);
-cached_type_info(Module, false) ->
-    TypeInfoFun = fun() -> spectra_abstract_code:types_in_module(Module) end,
-    do_cached_type_info(Module, TypeInfoFun).
-
--spec do_cached_type_info(Module :: module(), TypeInfoFun :: fun(() -> spectra:type_info())) ->
-    spectra:type_info().
-do_cached_type_info(Module, TypeInfoFun) ->
+cached_type_info(Module) ->
     case pers_type(Module) of
         {ok, TypeInfo} ->
             TypeInfo;
         error ->
-            TypeInfo = TypeInfoFun(),
+            TypeInfo = fetch_type_info(Module),
             pers_types_set(Module, TypeInfo),
             TypeInfo
     end.
 
--spec fetch_type_info(Module :: module(), HasTypeInfoFun :: boolean()) ->
-    spectra:type_info().
-fetch_type_info(Module, true) ->
-    apply(Module, ?TYPE_INFO_FUNCTION, []);
-fetch_type_info(Module, false) ->
-    spectra_abstract_code:types_in_module(Module).
+fetch_type_info(Module) ->
+    case code:ensure_loaded(Module) of
+        {module, Module} ->
+            ok;
+        {error, Reason} ->
+            erlang:error({module_types_not_found, Module, Reason})
+    end,
+        case erlang:function_exported(Module, ?TYPE_INFO_FUNCTION, 0) of
+            true ->
+                apply(Module, ?TYPE_INFO_FUNCTION, []);
+            false ->
+                spectra_abstract_code:types_in_module(Module)
+        end.
 
 -spec pers_type(Module :: module()) -> {ok, spectra:type_info()} | error.
 pers_type(Module) ->

--- a/src/spectra_openapi.erl
+++ b/src/spectra_openapi.erl
@@ -1020,15 +1020,13 @@ capitalize_word([First | Rest]) ->
     spectra_json_schema:json_schema().
 to_inline_schema(TypeInfo, {type, Name, Arity}, Config) ->
     Type = spectra_type_info:get_type(TypeInfo, Name, Arity),
-    Mod = spectra_type_info:get_module(TypeInfo),
-    case spectra_codec:try_codec_schema(Mod, json_schema, Type, Type, Config) of
+    case spectra_codec:try_codec_schema(TypeInfo, json_schema, Type, Type, Config) of
         continue -> spectra_json_schema:to_schema(TypeInfo, Type, Config);
         Schema -> Schema
     end;
 to_inline_schema(TypeInfo, {record, RecordName}, Config) ->
     Record = spectra_type_info:get_record(TypeInfo, RecordName),
-    Mod = spectra_type_info:get_module(TypeInfo),
-    case spectra_codec:try_codec_schema(Mod, json_schema, Record, Record, Config) of
+    case spectra_codec:try_codec_schema(TypeInfo, json_schema, Record, Record, Config) of
         continue -> spectra_json_schema:to_schema(TypeInfo, Record, Config);
         Schema -> Schema
     end;

--- a/src/spectra_openapi.erl
+++ b/src/spectra_openapi.erl
@@ -585,19 +585,24 @@ endpoints_to_openapi(MetaData, Endpoints) ->
 ) ->
     {ok, json:encode_value() | iodata()} | {error, [spectra:error()]}.
 endpoints_to_openapi(MetaData, Endpoints, Options) when is_list(Endpoints) ->
+    Config = #sp_config{
+        use_module_types_cache = application:get_env(spectra, use_module_types_cache, false),
+        check_unicode = application:get_env(spectra, check_unicode, false),
+        codecs = application:get_env(spectra, codecs, #{})
+    },
     PathGroups = group_endpoints_by_path(Endpoints),
     Paths =
         maps:fold(
             fun(Path, PathEndpoints, Acc) ->
-                PathOps = generate_path_operations(PathEndpoints),
+                PathOps = generate_path_operations(PathEndpoints, Config),
                 Acc#{Path => PathOps}
             end,
             #{},
             PathGroups
         ),
 
-    SchemaRefs = collect_schema_refs(Endpoints),
-    ComponentsResult = generate_components(SchemaRefs),
+    SchemaRefs = collect_schema_refs(Endpoints, Config),
+    ComponentsResult = generate_components(SchemaRefs, Config),
     BaseInfo = #{title => maps:get(title, MetaData), version => maps:get(version, MetaData)},
     Info = lists:foldl(
         fun({MetaKey, InfoKey}, Acc) ->
@@ -633,19 +638,19 @@ group_endpoints_by_path(Endpoints) ->
         Endpoints
     ).
 
--spec generate_path_operations([endpoint_spec()]) -> path_operations().
-generate_path_operations(Endpoints) ->
+-spec generate_path_operations([endpoint_spec()], spectra:sp_config()) -> path_operations().
+generate_path_operations(Endpoints, Config) ->
     lists:foldl(
         fun(#{method := Method} = Endpoint, Acc) ->
-            Operation = generate_operation(Endpoint),
+            Operation = generate_operation(Endpoint, Config),
             Acc#{Method => Operation}
         end,
         #{},
         Endpoints
     ).
 
--spec generate_operation(endpoint_spec()) -> openapi_operation().
-generate_operation(Endpoint) ->
+-spec generate_operation(endpoint_spec(), spectra:sp_config()) -> openapi_operation().
+generate_operation(Endpoint, Config) ->
     %% Start with documentation if present
     Operation = maps:get(doc, Endpoint, #{}),
 
@@ -656,7 +661,7 @@ generate_operation(Endpoint) ->
             true ->
                 OpenAPIResponses =
                     maps:map(
-                        fun(_StatusCode, ResponseSpec) -> generate_response(ResponseSpec) end,
+                        fun(_StatusCode, ResponseSpec) -> generate_response(ResponseSpec, Config) end,
                         Responses
                     ),
                 OpenAPIResponsesBinary =
@@ -678,7 +683,7 @@ generate_operation(Endpoint) ->
             undefined ->
                 OperationWithResponses;
             RequestBodyRef ->
-                RequestBody = generate_request_body(RequestBodyRef),
+                RequestBody = generate_request_body(RequestBodyRef, Config),
                 OperationWithResponses#{requestBody => RequestBody}
         end,
 
@@ -687,12 +692,12 @@ generate_operation(Endpoint) ->
         [] ->
             OperationWithBody;
         _ ->
-            OpenAPIParameters = lists:map(fun generate_parameter/1, Parameters),
+            OpenAPIParameters = lists:map(fun(P) -> generate_parameter(P, Config) end, Parameters),
             OperationWithBody#{parameters => OpenAPIParameters}
     end.
 
--spec generate_response(response_spec()) -> openapi_response().
-generate_response(#{description := Description} = ResponseSpec) when
+-spec generate_response(response_spec(), spectra:sp_config()) -> openapi_response().
+generate_response(#{description := Description} = ResponseSpec, Config) when
     is_binary(Description)
 ->
     %% Build base response with optional content
@@ -711,7 +716,9 @@ generate_response(#{description := Description} = ResponseSpec) when
             ->
                 #{description => Description};
             {Schema, Module} ->
-                ModuleTypeInfo = spectra_module_types:get(Module),
+                ModuleTypeInfo = spectra_module_types:get(
+                    Module, Config#sp_config.use_module_types_cache
+                ),
                 NormalizedSchema = spectra_util:normalize_type_ref(ModuleTypeInfo, Schema),
                 SchemaContent =
                     case NormalizedSchema of
@@ -744,7 +751,7 @@ generate_response(#{description := Description} = ResponseSpec) when
                             #{'$ref' => <<"#/components/schemas/", SchemaName/binary>>};
                         DirectType ->
                             InlineSchema =
-                                spectra_json_schema:to_schema(ModuleTypeInfo, DirectType),
+                                spectra_json_schema:to_schema(ModuleTypeInfo, DirectType, Config),
                             maps:remove('$schema', InlineSchema)
                     end,
                 ContentType = maps:get(content_type, ResponseSpec, ?DEFAULT_CONTENT_TYPE),
@@ -761,7 +768,7 @@ generate_response(#{description := Description} = ResponseSpec) when
         HeadersSpec ->
             GeneratedHeaders =
                 maps:map(
-                    fun(_HeaderName, HeaderSpec) -> generate_response_header(HeaderSpec) end,
+                    fun(_HeaderName, HeaderSpec) -> generate_response_header(HeaderSpec, Config) end,
                     HeadersSpec
                 ),
             BaseResponse#{headers => GeneratedHeaders}
@@ -774,19 +781,19 @@ copy_if_present(Key, Source, Target) ->
         Value -> Target#{Key => Value}
     end.
 
--spec generate_response_header(response_header_spec()) -> openapi_header().
-generate_response_header(#{schema := Schema, module := Module} = HeaderSpec) ->
-    ModuleTypeInfo = spectra_module_types:get(Module),
+-spec generate_response_header(response_header_spec(), spectra:sp_config()) -> openapi_header().
+generate_response_header(#{schema := Schema, module := Module} = HeaderSpec, Config) ->
+    ModuleTypeInfo = spectra_module_types:get(Module, Config#sp_config.use_module_types_cache),
     NormalizedSchema = spectra_util:normalize_type_ref(ModuleTypeInfo, Schema),
-    InlineSchema = to_inline_schema(ModuleTypeInfo, NormalizedSchema),
+    InlineSchema = to_inline_schema(ModuleTypeInfo, NormalizedSchema, Config),
     OpenApiSchema = maps:remove('$schema', InlineSchema),
-    Doc = maps:with([description, deprecated], type_doc(ModuleTypeInfo, NormalizedSchema)),
+    Doc = maps:with([description, deprecated], type_doc(ModuleTypeInfo, NormalizedSchema, Config)),
     Base = Doc#{schema => OpenApiSchema},
     copy_if_present(required, HeaderSpec, Base).
 
--spec generate_request_body(request_body_spec()) -> openapi_request_body().
-generate_request_body(#{schema := Schema, module := Module} = RequestBodySpec) ->
-    ModuleTypeInfo = spectra_module_types:get(Module),
+-spec generate_request_body(request_body_spec(), spectra:sp_config()) -> openapi_request_body().
+generate_request_body(#{schema := Schema, module := Module} = RequestBodySpec, Config) ->
+    ModuleTypeInfo = spectra_module_types:get(Module, Config#sp_config.use_module_types_cache),
     NormalizedSchema = spectra_util:normalize_type_ref(ModuleTypeInfo, Schema),
     SchemaContent =
         case NormalizedSchema of
@@ -800,17 +807,17 @@ generate_request_body(#{schema := Schema, module := Module} = RequestBodySpec) -
                 SchemaName = schema_component_name(RemoteMod, {type, RemoteName, RemoteArity}),
                 #{'$ref' => <<"#/components/schemas/", SchemaName/binary>>};
             DirectType ->
-                InlineSchema = spectra_json_schema:to_schema(ModuleTypeInfo, DirectType),
+                InlineSchema = spectra_json_schema:to_schema(ModuleTypeInfo, DirectType, Config),
                 OpenApiSchema = maps:remove('$schema', InlineSchema),
                 OpenApiSchema
         end,
 
     ContentType = maps:get(content_type, RequestBodySpec, ?DEFAULT_CONTENT_TYPE),
-    Doc = maps:with([description], type_doc(ModuleTypeInfo, NormalizedSchema)),
+    Doc = maps:with([description], type_doc(ModuleTypeInfo, NormalizedSchema, Config)),
     Base = Doc#{required => true, content => #{ContentType => #{schema => SchemaContent}}},
     Base.
 
--spec generate_parameter(parameter_spec()) -> openapi_parameter().
+-spec generate_parameter(parameter_spec(), spectra:sp_config()) -> openapi_parameter().
 generate_parameter(
     #{
         name := Name,
@@ -818,56 +825,59 @@ generate_parameter(
         schema := Schema,
         module := Module
     } =
-        ParameterSpec
+        ParameterSpec,
+    Config
 ) when
     is_binary(Name)
 ->
-    ModuleTypeInfo = spectra_module_types:get(Module),
+    ModuleTypeInfo = spectra_module_types:get(Module, Config#sp_config.use_module_types_cache),
     NormalizedSchema = spectra_util:normalize_type_ref(ModuleTypeInfo, Schema),
     Required = maps:get(required, ParameterSpec, false),
 
-    InlineSchema = to_inline_schema(ModuleTypeInfo, NormalizedSchema),
+    InlineSchema = to_inline_schema(ModuleTypeInfo, NormalizedSchema, Config),
     OpenApiSchema = maps:remove('$schema', InlineSchema),
-    Doc = maps:with([description, deprecated], type_doc(ModuleTypeInfo, NormalizedSchema)),
+    Doc = maps:with([description, deprecated], type_doc(ModuleTypeInfo, NormalizedSchema, Config)),
     Doc#{name => Name, in => In, required => Required, schema => OpenApiSchema}.
 
--spec collect_schema_refs([endpoint_spec()]) -> [{module(), spectra:sp_type_reference()}].
-collect_schema_refs(Endpoints) ->
+-spec collect_schema_refs([endpoint_spec()], spectra:sp_config()) ->
+    [{module(), spectra:sp_type_reference()}].
+collect_schema_refs(Endpoints, Config) ->
     lists:foldl(
         fun(Endpoint, Acc) ->
-            EndpointRefs = collect_endpoint_schema_refs(Endpoint),
+            EndpointRefs = collect_endpoint_schema_refs(Endpoint, Config),
             lists:usort(EndpointRefs ++ Acc)
         end,
         [],
         Endpoints
     ).
 
--spec collect_endpoint_schema_refs(endpoint_spec()) ->
+-spec collect_endpoint_schema_refs(endpoint_spec(), spectra:sp_config()) ->
     [{module(), spectra:sp_type_reference()}].
 collect_endpoint_schema_refs(
     #{responses := Responses, parameters := Parameters} =
-        Endpoint
+        Endpoint,
+    Config
 ) ->
-    ResponseRefs = collect_response_refs(Responses),
+    ResponseRefs = collect_response_refs(Responses, Config),
     RequestBodyRefs =
         case maps:get(request_body, Endpoint, undefined) of
             undefined ->
                 [];
             #{schema := Schema, module := Module} ->
-                case filter_typeref(Schema, Module) of
+                case filter_typeref(Schema, Module, Config) of
                     {true, ModuleTypeRef} ->
                         [ModuleTypeRef];
                     false ->
                         []
                 end
         end,
-    ParameterRefs = collect_parameter_refs(Parameters),
+    ParameterRefs = collect_parameter_refs(Parameters, Config),
 
     ResponseRefs ++ RequestBodyRefs ++ ParameterRefs.
 
--spec collect_response_refs(#{http_status_code() => response_spec()}) ->
+-spec collect_response_refs(#{http_status_code() => response_spec()}, spectra:sp_config()) ->
     [{module(), spectra:sp_type_reference()}].
-collect_response_refs(Responses) ->
+collect_response_refs(Responses, Config) ->
     maps:fold(
         fun(_StatusCode, ResponseSpec, Acc) ->
             case
@@ -883,7 +893,7 @@ collect_response_refs(Responses) ->
                     %% Schema without module should not happen
                     Acc;
                 {Schema, Module} ->
-                    case filter_typeref(Schema, Module) of
+                    case filter_typeref(Schema, Module, Config) of
                         {true, ModuleTypeRef} ->
                             [ModuleTypeRef | Acc];
                         false ->
@@ -895,20 +905,20 @@ collect_response_refs(Responses) ->
         Responses
     ).
 
--spec collect_parameter_refs([parameter_spec()]) ->
+-spec collect_parameter_refs([parameter_spec()], spectra:sp_config()) ->
     [{module(), spectra:sp_type_reference()}].
-collect_parameter_refs(Parameters) ->
+collect_parameter_refs(Parameters, Config) ->
     lists:filtermap(
         fun(#{schema := Schema, module := Module}) ->
-            filter_typeref(Schema, Module)
+            filter_typeref(Schema, Module, Config)
         end,
         Parameters
     ).
 
--spec filter_typeref(spectra:sp_type_or_ref(), module()) ->
+-spec filter_typeref(spectra:sp_type_or_ref(), module(), spectra:sp_config()) ->
     {true, {module(), spectra:sp_type_reference()}} | false.
-filter_typeref(Schema, Module) ->
-    TypeInfo = spectra_module_types:get(Module),
+filter_typeref(Schema, Module, Config) ->
+    TypeInfo = spectra_module_types:get(Module, Config#sp_config.use_module_types_cache),
     NormalizedSchema = spectra_util:normalize_type_ref(TypeInfo, Schema),
     case NormalizedSchema of
         {type, _, _} = TypeRef ->
@@ -923,13 +933,15 @@ filter_typeref(Schema, Module) ->
             false
     end.
 
--spec generate_components([{module(), spectra:sp_type_reference()}]) ->
+-spec generate_components([{module(), spectra:sp_type_reference()}], spectra:sp_config()) ->
     #{schemas => #{binary() => openapi_schema()}}.
-generate_components(SchemaRefs) ->
+generate_components(SchemaRefs, Config) ->
     Schemas = lists:foldl(
         fun({Module, TypeRef}, Acc) ->
-            ModuleTypeInfo = spectra_module_types:get(Module),
-            Schema = to_inline_schema(ModuleTypeInfo, TypeRef),
+            ModuleTypeInfo = spectra_module_types:get(
+                Module, Config#sp_config.use_module_types_cache
+            ),
+            Schema = to_inline_schema(ModuleTypeInfo, TypeRef, Config),
             SchemaName = schema_component_name(Module, TypeRef),
             OpenApiSchema = maps:remove('$schema', Schema),
             Acc#{SchemaName => OpenApiSchema}
@@ -968,25 +980,26 @@ schema_component_name(Module, {type, t, 0}) ->
 schema_component_name(_Module, TypeRef) ->
     type_ref_to_component_name(TypeRef).
 
--spec type_doc(spectra:type_info(), spectra:sp_type_or_ref()) -> spectra:type_doc().
-type_doc(TypeInfo, {type, Name, Arity}) ->
-    type_doc(TypeInfo, spectra_type_info:get_type(TypeInfo, Name, Arity));
-type_doc(TypeInfo, {record, Name}) ->
-    type_doc(TypeInfo, spectra_type_info:get_record(TypeInfo, Name));
-type_doc(TypeInfo, #sp_user_type_ref{type_name = Name, arity = Arity} = Ref) ->
+-spec type_doc(spectra:type_info(), spectra:sp_type_or_ref(), spectra:sp_config()) ->
+    spectra:type_doc().
+type_doc(TypeInfo, {type, Name, Arity}, Config) ->
+    type_doc(TypeInfo, spectra_type_info:get_type(TypeInfo, Name, Arity), Config);
+type_doc(TypeInfo, {record, Name}, Config) ->
+    type_doc(TypeInfo, spectra_type_info:get_record(TypeInfo, Name), Config);
+type_doc(TypeInfo, #sp_user_type_ref{type_name = Name, arity = Arity} = Ref, Config) ->
     case spectra_type:get_meta(Ref) of
         #{doc := Doc} -> maps:remove(examples_function, Doc);
-        _ -> type_doc(TypeInfo, spectra_type_info:get_type(TypeInfo, Name, Arity))
+        _ -> type_doc(TypeInfo, spectra_type_info:get_type(TypeInfo, Name, Arity), Config)
     end;
-type_doc(_TypeInfo, #sp_remote_type{mfargs = {Mod, Name, _}, arity = Arity} = Ref) ->
+type_doc(_TypeInfo, #sp_remote_type{mfargs = {Mod, Name, _}, arity = Arity} = Ref, Config) ->
     case spectra_type:get_meta(Ref) of
         #{doc := Doc} ->
             maps:remove(examples_function, Doc);
         _ ->
-            RemoteTypeInfo = spectra_module_types:get(Mod),
-            type_doc(RemoteTypeInfo, spectra_type_info:get_type(RemoteTypeInfo, Name, Arity))
+            RemoteTypeInfo = spectra_module_types:get(Mod, Config#sp_config.use_module_types_cache),
+            type_doc(RemoteTypeInfo, spectra_type_info:get_type(RemoteTypeInfo, Name, Arity), Config)
     end;
-type_doc(_TypeInfo, Type) ->
+type_doc(_TypeInfo, Type, _Config) ->
     case spectra_type:get_meta(Type) of
         #{doc := Doc} -> maps:remove(examples_function, Doc);
         _ -> #{}
@@ -997,21 +1010,21 @@ capitalize_word([]) ->
 capitalize_word([First | Rest]) ->
     [string:to_upper(First) | Rest].
 
--spec to_inline_schema(spectra:type_info(), spectra:sp_type_or_ref()) ->
+-spec to_inline_schema(spectra:type_info(), spectra:sp_type_or_ref(), spectra:sp_config()) ->
     spectra_json_schema:json_schema().
-to_inline_schema(TypeInfo, {type, Name, Arity}) ->
+to_inline_schema(TypeInfo, {type, Name, Arity}, Config) ->
     Type = spectra_type_info:get_type(TypeInfo, Name, Arity),
     Mod = spectra_type_info:get_module(TypeInfo),
-    case spectra_codec:try_codec_schema(Mod, json_schema, Type, Type) of
-        continue -> spectra_json_schema:to_schema(TypeInfo, Type);
+    case spectra_codec:try_codec_schema(Mod, json_schema, Type, Type, Config) of
+        continue -> spectra_json_schema:to_schema(TypeInfo, Type, Config);
         Schema -> Schema
     end;
-to_inline_schema(TypeInfo, {record, RecordName}) ->
+to_inline_schema(TypeInfo, {record, RecordName}, Config) ->
     Record = spectra_type_info:get_record(TypeInfo, RecordName),
     Mod = spectra_type_info:get_module(TypeInfo),
-    case spectra_codec:try_codec_schema(Mod, json_schema, Record, Record) of
-        continue -> spectra_json_schema:to_schema(TypeInfo, Record);
+    case spectra_codec:try_codec_schema(Mod, json_schema, Record, Record, Config) of
+        continue -> spectra_json_schema:to_schema(TypeInfo, Record, Config);
         Schema -> Schema
     end;
-to_inline_schema(TypeInfo, SpType) ->
-    spectra_json_schema:to_schema(TypeInfo, SpType).
+to_inline_schema(TypeInfo, SpType, Config) ->
+    spectra_json_schema:to_schema(TypeInfo, SpType, Config).

--- a/src/spectra_openapi.erl
+++ b/src/spectra_openapi.erl
@@ -661,7 +661,9 @@ generate_operation(Endpoint, Config) ->
             true ->
                 OpenAPIResponses =
                     maps:map(
-                        fun(_StatusCode, ResponseSpec) -> generate_response(ResponseSpec, Config) end,
+                        fun(_StatusCode, ResponseSpec) ->
+                            generate_response(ResponseSpec, Config)
+                        end,
                         Responses
                     ),
                 OpenAPIResponsesBinary =
@@ -768,7 +770,9 @@ generate_response(#{description := Description} = ResponseSpec, Config) when
         HeadersSpec ->
             GeneratedHeaders =
                 maps:map(
-                    fun(_HeaderName, HeaderSpec) -> generate_response_header(HeaderSpec, Config) end,
+                    fun(_HeaderName, HeaderSpec) ->
+                        generate_response_header(HeaderSpec, Config)
+                    end,
                     HeadersSpec
                 ),
             BaseResponse#{headers => GeneratedHeaders}
@@ -997,7 +1001,9 @@ type_doc(_TypeInfo, #sp_remote_type{mfargs = {Mod, Name, _}, arity = Arity} = Re
             maps:remove(examples_function, Doc);
         _ ->
             RemoteTypeInfo = spectra_module_types:get(Mod, Config#sp_config.use_module_types_cache),
-            type_doc(RemoteTypeInfo, spectra_type_info:get_type(RemoteTypeInfo, Name, Arity), Config)
+            type_doc(
+                RemoteTypeInfo, spectra_type_info:get_type(RemoteTypeInfo, Name, Arity), Config
+            )
     end;
 type_doc(_TypeInfo, Type, _Config) ->
     case spectra_type:get_meta(Type) of

--- a/src/spectra_openapi.erl
+++ b/src/spectra_openapi.erl
@@ -719,7 +719,7 @@ generate_response(#{description := Description} = ResponseSpec, Config) when
                 #{description => Description};
             {Schema, Module} ->
                 ModuleTypeInfo = spectra_module_types:get(
-                    Module, Config#sp_config.module_types_cache
+                    Module, Config
                 ),
                 NormalizedSchema = spectra_util:normalize_type_ref(ModuleTypeInfo, Schema),
                 SchemaContent =
@@ -787,7 +787,7 @@ copy_if_present(Key, Source, Target) ->
 
 -spec generate_response_header(response_header_spec(), spectra:sp_config()) -> openapi_header().
 generate_response_header(#{schema := Schema, module := Module} = HeaderSpec, Config) ->
-    ModuleTypeInfo = spectra_module_types:get(Module, Config#sp_config.module_types_cache),
+    ModuleTypeInfo = spectra_module_types:get(Module, Config),
     NormalizedSchema = spectra_util:normalize_type_ref(ModuleTypeInfo, Schema),
     InlineSchema = to_inline_schema(ModuleTypeInfo, NormalizedSchema, Config),
     OpenApiSchema = maps:remove('$schema', InlineSchema),
@@ -797,7 +797,7 @@ generate_response_header(#{schema := Schema, module := Module} = HeaderSpec, Con
 
 -spec generate_request_body(request_body_spec(), spectra:sp_config()) -> openapi_request_body().
 generate_request_body(#{schema := Schema, module := Module} = RequestBodySpec, Config) ->
-    ModuleTypeInfo = spectra_module_types:get(Module, Config#sp_config.module_types_cache),
+    ModuleTypeInfo = spectra_module_types:get(Module, Config),
     NormalizedSchema = spectra_util:normalize_type_ref(ModuleTypeInfo, Schema),
     SchemaContent =
         case NormalizedSchema of
@@ -834,7 +834,7 @@ generate_parameter(
 ) when
     is_binary(Name)
 ->
-    ModuleTypeInfo = spectra_module_types:get(Module, Config#sp_config.module_types_cache),
+    ModuleTypeInfo = spectra_module_types:get(Module, Config),
     NormalizedSchema = spectra_util:normalize_type_ref(ModuleTypeInfo, Schema),
     Required = maps:get(required, ParameterSpec, false),
 
@@ -922,7 +922,7 @@ collect_parameter_refs(Parameters, Config) ->
 -spec filter_typeref(spectra:sp_type_or_ref(), module(), spectra:sp_config()) ->
     {true, {module(), spectra:sp_type_reference()}} | false.
 filter_typeref(Schema, Module, Config) ->
-    TypeInfo = spectra_module_types:get(Module, Config#sp_config.module_types_cache),
+    TypeInfo = spectra_module_types:get(Module, Config),
     NormalizedSchema = spectra_util:normalize_type_ref(TypeInfo, Schema),
     case NormalizedSchema of
         {type, _, _} = TypeRef ->
@@ -943,7 +943,7 @@ generate_components(SchemaRefs, Config) ->
     Schemas = lists:foldl(
         fun({Module, TypeRef}, Acc) ->
             ModuleTypeInfo = spectra_module_types:get(
-                Module, Config#sp_config.module_types_cache
+                Module, Config
             ),
             Schema = to_inline_schema(ModuleTypeInfo, TypeRef, Config),
             SchemaName = schema_component_name(Module, TypeRef),
@@ -1000,7 +1000,7 @@ type_doc(_TypeInfo, #sp_remote_type{mfargs = {Mod, Name, _}, arity = Arity} = Re
         #{doc := Doc} ->
             maps:remove(examples_function, Doc);
         _ ->
-            RemoteTypeInfo = spectra_module_types:get(Mod, Config#sp_config.module_types_cache),
+            RemoteTypeInfo = spectra_module_types:get(Mod, Config),
             type_doc(
                 RemoteTypeInfo, spectra_type_info:get_type(RemoteTypeInfo, Name, Arity), Config
             )

--- a/src/spectra_openapi.erl
+++ b/src/spectra_openapi.erl
@@ -586,7 +586,7 @@ endpoints_to_openapi(MetaData, Endpoints) ->
     {ok, json:encode_value() | iodata()} | {error, [spectra:error()]}.
 endpoints_to_openapi(MetaData, Endpoints, Options) when is_list(Endpoints) ->
     Config = #sp_config{
-        use_module_types_cache = application:get_env(spectra, use_module_types_cache, false),
+        module_types_cache = application:get_env(spectra, module_types_cache, local),
         check_unicode = application:get_env(spectra, check_unicode, false),
         codecs = application:get_env(spectra, codecs, #{})
     },
@@ -719,7 +719,7 @@ generate_response(#{description := Description} = ResponseSpec, Config) when
                 #{description => Description};
             {Schema, Module} ->
                 ModuleTypeInfo = spectra_module_types:get(
-                    Module, Config#sp_config.use_module_types_cache
+                    Module, Config#sp_config.module_types_cache
                 ),
                 NormalizedSchema = spectra_util:normalize_type_ref(ModuleTypeInfo, Schema),
                 SchemaContent =
@@ -787,7 +787,7 @@ copy_if_present(Key, Source, Target) ->
 
 -spec generate_response_header(response_header_spec(), spectra:sp_config()) -> openapi_header().
 generate_response_header(#{schema := Schema, module := Module} = HeaderSpec, Config) ->
-    ModuleTypeInfo = spectra_module_types:get(Module, Config#sp_config.use_module_types_cache),
+    ModuleTypeInfo = spectra_module_types:get(Module, Config#sp_config.module_types_cache),
     NormalizedSchema = spectra_util:normalize_type_ref(ModuleTypeInfo, Schema),
     InlineSchema = to_inline_schema(ModuleTypeInfo, NormalizedSchema, Config),
     OpenApiSchema = maps:remove('$schema', InlineSchema),
@@ -797,7 +797,7 @@ generate_response_header(#{schema := Schema, module := Module} = HeaderSpec, Con
 
 -spec generate_request_body(request_body_spec(), spectra:sp_config()) -> openapi_request_body().
 generate_request_body(#{schema := Schema, module := Module} = RequestBodySpec, Config) ->
-    ModuleTypeInfo = spectra_module_types:get(Module, Config#sp_config.use_module_types_cache),
+    ModuleTypeInfo = spectra_module_types:get(Module, Config#sp_config.module_types_cache),
     NormalizedSchema = spectra_util:normalize_type_ref(ModuleTypeInfo, Schema),
     SchemaContent =
         case NormalizedSchema of
@@ -834,7 +834,7 @@ generate_parameter(
 ) when
     is_binary(Name)
 ->
-    ModuleTypeInfo = spectra_module_types:get(Module, Config#sp_config.use_module_types_cache),
+    ModuleTypeInfo = spectra_module_types:get(Module, Config#sp_config.module_types_cache),
     NormalizedSchema = spectra_util:normalize_type_ref(ModuleTypeInfo, Schema),
     Required = maps:get(required, ParameterSpec, false),
 
@@ -922,7 +922,7 @@ collect_parameter_refs(Parameters, Config) ->
 -spec filter_typeref(spectra:sp_type_or_ref(), module(), spectra:sp_config()) ->
     {true, {module(), spectra:sp_type_reference()}} | false.
 filter_typeref(Schema, Module, Config) ->
-    TypeInfo = spectra_module_types:get(Module, Config#sp_config.use_module_types_cache),
+    TypeInfo = spectra_module_types:get(Module, Config#sp_config.module_types_cache),
     NormalizedSchema = spectra_util:normalize_type_ref(TypeInfo, Schema),
     case NormalizedSchema of
         {type, _, _} = TypeRef ->
@@ -943,7 +943,7 @@ generate_components(SchemaRefs, Config) ->
     Schemas = lists:foldl(
         fun({Module, TypeRef}, Acc) ->
             ModuleTypeInfo = spectra_module_types:get(
-                Module, Config#sp_config.use_module_types_cache
+                Module, Config#sp_config.module_types_cache
             ),
             Schema = to_inline_schema(ModuleTypeInfo, TypeRef, Config),
             SchemaName = schema_component_name(Module, TypeRef),
@@ -1000,7 +1000,7 @@ type_doc(_TypeInfo, #sp_remote_type{mfargs = {Mod, Name, _}, arity = Arity} = Re
         #{doc := Doc} ->
             maps:remove(examples_function, Doc);
         _ ->
-            RemoteTypeInfo = spectra_module_types:get(Mod, Config#sp_config.use_module_types_cache),
+            RemoteTypeInfo = spectra_module_types:get(Mod, Config#sp_config.module_types_cache),
             type_doc(
                 RemoteTypeInfo, spectra_type_info:get_type(RemoteTypeInfo, Name, Arity), Config
             )

--- a/src/spectra_openapi.erl
+++ b/src/spectra_openapi.erl
@@ -585,46 +585,46 @@ endpoints_to_openapi(MetaData, Endpoints) ->
 ) ->
     {ok, json:encode_value() | iodata()} | {error, [spectra:error()]}.
 endpoints_to_openapi(MetaData, Endpoints, Options) when is_list(Endpoints) ->
-    Config = #sp_config{
-        module_types_cache = application:get_env(spectra, module_types_cache, local),
-        check_unicode = application:get_env(spectra, check_unicode, false),
-        codecs = application:get_env(spectra, codecs, #{})
-    },
-    PathGroups = group_endpoints_by_path(Endpoints),
-    Paths =
-        maps:fold(
-            fun(Path, PathEndpoints, Acc) ->
-                PathOps = generate_path_operations(PathEndpoints, Config),
-                Acc#{Path => PathOps}
-            end,
-            #{},
-            PathGroups
-        ),
+    Config = spectra:get_config(),
+    try
+        PathGroups = group_endpoints_by_path(Endpoints),
+        Paths =
+            maps:fold(
+                fun(Path, PathEndpoints, Acc) ->
+                    PathOps = generate_path_operations(PathEndpoints, Config),
+                    Acc#{Path => PathOps}
+                end,
+                #{},
+                PathGroups
+            ),
 
-    SchemaRefs = collect_schema_refs(Endpoints, Config),
-    ComponentsResult = generate_components(SchemaRefs, Config),
-    BaseInfo = #{title => maps:get(title, MetaData), version => maps:get(version, MetaData)},
-    Info = lists:foldl(
-        fun({MetaKey, InfoKey}, Acc) ->
-            case maps:get(MetaKey, MetaData, undefined) of
-                undefined -> Acc;
-                Value -> Acc#{InfoKey => Value}
-            end
-        end,
-        BaseInfo,
-        [
-            {summary, summary},
-            {description, description},
-            {terms_of_service, termsOfService},
-            {contact, contact},
-            {license, license}
-        ]
-    ),
-    BaseSpec = #{
-        openapi => <<"3.1.0">>, info => Info, paths => Paths, components => ComponentsResult
-    },
-    OpenAPISpec = copy_if_present(servers, MetaData, BaseSpec),
-    spectra:encode(json, ?MODULE, {type, openapi_spec, 0}, OpenAPISpec, Options).
+        SchemaRefs = collect_schema_refs(Endpoints, Config),
+        ComponentsResult = generate_components(SchemaRefs, Config),
+        BaseInfo = #{title => maps:get(title, MetaData), version => maps:get(version, MetaData)},
+        Info = lists:foldl(
+            fun({MetaKey, InfoKey}, Acc) ->
+                case maps:get(MetaKey, MetaData, undefined) of
+                    undefined -> Acc;
+                    Value -> Acc#{InfoKey => Value}
+                end
+            end,
+            BaseInfo,
+            [
+                {summary, summary},
+                {description, description},
+                {terms_of_service, termsOfService},
+                {contact, contact},
+                {license, license}
+            ]
+        ),
+        BaseSpec = #{
+            openapi => <<"3.1.0">>, info => Info, paths => Paths, components => ComponentsResult
+        },
+        OpenAPISpec = copy_if_present(servers, MetaData, BaseSpec),
+        spectra:encode(json, ?MODULE, {type, openapi_spec, 0}, OpenAPISpec, Options)
+    after
+        spectra_module_types:clear_local()
+    end.
 
 -spec group_endpoints_by_path([endpoint_spec()]) -> #{binary() => [endpoint_spec()]}.
 group_endpoints_by_path(Endpoints) ->

--- a/src/spectra_string.erl
+++ b/src/spectra_string.erl
@@ -84,7 +84,13 @@ from_string(
     Type = spectra_type_info:get_type(TypeInfo, TypeName, Arity),
     case
         spectra_codec:try_codec_decode(
-            Mod, string, Type, String, UserTypeRef, Config#sp_config.codecs, Config#sp_config.use_module_types_cache
+            Mod,
+            string,
+            Type,
+            String,
+            UserTypeRef,
+            Config#sp_config.codecs,
+            Config#sp_config.use_module_types_cache
         )
     of
         continue ->
@@ -98,7 +104,13 @@ from_string(TypeInfo, #sp_rec_ref{record_name = RecordName} = RecordRef, String,
     RecordType = spectra_type_info:get_record(TypeInfo, RecordName),
     case
         spectra_codec:try_codec_decode(
-            Mod, string, RecordType, String, RecordRef, Config#sp_config.codecs, Config#sp_config.use_module_types_cache
+            Mod,
+            string,
+            RecordType,
+            String,
+            RecordRef,
+            Config#sp_config.codecs,
+            Config#sp_config.use_module_types_cache
         )
     of
         continue -> erlang:error({type_not_supported, RecordType});
@@ -114,7 +126,13 @@ from_string(
     RemoteType = spectra_type_info:get_type(RemoteTypeInfo, TypeName, TypeArity),
     case
         spectra_codec:try_codec_decode(
-            Module, string, RemoteType, String, RemoteRef, Config#sp_config.codecs, Config#sp_config.use_module_types_cache
+            Module,
+            string,
+            RemoteType,
+            String,
+            RemoteRef,
+            Config#sp_config.codecs,
+            Config#sp_config.use_module_types_cache
         )
     of
         continue ->
@@ -233,7 +251,13 @@ to_string(
     Type = spectra_type_info:get_type(TypeInfo, TypeName, Arity),
     case
         spectra_codec:try_codec_encode(
-            Mod, string, Type, Data, UserTypeRef, Config#sp_config.codecs, Config#sp_config.use_module_types_cache
+            Mod,
+            string,
+            Type,
+            Data,
+            UserTypeRef,
+            Config#sp_config.codecs,
+            Config#sp_config.use_module_types_cache
         )
     of
         continue ->
@@ -247,7 +271,13 @@ to_string(TypeInfo, #sp_rec_ref{record_name = RecordName} = RecordRef, Data, Con
     RecordType = spectra_type_info:get_record(TypeInfo, RecordName),
     case
         spectra_codec:try_codec_encode(
-            Mod, string, RecordType, Data, RecordRef, Config#sp_config.codecs, Config#sp_config.use_module_types_cache
+            Mod,
+            string,
+            RecordType,
+            Data,
+            RecordRef,
+            Config#sp_config.codecs,
+            Config#sp_config.use_module_types_cache
         )
     of
         continue -> erlang:error({type_not_supported, RecordType});
@@ -263,7 +293,13 @@ to_string(
     RemoteType = spectra_type_info:get_type(RemoteTypeInfo, TypeName, TypeArity),
     case
         spectra_codec:try_codec_encode(
-            Module, string, RemoteType, Data, RemoteRef, Config#sp_config.codecs, Config#sp_config.use_module_types_cache
+            Module,
+            string,
+            RemoteType,
+            Data,
+            RemoteRef,
+            Config#sp_config.codecs,
+            Config#sp_config.use_module_types_cache
         )
     of
         continue ->

--- a/src/spectra_string.erl
+++ b/src/spectra_string.erl
@@ -40,11 +40,11 @@ Equivalent to calling from_string/4 with a default configuration.
 ) ->
     {ok, dynamic()} | {error, [spectra:error()]}.
 from_string(TypeInfo, Type, String) ->
-    UseCache = application:get_env(spectra, use_module_types_cache, false),
+    CacheMode = application:get_env(spectra, module_types_cache, local),
     Codecs = application:get_env(spectra, codecs, #{}),
     CheckUnicode = application:get_env(spectra, check_unicode, false),
     Config = #sp_config{
-        use_module_types_cache = UseCache, codecs = Codecs, check_unicode = CheckUnicode
+        module_types_cache = CacheMode, codecs = Codecs, check_unicode = CheckUnicode
     },
     from_string(TypeInfo, Type, String, Config).
 
@@ -90,7 +90,7 @@ from_string(
             String,
             UserTypeRef,
             Config#sp_config.codecs,
-            Config#sp_config.use_module_types_cache
+            Config#sp_config.module_types_cache
         )
     of
         continue ->
@@ -110,7 +110,7 @@ from_string(TypeInfo, #sp_rec_ref{record_name = RecordName} = RecordRef, String,
             String,
             RecordRef,
             Config#sp_config.codecs,
-            Config#sp_config.use_module_types_cache
+            Config#sp_config.module_types_cache
         )
     of
         continue -> erlang:error({type_not_supported, RecordType});
@@ -122,7 +122,7 @@ from_string(
     String,
     Config
 ) ->
-    RemoteTypeInfo = spectra_module_types:get(Module, Config#sp_config.use_module_types_cache),
+    RemoteTypeInfo = spectra_module_types:get(Module, Config#sp_config.module_types_cache),
     RemoteType = spectra_type_info:get_type(RemoteTypeInfo, TypeName, TypeArity),
     case
         spectra_codec:try_codec_decode(
@@ -132,7 +132,7 @@ from_string(
             String,
             RemoteRef,
             Config#sp_config.codecs,
-            Config#sp_config.use_module_types_cache
+            Config#sp_config.module_types_cache
         )
     of
         continue ->
@@ -207,11 +207,11 @@ Equivalent to calling to_string/4 with a default configuration.
 ) ->
     {ok, string()} | {error, [spectra:error()]}.
 to_string(TypeInfo, Type, Data) ->
-    UseCache = application:get_env(spectra, use_module_types_cache, false),
+    CacheMode = application:get_env(spectra, module_types_cache, local),
     Codecs = application:get_env(spectra, codecs, #{}),
     CheckUnicode = application:get_env(spectra, check_unicode, false),
     Config = #sp_config{
-        use_module_types_cache = UseCache, codecs = Codecs, check_unicode = CheckUnicode
+        module_types_cache = CacheMode, codecs = Codecs, check_unicode = CheckUnicode
     },
     to_string(TypeInfo, Type, Data, Config).
 
@@ -257,7 +257,7 @@ to_string(
             Data,
             UserTypeRef,
             Config#sp_config.codecs,
-            Config#sp_config.use_module_types_cache
+            Config#sp_config.module_types_cache
         )
     of
         continue ->
@@ -277,7 +277,7 @@ to_string(TypeInfo, #sp_rec_ref{record_name = RecordName} = RecordRef, Data, Con
             Data,
             RecordRef,
             Config#sp_config.codecs,
-            Config#sp_config.use_module_types_cache
+            Config#sp_config.module_types_cache
         )
     of
         continue -> erlang:error({type_not_supported, RecordType});
@@ -289,7 +289,7 @@ to_string(
     Data,
     Config
 ) ->
-    RemoteTypeInfo = spectra_module_types:get(Module, Config#sp_config.use_module_types_cache),
+    RemoteTypeInfo = spectra_module_types:get(Module, Config#sp_config.module_types_cache),
     RemoteType = spectra_type_info:get_type(RemoteTypeInfo, TypeName, TypeArity),
     case
         spectra_codec:try_codec_encode(
@@ -299,7 +299,7 @@ to_string(
             Data,
             RemoteRef,
             Config#sp_config.codecs,
-            Config#sp_config.use_module_types_cache
+            Config#sp_config.module_types_cache
         )
     of
         continue ->

--- a/src/spectra_string.erl
+++ b/src/spectra_string.erl
@@ -84,7 +84,7 @@ from_string(
     Type = spectra_type_info:get_type(TypeInfo, TypeName, Arity),
     case
         spectra_codec:try_codec_decode(
-            Mod, string, Type, String, UserTypeRef, Config#sp_config.codecs
+            Mod, string, Type, String, UserTypeRef, Config#sp_config.codecs, Config#sp_config.use_module_types_cache
         )
     of
         continue ->
@@ -98,7 +98,7 @@ from_string(TypeInfo, #sp_rec_ref{record_name = RecordName} = RecordRef, String,
     RecordType = spectra_type_info:get_record(TypeInfo, RecordName),
     case
         spectra_codec:try_codec_decode(
-            Mod, string, RecordType, String, RecordRef, Config#sp_config.codecs
+            Mod, string, RecordType, String, RecordRef, Config#sp_config.codecs, Config#sp_config.use_module_types_cache
         )
     of
         continue -> erlang:error({type_not_supported, RecordType});
@@ -114,7 +114,7 @@ from_string(
     RemoteType = spectra_type_info:get_type(RemoteTypeInfo, TypeName, TypeArity),
     case
         spectra_codec:try_codec_decode(
-            Module, string, RemoteType, String, RemoteRef, Config#sp_config.codecs
+            Module, string, RemoteType, String, RemoteRef, Config#sp_config.codecs, Config#sp_config.use_module_types_cache
         )
     of
         continue ->
@@ -233,7 +233,7 @@ to_string(
     Type = spectra_type_info:get_type(TypeInfo, TypeName, Arity),
     case
         spectra_codec:try_codec_encode(
-            Mod, string, Type, Data, UserTypeRef, Config#sp_config.codecs
+            Mod, string, Type, Data, UserTypeRef, Config#sp_config.codecs, Config#sp_config.use_module_types_cache
         )
     of
         continue ->
@@ -247,7 +247,7 @@ to_string(TypeInfo, #sp_rec_ref{record_name = RecordName} = RecordRef, Data, Con
     RecordType = spectra_type_info:get_record(TypeInfo, RecordName),
     case
         spectra_codec:try_codec_encode(
-            Mod, string, RecordType, Data, RecordRef, Config#sp_config.codecs
+            Mod, string, RecordType, Data, RecordRef, Config#sp_config.codecs, Config#sp_config.use_module_types_cache
         )
     of
         continue -> erlang:error({type_not_supported, RecordType});
@@ -263,7 +263,7 @@ to_string(
     RemoteType = spectra_type_info:get_type(RemoteTypeInfo, TypeName, TypeArity),
     case
         spectra_codec:try_codec_encode(
-            Module, string, RemoteType, Data, RemoteRef, Config#sp_config.codecs
+            Module, string, RemoteType, Data, RemoteRef, Config#sp_config.codecs, Config#sp_config.use_module_types_cache
         )
     of
         continue ->

--- a/src/spectra_string.erl
+++ b/src/spectra_string.erl
@@ -52,8 +52,7 @@ from_string(
             Type,
             String,
             UserTypeRef,
-            Config#sp_config.codecs,
-            Config#sp_config.module_types_cache
+            Config
         )
     of
         continue ->
@@ -72,8 +71,7 @@ from_string(TypeInfo, #sp_rec_ref{record_name = RecordName} = RecordRef, String,
             RecordType,
             String,
             RecordRef,
-            Config#sp_config.codecs,
-            Config#sp_config.module_types_cache
+            Config
         )
     of
         continue -> erlang:error({type_not_supported, RecordType});
@@ -94,8 +92,7 @@ from_string(
             RemoteType,
             String,
             RemoteRef,
-            Config#sp_config.codecs,
-            Config#sp_config.module_types_cache
+            Config
         )
     of
         continue ->
@@ -184,8 +181,7 @@ to_string(
             Type,
             Data,
             UserTypeRef,
-            Config#sp_config.codecs,
-            Config#sp_config.module_types_cache
+            Config
         )
     of
         continue ->
@@ -204,8 +200,7 @@ to_string(TypeInfo, #sp_rec_ref{record_name = RecordName} = RecordRef, Data, Con
             RecordType,
             Data,
             RecordRef,
-            Config#sp_config.codecs,
-            Config#sp_config.module_types_cache
+            Config
         )
     of
         continue -> erlang:error({type_not_supported, RecordType});
@@ -226,8 +221,7 @@ to_string(
             RemoteType,
             Data,
             RemoteRef,
-            Config#sp_config.codecs,
-            Config#sp_config.module_types_cache
+            Config
         )
     of
         continue ->

--- a/src/spectra_string.erl
+++ b/src/spectra_string.erl
@@ -83,7 +83,7 @@ from_string(
     String,
     Config
 ) ->
-    RemoteTypeInfo = spectra_module_types:get(Module, Config#sp_config.module_types_cache),
+    RemoteTypeInfo = spectra_module_types:get(Module, Config),
     RemoteType = spectra_type_info:get_type(RemoteTypeInfo, TypeName, TypeArity),
     case
         spectra_codec:try_codec_decode(
@@ -212,7 +212,7 @@ to_string(
     Data,
     Config
 ) ->
-    RemoteTypeInfo = spectra_module_types:get(Module, Config#sp_config.module_types_cache),
+    RemoteTypeInfo = spectra_module_types:get(Module, Config),
     RemoteType = spectra_type_info:get_type(RemoteTypeInfo, TypeName, TypeArity),
     case
         spectra_codec:try_codec_encode(

--- a/src/spectra_string.erl
+++ b/src/spectra_string.erl
@@ -55,7 +55,7 @@ from_string(
         )
     of
         continue ->
-            TypeWithoutVars = apply_args(TypeInfo, Type, Args),
+            TypeWithoutVars = spectra_util:apply_args(TypeInfo, Type, Args),
             from_string(TypeInfo, TypeWithoutVars, String, Config);
         Result ->
             Result
@@ -94,7 +94,7 @@ from_string(
         )
     of
         continue ->
-            TypeWithoutVars = apply_args(RemoteTypeInfo, RemoteType, Args),
+            TypeWithoutVars = spectra_util:apply_args(RemoteTypeInfo, RemoteType, Args),
             from_string(RemoteTypeInfo, TypeWithoutVars, String, Config);
         Result ->
             Result
@@ -182,7 +182,7 @@ to_string(
         )
     of
         continue ->
-            TypeWithoutVars = apply_args(TypeInfo, Type, Args),
+            TypeWithoutVars = spectra_util:apply_args(TypeInfo, Type, Args),
             to_string(TypeInfo, TypeWithoutVars, Data, Config);
         Result ->
             Result
@@ -221,7 +221,7 @@ to_string(
         )
     of
         continue ->
-            TypeWithoutVars = apply_args(RemoteTypeInfo, RemoteType, Args),
+            TypeWithoutVars = spectra_util:apply_args(RemoteTypeInfo, RemoteType, Args),
             to_string(RemoteTypeInfo, TypeWithoutVars, Data, Config);
         Result ->
             Result
@@ -423,19 +423,6 @@ do_first(Fun, TypeInfo, [Type | Rest], String, Config, ErrorsAcc) ->
         {error, Errors} ->
             do_first(Fun, TypeInfo, Rest, String, Config, [{Type, Errors} | ErrorsAcc])
     end.
-
-apply_args(TypeInfo, Type, TypeArgs) when is_list(TypeArgs) ->
-    ArgNames = arg_names(Type),
-    NamedTypes =
-        maps:from_list(
-            lists:zip(ArgNames, TypeArgs)
-        ),
-    spectra_util:type_replace_vars(TypeInfo, Type, NamedTypes).
-
-arg_names(#sp_type_with_variables{vars = Args}) ->
-    Args;
-arg_names(_) ->
-    [].
 
 -spec convert_type_to_string(
     Type :: spectra:simple_types(), Data :: dynamic(), Config :: spectra:sp_config() | undefined

--- a/src/spectra_string.erl
+++ b/src/spectra_string.erl
@@ -43,11 +43,10 @@ from_string(
     String,
     Config
 ) ->
-    Mod = spectra_type_info:get_module(TypeInfo),
     Type = spectra_type_info:get_type(TypeInfo, TypeName, Arity),
     case
         spectra_codec:try_codec_decode(
-            Mod,
+            TypeInfo,
             string,
             Type,
             String,
@@ -62,11 +61,10 @@ from_string(
             Result
     end;
 from_string(TypeInfo, #sp_rec_ref{record_name = RecordName} = RecordRef, String, Config) ->
-    Mod = spectra_type_info:get_module(TypeInfo),
     RecordType = spectra_type_info:get_record(TypeInfo, RecordName),
     case
         spectra_codec:try_codec_decode(
-            Mod,
+            TypeInfo,
             string,
             RecordType,
             String,
@@ -87,7 +85,7 @@ from_string(
     RemoteType = spectra_type_info:get_type(RemoteTypeInfo, TypeName, TypeArity),
     case
         spectra_codec:try_codec_decode(
-            Module,
+            RemoteTypeInfo,
             string,
             RemoteType,
             String,
@@ -172,11 +170,10 @@ to_string(
     Data,
     Config
 ) ->
-    Mod = spectra_type_info:get_module(TypeInfo),
     Type = spectra_type_info:get_type(TypeInfo, TypeName, Arity),
     case
         spectra_codec:try_codec_encode(
-            Mod,
+            TypeInfo,
             string,
             Type,
             Data,
@@ -191,11 +188,10 @@ to_string(
             Result
     end;
 to_string(TypeInfo, #sp_rec_ref{record_name = RecordName} = RecordRef, Data, Config) ->
-    Mod = spectra_type_info:get_module(TypeInfo),
     RecordType = spectra_type_info:get_record(TypeInfo, RecordName),
     case
         spectra_codec:try_codec_encode(
-            Mod,
+            TypeInfo,
             string,
             RecordType,
             Data,
@@ -216,7 +212,7 @@ to_string(
     RemoteType = spectra_type_info:get_type(RemoteTypeInfo, TypeName, TypeArity),
     case
         spectra_codec:try_codec_encode(
-            Module,
+            RemoteTypeInfo,
             string,
             RemoteType,
             Data,

--- a/src/spectra_string.erl
+++ b/src/spectra_string.erl
@@ -1,52 +1,15 @@
 -module(spectra_string).
 
--export([from_string/3, from_string/4, to_string/3, to_string/4]).
+-export([from_string/4, to_string/4]).
 
 -ignore_xref([
-    {spectra_string, from_string, 3},
     {spectra_string, from_string, 4},
-    {spectra_string, to_string, 3},
     {spectra_string, to_string, 4}
 ]).
 
 -include("../include/spectra_internal.hrl").
 
 %% API
-
--doc """
-Converts a string value to an Erlang value based on a type specification.
-
-This function validates the given string value against the specified type definition
-and converts it to the corresponding Erlang value.
-
-Equivalent to calling from_string/4 with a default configuration.
-
-### Returns
-{ok, ErlangValue} if conversion succeeds, or {error, Errors} if validation fails
-""".
--doc #{
-    params =>
-        #{
-            "String" => "The string value to convert to Erlang format",
-            "Type" => "The type specification (spectra:sp_type())",
-            "TypeInfo" => "The type information containing type definitions"
-        }
-}.
-
--spec from_string(
-    TypeInfo :: spectra:type_info(),
-    Type :: spectra:sp_type(),
-    String :: list()
-) ->
-    {ok, dynamic()} | {error, [spectra:error()]}.
-from_string(TypeInfo, Type, String) ->
-    CacheMode = application:get_env(spectra, module_types_cache, local),
-    Codecs = application:get_env(spectra, codecs, #{}),
-    CheckUnicode = application:get_env(spectra, check_unicode, false),
-    Config = #sp_config{
-        module_types_cache = CacheMode, codecs = Codecs, check_unicode = CheckUnicode
-    },
-    from_string(TypeInfo, Type, String, Config).
 
 -doc """
 Converts a string value to an Erlang value based on a type specification.
@@ -179,41 +142,6 @@ from_string(_TypeInfo, #sp_rec{} = T, _String, _Config) ->
     erlang:error({type_not_supported, T});
 from_string(_TypeInfo, Type, String, _Config) ->
     {error, [sp_error:type_mismatch(Type, String)]}.
-
--doc """
-Converts an Erlang value to a string based on a type specification.
-
-This function validates the given Erlang value against the specified type definition
-and converts it to a string representation.
-
-Equivalent to calling to_string/4 with a default configuration.
-
-### Returns
-{ok, String} if conversion succeeds, or {error, Errors} if validation fails
-""".
--doc #{
-    params =>
-        #{
-            "Data" => "The Erlang value to convert to string format",
-            "Type" => "The type specification (spectra:sp_type())",
-            "TypeInfo" => "The type information containing type definitions"
-        }
-}.
-
--spec to_string(
-    TypeInfo :: spectra:type_info(),
-    Type :: spectra:sp_type(),
-    Data :: dynamic()
-) ->
-    {ok, string()} | {error, [spectra:error()]}.
-to_string(TypeInfo, Type, Data) ->
-    CacheMode = application:get_env(spectra, module_types_cache, local),
-    Codecs = application:get_env(spectra, codecs, #{}),
-    CheckUnicode = application:get_env(spectra, check_unicode, false),
-    Config = #sp_config{
-        module_types_cache = CacheMode, codecs = Codecs, check_unicode = CheckUnicode
-    },
-    to_string(TypeInfo, Type, Data, Config).
 
 -doc """
 Converts an Erlang value to a string based on a type specification.

--- a/src/spectra_string.erl
+++ b/src/spectra_string.erl
@@ -1,8 +1,13 @@
 -module(spectra_string).
 
--export([from_string/3, to_string/3]).
+-export([from_string/3, from_string/4, to_string/3, to_string/4]).
 
--ignore_xref([{spectra_string, from_string, 3}, {spectra_string, to_string, 3}]).
+-ignore_xref([
+    {spectra_string, from_string, 3},
+    {spectra_string, from_string, 4},
+    {spectra_string, to_string, 3},
+    {spectra_string, to_string, 4}
+]).
 
 -include("../include/spectra_internal.hrl").
 
@@ -13,6 +18,8 @@ Converts a string value to an Erlang value based on a type specification.
 
 This function validates the given string value against the specified type definition
 and converts it to the corresponding Erlang value.
+
+Equivalent to calling from_string/4 with a default configuration.
 
 ### Returns
 {ok, ErlangValue} if conversion succeeds, or {error, Errors} if validation fails
@@ -32,42 +39,91 @@ and converts it to the corresponding Erlang value.
     String :: list()
 ) ->
     {ok, dynamic()} | {error, [spectra:error()]}.
+from_string(TypeInfo, Type, String) ->
+    UseCache = application:get_env(spectra, use_module_types_cache, false),
+    Codecs = application:get_env(spectra, codecs, #{}),
+    CheckUnicode = application:get_env(spectra, check_unicode, false),
+    Config = #sp_config{
+        use_module_types_cache = UseCache, codecs = Codecs, check_unicode = CheckUnicode
+    },
+    from_string(TypeInfo, Type, String, Config).
+
+-doc """
+Converts a string value to an Erlang value based on a type specification.
+
+This function validates the given string value against the specified type definition
+and converts it to the corresponding Erlang value.
+
+### Returns
+{ok, ErlangValue} if conversion succeeds, or {error, Errors} if validation fails
+""".
+-doc #{
+    params =>
+        #{
+            "Config" => "Runtime configuration",
+            "String" => "The string value to convert to Erlang format",
+            "Type" => "The type specification (spectra:sp_type())",
+            "TypeInfo" => "The type information containing type definitions"
+        }
+}.
+
+-spec from_string(
+    TypeInfo :: spectra:type_info(),
+    Type :: spectra:sp_type(),
+    String :: list(),
+    Config :: spectra:sp_config()
+) ->
+    {ok, dynamic()} | {error, [spectra:error()]}.
 from_string(
     TypeInfo,
     #sp_user_type_ref{type_name = TypeName, variables = Args, arity = Arity} = UserTypeRef,
-    String
+    String,
+    Config
 ) ->
     Mod = spectra_type_info:get_module(TypeInfo),
     Type = spectra_type_info:get_type(TypeInfo, TypeName, Arity),
-    case spectra_codec:try_codec_decode(Mod, string, Type, String, UserTypeRef) of
+    case
+        spectra_codec:try_codec_decode(
+            Mod, string, Type, String, UserTypeRef, Config#sp_config.codecs
+        )
+    of
         continue ->
             TypeWithoutVars = apply_args(TypeInfo, Type, Args),
-            from_string(TypeInfo, TypeWithoutVars, String);
+            from_string(TypeInfo, TypeWithoutVars, String, Config);
         Result ->
             Result
     end;
-from_string(TypeInfo, #sp_rec_ref{record_name = RecordName} = RecordRef, String) ->
+from_string(TypeInfo, #sp_rec_ref{record_name = RecordName} = RecordRef, String, Config) ->
     Mod = spectra_type_info:get_module(TypeInfo),
     RecordType = spectra_type_info:get_record(TypeInfo, RecordName),
-    case spectra_codec:try_codec_decode(Mod, string, RecordType, String, RecordRef) of
+    case
+        spectra_codec:try_codec_decode(
+            Mod, string, RecordType, String, RecordRef, Config#sp_config.codecs
+        )
+    of
         continue -> erlang:error({type_not_supported, RecordType});
         Result -> Result
     end;
 from_string(
     _TypeInfo,
     #sp_remote_type{mfargs = {Module, TypeName, Args}, arity = TypeArity} = RemoteRef,
-    String
+    String,
+    Config
 ) ->
-    RemoteTypeInfo = spectra_module_types:get(Module),
+    RemoteTypeInfo = spectra_module_types:get(Module, Config#sp_config.use_module_types_cache),
     RemoteType = spectra_type_info:get_type(RemoteTypeInfo, TypeName, TypeArity),
-    case spectra_codec:try_codec_decode(Module, string, RemoteType, String, RemoteRef) of
+    case
+        spectra_codec:try_codec_decode(
+            Module, string, RemoteType, String, RemoteRef, Config#sp_config.codecs
+        )
+    of
         continue ->
             TypeWithoutVars = apply_args(RemoteTypeInfo, RemoteType, Args),
-            from_string(RemoteTypeInfo, TypeWithoutVars, String);
+            from_string(RemoteTypeInfo, TypeWithoutVars, String, Config);
         Result ->
             Result
     end;
-from_string(_TypeInfo, #sp_simple_type{type = NotSupported} = T, _String) when
+from_string(_TypeInfo, #sp_simple_type{type = NotSupported} = T, _String, _Config) when
     NotSupported =:= pid orelse
         NotSupported =:= port orelse
         NotSupported =:= reference orelse
@@ -76,7 +132,7 @@ from_string(_TypeInfo, #sp_simple_type{type = NotSupported} = T, _String) when
         NotSupported =:= none
 ->
     erlang:error({type_not_supported, T});
-from_string(_TypeInfo, #sp_simple_type{type = PrimaryType}, String) ->
+from_string(_TypeInfo, #sp_simple_type{type = PrimaryType}, String, _Config) ->
     convert_string_to_type(PrimaryType, String);
 from_string(
     _TypeInfo,
@@ -86,7 +142,8 @@ from_string(
         upper_bound = Max
     } =
         Range,
-    String
+    String,
+    _Config
 ) ->
     case convert_string_to_type(integer, String) of
         {ok, Value} when Min =< Value, Value =< Max ->
@@ -96,13 +153,13 @@ from_string(
         {error, Reason} ->
             {error, Reason}
     end;
-from_string(_TypeInfo, #sp_literal{value = Literal}, String) ->
+from_string(_TypeInfo, #sp_literal{value = Literal}, String, _Config) ->
     try_convert_string_to_literal(Literal, String);
-from_string(TypeInfo, #sp_union{} = Type, String) ->
-    union(fun from_string/3, TypeInfo, Type, String);
-from_string(_TypeInfo, #sp_rec{} = T, _String) ->
+from_string(TypeInfo, #sp_union{} = Type, String, Config) ->
+    union(fun from_string/4, TypeInfo, Type, String, Config);
+from_string(_TypeInfo, #sp_rec{} = T, _String, _Config) ->
     erlang:error({type_not_supported, T});
-from_string(_TypeInfo, Type, String) ->
+from_string(_TypeInfo, Type, String, _Config) ->
     {error, [sp_error:type_mismatch(Type, String)]}.
 
 -doc """
@@ -110,6 +167,8 @@ Converts an Erlang value to a string based on a type specification.
 
 This function validates the given Erlang value against the specified type definition
 and converts it to a string representation.
+
+Equivalent to calling to_string/4 with a default configuration.
 
 ### Returns
 {ok, String} if conversion succeeds, or {error, Errors} if validation fails
@@ -129,42 +188,91 @@ and converts it to a string representation.
     Data :: dynamic()
 ) ->
     {ok, string()} | {error, [spectra:error()]}.
+to_string(TypeInfo, Type, Data) ->
+    UseCache = application:get_env(spectra, use_module_types_cache, false),
+    Codecs = application:get_env(spectra, codecs, #{}),
+    CheckUnicode = application:get_env(spectra, check_unicode, false),
+    Config = #sp_config{
+        use_module_types_cache = UseCache, codecs = Codecs, check_unicode = CheckUnicode
+    },
+    to_string(TypeInfo, Type, Data, Config).
+
+-doc """
+Converts an Erlang value to a string based on a type specification.
+
+This function validates the given Erlang value against the specified type definition
+and converts it to a string representation.
+
+### Returns
+{ok, String} if conversion succeeds, or {error, Errors} if validation fails
+""".
+-doc #{
+    params =>
+        #{
+            "Config" => "Runtime configuration",
+            "Data" => "The Erlang value to convert to string format",
+            "Type" => "The type specification (spectra:sp_type())",
+            "TypeInfo" => "The type information containing type definitions"
+        }
+}.
+
+-spec to_string(
+    TypeInfo :: spectra:type_info(),
+    Type :: spectra:sp_type(),
+    Data :: dynamic(),
+    Config :: spectra:sp_config()
+) ->
+    {ok, string()} | {error, [spectra:error()]}.
 to_string(
     TypeInfo,
     #sp_user_type_ref{type_name = TypeName, variables = Args, arity = Arity} = UserTypeRef,
-    Data
+    Data,
+    Config
 ) ->
     Mod = spectra_type_info:get_module(TypeInfo),
     Type = spectra_type_info:get_type(TypeInfo, TypeName, Arity),
-    case spectra_codec:try_codec_encode(Mod, string, Type, Data, UserTypeRef) of
+    case
+        spectra_codec:try_codec_encode(
+            Mod, string, Type, Data, UserTypeRef, Config#sp_config.codecs
+        )
+    of
         continue ->
             TypeWithoutVars = apply_args(TypeInfo, Type, Args),
-            to_string(TypeInfo, TypeWithoutVars, Data);
+            to_string(TypeInfo, TypeWithoutVars, Data, Config);
         Result ->
             Result
     end;
-to_string(TypeInfo, #sp_rec_ref{record_name = RecordName} = RecordRef, Data) ->
+to_string(TypeInfo, #sp_rec_ref{record_name = RecordName} = RecordRef, Data, Config) ->
     Mod = spectra_type_info:get_module(TypeInfo),
     RecordType = spectra_type_info:get_record(TypeInfo, RecordName),
-    case spectra_codec:try_codec_encode(Mod, string, RecordType, Data, RecordRef) of
+    case
+        spectra_codec:try_codec_encode(
+            Mod, string, RecordType, Data, RecordRef, Config#sp_config.codecs
+        )
+    of
         continue -> erlang:error({type_not_supported, RecordType});
         Result -> Result
     end;
 to_string(
     _TypeInfo,
     #sp_remote_type{mfargs = {Module, TypeName, Args}, arity = TypeArity} = RemoteRef,
-    Data
+    Data,
+    Config
 ) ->
-    RemoteTypeInfo = spectra_module_types:get(Module),
+    RemoteTypeInfo = spectra_module_types:get(Module, Config#sp_config.use_module_types_cache),
     RemoteType = spectra_type_info:get_type(RemoteTypeInfo, TypeName, TypeArity),
-    case spectra_codec:try_codec_encode(Module, string, RemoteType, Data, RemoteRef) of
+    case
+        spectra_codec:try_codec_encode(
+            Module, string, RemoteType, Data, RemoteRef, Config#sp_config.codecs
+        )
+    of
         continue ->
             TypeWithoutVars = apply_args(RemoteTypeInfo, RemoteType, Args),
-            to_string(RemoteTypeInfo, TypeWithoutVars, Data);
+            to_string(RemoteTypeInfo, TypeWithoutVars, Data, Config);
         Result ->
             Result
     end;
-to_string(_TypeInfo, #sp_simple_type{type = NotSupported} = T, _Data) when
+to_string(_TypeInfo, #sp_simple_type{type = NotSupported} = T, _Data, _Config) when
     NotSupported =:= pid orelse
         NotSupported =:= port orelse
         NotSupported =:= reference orelse
@@ -173,8 +281,8 @@ to_string(_TypeInfo, #sp_simple_type{type = NotSupported} = T, _Data) when
         NotSupported =:= none
 ->
     erlang:error({type_not_supported, T});
-to_string(_TypeInfo, #sp_simple_type{type = PrimaryType}, Data) ->
-    convert_type_to_string(PrimaryType, Data);
+to_string(_TypeInfo, #sp_simple_type{type = PrimaryType}, Data, Config) ->
+    convert_type_to_string(PrimaryType, Data, Config);
 to_string(
     _TypeInfo,
     #sp_range{
@@ -183,9 +291,10 @@ to_string(
         upper_bound = Max
     } =
         Range,
-    Data
+    Data,
+    _Config
 ) ->
-    case convert_type_to_string(integer, Data) of
+    case convert_type_to_string(integer, Data, undefined) of
         {ok, String} when Min =< Data, Data =< Max ->
             {ok, String};
         {ok, _String} when is_integer(Data) ->
@@ -193,13 +302,13 @@ to_string(
         {error, Reason} ->
             {error, Reason}
     end;
-to_string(_TypeInfo, #sp_literal{value = Literal}, Data) ->
+to_string(_TypeInfo, #sp_literal{value = Literal}, Data, _Config) ->
     try_convert_literal_to_string(Literal, Data);
-to_string(TypeInfo, #sp_union{} = Type, Data) ->
-    union(fun to_string/3, TypeInfo, Type, Data);
-to_string(_TypeInfo, #sp_rec{} = T, _Data) ->
+to_string(TypeInfo, #sp_union{} = Type, Data, Config) ->
+    union(fun to_string/4, TypeInfo, Type, Data, Config);
+to_string(_TypeInfo, #sp_rec{} = T, _Data, _Config) ->
     erlang:error({type_not_supported, T});
-to_string(_TypeInfo, Type, Data) ->
+to_string(_TypeInfo, Type, Data, _Config) ->
     {error, [sp_error:type_mismatch(Type, Data)]}.
 
 %% INTERNAL
@@ -343,22 +452,22 @@ try_convert_string_to_literal(Literal, String) ->
         )
     ]}.
 
-union(Fun, TypeInfo, #sp_union{types = Types} = T, String) ->
-    case do_first(Fun, TypeInfo, Types, String, []) of
+union(Fun, TypeInfo, #sp_union{types = Types} = T, String, Config) ->
+    case do_first(Fun, TypeInfo, Types, String, Config, []) of
         {error, UnionErrors} ->
             {error, [sp_error:no_match(T, String, UnionErrors)]};
         Result ->
             Result
     end.
 
-do_first(_Fun, _TypeInfo, [], _String, Errors) ->
+do_first(_Fun, _TypeInfo, [], _String, _Config, Errors) ->
     {error, Errors};
-do_first(Fun, TypeInfo, [Type | Rest], String, ErrorsAcc) ->
-    case Fun(TypeInfo, Type, String) of
+do_first(Fun, TypeInfo, [Type | Rest], String, Config, ErrorsAcc) ->
+    case Fun(TypeInfo, Type, String, Config) of
         {ok, Result} ->
             {ok, Result};
         {error, Errors} ->
-            do_first(Fun, TypeInfo, Rest, String, [{Type, Errors} | ErrorsAcc])
+            do_first(Fun, TypeInfo, Rest, String, Config, [{Type, Errors} | ErrorsAcc])
     end.
 
 apply_args(TypeInfo, Type, TypeArgs) when is_list(TypeArgs) ->
@@ -374,76 +483,77 @@ arg_names(#sp_type_with_variables{vars = Args}) ->
 arg_names(_) ->
     [].
 
-convert_type_to_string(integer, Data) when is_integer(Data) ->
+-spec convert_type_to_string(
+    Type :: spectra:simple_types(), Data :: dynamic(), Config :: spectra:sp_config() | undefined
+) ->
+    {ok, string()} | {error, [spectra:error()]}.
+convert_type_to_string(integer, Data, _Config) when is_integer(Data) ->
     {ok, integer_to_list(Data)};
-convert_type_to_string(integer, Data) ->
+convert_type_to_string(integer, Data, _Config) ->
     {error, [sp_error:type_mismatch(#sp_simple_type{type = integer}, Data)]};
-convert_type_to_string(float, Data) when is_float(Data) ->
+convert_type_to_string(float, Data, _Config) when is_float(Data) ->
     {ok, float_to_list(Data)};
-convert_type_to_string(float, Data) ->
+convert_type_to_string(float, Data, _Config) ->
     {error, [sp_error:type_mismatch(#sp_simple_type{type = float}, Data)]};
-convert_type_to_string(number, Data) when is_number(Data) ->
+convert_type_to_string(number, Data, _Config) when is_number(Data) ->
     if
         is_integer(Data) ->
             {ok, integer_to_list(Data)};
         is_float(Data) ->
             {ok, float_to_list(Data)}
     end;
-convert_type_to_string(number, Data) ->
+convert_type_to_string(number, Data, _Config) ->
     {error, [sp_error:type_mismatch(#sp_simple_type{type = number}, Data)]};
-convert_type_to_string(boolean, true) ->
+convert_type_to_string(boolean, true, _Config) ->
     {ok, "true"};
-convert_type_to_string(boolean, false) ->
+convert_type_to_string(boolean, false, _Config) ->
     {ok, "false"};
-convert_type_to_string(boolean, Data) ->
+convert_type_to_string(boolean, Data, _Config) ->
     {error, [sp_error:type_mismatch(#sp_simple_type{type = boolean}, Data)]};
-convert_type_to_string(atom, Data) when is_atom(Data) ->
+convert_type_to_string(atom, Data, _Config) when is_atom(Data) ->
     {ok, atom_to_list(Data)};
-convert_type_to_string(atom, Data) ->
+convert_type_to_string(atom, Data, _Config) ->
     {error, [sp_error:type_mismatch(#sp_simple_type{type = atom}, Data)]};
-convert_type_to_string(string, Data) when is_list(Data) ->
-    list_to_charlist(Data);
-convert_type_to_string(string, Data) ->
+convert_type_to_string(string, Data, Config) when is_list(Data) ->
+    list_to_charlist(Data, Config);
+convert_type_to_string(string, Data, _Config) ->
     {error, [sp_error:type_mismatch(#sp_simple_type{type = string}, Data)]};
-convert_type_to_string(nonempty_string, Data) when is_list(Data), Data =/= [] ->
-    list_to_charlist(Data);
-convert_type_to_string(nonempty_string, Data) ->
+convert_type_to_string(nonempty_string, Data, Config) when is_list(Data), Data =/= [] ->
+    list_to_charlist(Data, Config);
+convert_type_to_string(nonempty_string, Data, _Config) ->
     {error, [sp_error:type_mismatch(#sp_simple_type{type = nonempty_string}, Data)]};
-convert_type_to_string(binary, Data) when is_binary(Data) ->
+convert_type_to_string(binary, Data, _Config) when is_binary(Data) ->
     {ok, binary_to_list(Data)};
-convert_type_to_string(binary, Data) ->
+convert_type_to_string(binary, Data, _Config) ->
     {error, [sp_error:type_mismatch(#sp_simple_type{type = binary}, Data)]};
-convert_type_to_string(nonempty_binary, Data) when is_binary(Data), Data =/= <<>> ->
+convert_type_to_string(nonempty_binary, Data, _Config) when is_binary(Data), Data =/= <<>> ->
     {ok, binary_to_list(Data)};
-convert_type_to_string(nonempty_binary, Data) ->
+convert_type_to_string(nonempty_binary, Data, _Config) ->
     {error, [sp_error:type_mismatch(#sp_simple_type{type = nonempty_binary}, Data)]};
-convert_type_to_string(non_neg_integer, Data) when is_integer(Data), Data >= 0 ->
+convert_type_to_string(non_neg_integer, Data, _Config) when is_integer(Data), Data >= 0 ->
     {ok, integer_to_list(Data)};
-convert_type_to_string(non_neg_integer, Data) ->
+convert_type_to_string(non_neg_integer, Data, _Config) ->
     {error, [sp_error:type_mismatch(#sp_simple_type{type = non_neg_integer}, Data)]};
-convert_type_to_string(pos_integer, Data) when is_integer(Data), Data > 0 ->
+convert_type_to_string(pos_integer, Data, _Config) when is_integer(Data), Data > 0 ->
     {ok, integer_to_list(Data)};
-convert_type_to_string(pos_integer, Data) ->
+convert_type_to_string(pos_integer, Data, _Config) ->
     {error, [sp_error:type_mismatch(#sp_simple_type{type = pos_integer}, Data)]};
-convert_type_to_string(neg_integer, Data) when is_integer(Data), Data < 0 ->
+convert_type_to_string(neg_integer, Data, _Config) when is_integer(Data), Data < 0 ->
     {ok, integer_to_list(Data)};
-convert_type_to_string(neg_integer, Data) ->
+convert_type_to_string(neg_integer, Data, _Config) ->
     {error, [sp_error:type_mismatch(#sp_simple_type{type = neg_integer}, Data)]};
-convert_type_to_string(Type, Data) ->
+convert_type_to_string(Type, Data, _Config) ->
     {error, [sp_error:type_mismatch(#sp_simple_type{type = Type}, Data)]}.
 
-list_to_charlist(Data) ->
-    case application:get_env(spectra, check_unicode, false) of
-        true ->
-            case unicode:characters_to_list(Data) of
-                DataList when is_list(DataList) ->
-                    {ok, DataList};
-                _Other ->
-                    {error, [sp_error:type_mismatch(#sp_simple_type{type = string}, Data)]}
-            end;
-        false ->
-            {ok, Data}
-    end.
+list_to_charlist(Data, #sp_config{check_unicode = true}) ->
+    case unicode:characters_to_list(Data) of
+        DataList when is_list(DataList) ->
+            {ok, DataList};
+        _Other ->
+            {error, [sp_error:type_mismatch(#sp_simple_type{type = string}, Data)]}
+    end;
+list_to_charlist(Data, _Config) ->
+    {ok, Data}.
 
 -spec try_convert_literal_to_string(Literal :: spectra:literal_value(), Data :: dynamic()) ->
     {ok, string()} | {error, [spectra:error()]}.

--- a/src/spectra_type.erl
+++ b/src/spectra_type.erl
@@ -53,12 +53,7 @@ can_be_missing(TypeInfo, Type) ->
         #sp_type_with_variables{type = Type2} ->
             can_be_missing(TypeInfo, Type2);
         #sp_union{types = Types} ->
-            case lists:filtermap(fun(T) -> can_be_missing(TypeInfo, T) end, Types) of
-                [] ->
-                    false;
-                MissingValues ->
-                    {true, lists:last(MissingValues)}
-            end;
+            union_missing_value(TypeInfo, Types, false);
         #sp_literal{value = LiteralValue} when
             LiteralValue =:= nil orelse LiteralValue =:= undefined
         ->
@@ -68,6 +63,21 @@ can_be_missing(TypeInfo, Type) ->
             can_be_missing(TypeInfo, RefType);
         _ ->
             false
+    end.
+
+-spec union_missing_value(
+    TypeInfo :: spectra:type_info(),
+    Types :: [spectra:sp_type()],
+    Acc :: {true, spectra:missing_value()} | false
+) -> {true, spectra:missing_value()} | false.
+union_missing_value(_TypeInfo, [], Acc) ->
+    Acc;
+union_missing_value(TypeInfo, [Type | Rest], Acc) ->
+    case can_be_missing(TypeInfo, Type) of
+        false ->
+            union_missing_value(TypeInfo, Rest, Acc);
+        {true, _} = Missing ->
+            union_missing_value(TypeInfo, Rest, Missing)
     end.
 
 -doc "Extracts the meta map from any `sp_type()` record.".

--- a/src/spectra_type_info.erl
+++ b/src/spectra_type_info.erl
@@ -18,7 +18,7 @@ tracks whether the owning module implements the `spectra_codec` behaviour.
 -export([add_type/4, find_type/3, get_type/3]).
 -export([add_record/3, find_record/2, get_record/2]).
 -export([add_function/4, find_function/3]).
--export([find_codec/4]).
+-export([find_codec/3]).
 
 -export_type([type_info/0, type_key/0, function_key/0]).
 
@@ -98,15 +98,12 @@ Checks the supplied `Codecs` map first, then falls back to the module's own
 `spectra_codec` behaviour if it implements one. Calls `code:ensure_loaded/1`
 on any codec found in the map so it is ready before its callbacks are dispatched.
 
-The `CacheMode` flag is forwarded to `spectra_module_types:get/2` when a local
+The `Config` is forwarded to `spectra_module_types:get/2` when a local
 codec check is needed.
 """.
--spec find_codec(module(), spectra:sp_type_reference(), Codecs, CacheMode) ->
-    {ok, module()} | error
-when
-    Codecs :: #{spectra:codec_key() => module()},
-    CacheMode :: spectra:module_types_cache().
-find_codec(Mod, TypeRef, Codecs, CacheMode) ->
+-spec find_codec(module(), spectra:sp_type_reference(), spectra:sp_config()) ->
+    {ok, module()} | error.
+find_codec(Mod, TypeRef, #sp_config{codecs = Codecs, module_types_cache = CacheMode}) ->
     case maps:find({Mod, TypeRef}, Codecs) of
         {ok, CodecMod} ->
             code:ensure_loaded(CodecMod),

--- a/src/spectra_type_info.erl
+++ b/src/spectra_type_info.erl
@@ -98,19 +98,19 @@ Checks the supplied `Codecs` map first, then falls back to the module's own
 `spectra_codec` behaviour if it implements one. Calls `code:ensure_loaded/1`
 on any codec found in the map so it is ready before its callbacks are dispatched.
 
-The `UseCache` flag is forwarded to `spectra_module_types:get/2` when a local
+The `CacheMode` flag is forwarded to `spectra_module_types:get/2` when a local
 codec check is needed.
 """.
--spec find_codec(module(), spectra:sp_type_reference(), Codecs, UseCache) ->
+-spec find_codec(module(), spectra:sp_type_reference(), Codecs, CacheMode) ->
     {ok, module()} | error
 when
     Codecs :: #{spectra:codec_key() => module()},
-    UseCache :: boolean().
-find_codec(Mod, TypeRef, Codecs, UseCache) ->
+    CacheMode :: spectra:module_types_cache().
+find_codec(Mod, TypeRef, Codecs, CacheMode) ->
     case maps:find({Mod, TypeRef}, Codecs) of
         {ok, CodecMod} ->
             code:ensure_loaded(CodecMod),
             {ok, CodecMod};
         error ->
-            find_local_codec(spectra_module_types:get(Mod, UseCache))
+            find_local_codec(spectra_module_types:get(Mod, CacheMode))
     end.

--- a/src/spectra_type_info.erl
+++ b/src/spectra_type_info.erl
@@ -18,7 +18,7 @@ tracks whether the owning module implements the `spectra_codec` behaviour.
 -export([add_type/4, find_type/3, get_type/3]).
 -export([add_record/3, find_record/2, get_record/2]).
 -export([add_function/4, find_function/3]).
--export([find_codec/2]).
+-export([find_codec/4]).
 
 -export_type([type_info/0, type_key/0, function_key/0]).
 
@@ -94,18 +94,23 @@ find_local_codec(#type_info{implements_codec = false}) -> error.
 -doc """
 Resolves the codec module for `{Mod, TypeRef}`.
 
-Checks the application env (`{spectra, [{codecs, #{...}}]}`) first, then
-falls back to the module's own `spectra_codec` behaviour if it implements
-one. Calls `code:ensure_loaded/1` on any codec found in app env so it is
-ready before its callbacks are dispatched.
+Checks the supplied `Codecs` map first, then falls back to the module's own
+`spectra_codec` behaviour if it implements one. Calls `code:ensure_loaded/1`
+on any codec found in the map so it is ready before its callbacks are dispatched.
+
+The `UseCache` flag is forwarded to `spectra_module_types:get/2` when a local
+codec check is needed.
 """.
--spec find_codec(module(), spectra:sp_type_reference()) -> {ok, module()} | error.
-find_codec(Mod, TypeRef) ->
-    GlobalCodecs = application:get_env(spectra, codecs, #{}),
-    case maps:find({Mod, TypeRef}, GlobalCodecs) of
+-spec find_codec(module(), spectra:sp_type_reference(), Codecs, UseCache) ->
+    {ok, module()} | error
+when
+    Codecs :: #{spectra:codec_key() => module()},
+    UseCache :: boolean().
+find_codec(Mod, TypeRef, Codecs, UseCache) ->
+    case maps:find({Mod, TypeRef}, Codecs) of
         {ok, CodecMod} ->
             code:ensure_loaded(CodecMod),
             {ok, CodecMod};
         error ->
-            find_local_codec(spectra_module_types:get(Mod))
+            find_local_codec(spectra_module_types:get(Mod, UseCache))
     end.

--- a/src/spectra_type_info.erl
+++ b/src/spectra_type_info.erl
@@ -92,22 +92,22 @@ find_local_codec(#type_info{implements_codec = true, module = M}) -> {ok, M};
 find_local_codec(#type_info{implements_codec = false}) -> error.
 
 -doc """
-Resolves the codec module for `{Mod, TypeRef}`.
+Resolves the codec module for `{Mod, TypeRef}` using a pre-loaded `TypeInfo`.
 
-Checks the supplied `Codecs` map first, then falls back to the module's own
-`spectra_codec` behaviour if it implements one. Calls `code:ensure_loaded/1`
-on any codec found in the map so it is ready before its callbacks are dispatched.
-
-The `Config` is forwarded to `spectra_module_types:get/2` when a local
-codec check is needed.
+Checks the global codecs map first, then falls back to the module's own
+`spectra_codec` behaviour if it implements one. Uses the already-loaded
+`TypeInfo` to avoid a cache lookup. The caller must ensure that `TypeInfo`
+is the type info for the module that owns `TypeRef`.
 """.
--spec find_codec(module(), spectra:sp_type_reference(), spectra:sp_config()) ->
+-spec find_codec(type_info(), spectra:sp_type_reference(), spectra:sp_config()) ->
     {ok, module()} | error.
-find_codec(Mod, TypeRef, #sp_config{codecs = Codecs} = Config) ->
+find_codec(TypeInfo, TypeRef, #sp_config{codecs = Codecs}) ->
+    Mod = get_module(TypeInfo),
     case maps:find({Mod, TypeRef}, Codecs) of
         {ok, CodecMod} ->
             code:ensure_loaded(CodecMod),
             {ok, CodecMod};
         error ->
-            find_local_codec(spectra_module_types:get(Mod, Config))
+            find_local_codec(TypeInfo)
     end.
+

--- a/src/spectra_type_info.erl
+++ b/src/spectra_type_info.erl
@@ -103,11 +103,11 @@ codec check is needed.
 """.
 -spec find_codec(module(), spectra:sp_type_reference(), spectra:sp_config()) ->
     {ok, module()} | error.
-find_codec(Mod, TypeRef, #sp_config{codecs = Codecs, module_types_cache = CacheMode}) ->
+find_codec(Mod, TypeRef, #sp_config{codecs = Codecs} = Config) ->
     case maps:find({Mod, TypeRef}, Codecs) of
         {ok, CodecMod} ->
             code:ensure_loaded(CodecMod),
             {ok, CodecMod};
         error ->
-            find_local_codec(spectra_module_types:get(Mod, CacheMode))
+            find_local_codec(spectra_module_types:get(Mod, Config))
     end.

--- a/src/spectra_type_info.erl
+++ b/src/spectra_type_info.erl
@@ -103,10 +103,9 @@ is the type info for the module that owns `TypeRef`.
     {ok, module()} | error.
 find_codec(TypeInfo, TypeRef, #sp_config{codecs = Codecs}) ->
     Mod = get_module(TypeInfo),
-    case maps:find({Mod, TypeRef}, Codecs) of
-        {ok, CodecMod} ->
-            code:ensure_loaded(CodecMod),
+    case Codecs of
+        #{{Mod, TypeRef} := CodecMod} ->
             {ok, CodecMod};
-        error ->
+        #{} ->
             find_local_codec(TypeInfo)
     end.

--- a/src/spectra_type_info.erl
+++ b/src/spectra_type_info.erl
@@ -110,4 +110,3 @@ find_codec(TypeInfo, TypeRef, #sp_config{codecs = Codecs}) ->
         error ->
             find_local_codec(TypeInfo)
     end.
-

--- a/src/spectra_util.erl
+++ b/src/spectra_util.erl
@@ -228,5 +228,5 @@ type_replace_vars(
     #sp_remote_type{
         mfargs = {Module, TypeName, ResolvedArgs}, arity = length(ResolvedArgs), meta = Meta
     };
-type_replace_vars(_TypeInfo, Type, _NamedTypes) ->
+type_replace_vars(_TypeInfo, Type, #{}) ->
     Type.

--- a/src/spectra_util.erl
+++ b/src/spectra_util.erl
@@ -2,6 +2,7 @@
 
 -export([
     test_abs_code/1,
+    apply_args/3,
     fold_until_error/3,
     map_until_error/2,
     normalize_type_ref/2,
@@ -55,6 +56,23 @@ test_abs_code(Module) ->
         Class:Reason:Stacktrace ->
             {error, {Class, Reason, Stacktrace}}
     end.
+
+-spec apply_args(spectra:type_info(), spectra:sp_type(), [spectra:sp_type()]) ->
+    spectra:sp_type().
+apply_args(_TypeInfo, Type, []) ->
+    Type;
+apply_args(TypeInfo, Type, TypeArgs) when is_list(TypeArgs) ->
+    ArgNames = arg_names(Type),
+    NamedTypes =
+        maps:from_list(
+            lists:zip(ArgNames, TypeArgs)
+        ),
+    type_replace_vars(TypeInfo, Type, NamedTypes).
+
+arg_names(#sp_type_with_variables{vars = Args}) ->
+    Args;
+arg_names(_) ->
+    [].
 
 -spec fold_until_error(
     Fun ::

--- a/test/codec_animal_codec.erl
+++ b/test/codec_animal_codec.erl
@@ -19,32 +19,52 @@
 -type zoo() :: [codec_animal_codec:animal()].
 
 -export_type([animal/0, cat/0, dog/0, zoo/0]).
--export([encode/6, decode/6]).
+-export([encode/7, decode/7]).
 
--spec encode(atom(), module(), spectra:sp_type_reference(), dynamic(), spectra:sp_type(), term()) ->
+-spec encode(
+    atom(),
+    module(),
+    spectra:sp_type_reference(),
+    dynamic(),
+    spectra:sp_type(),
+    term(),
+    spectra:sp_config()
+) ->
     spectra:codec_encode_result().
-encode(Format, _Mod, {type, animal, 0}, #cat{} = Cat, _SpType, _Params) ->
+encode(Format, _Mod, {type, animal, 0}, #cat{} = Cat, _SpType, _Params, _Config) ->
     case spectra:encode(Format, ?MODULE, {type, cat, 0}, Cat, [pre_encoded]) of
         {ok, Fields} when is_map(Fields) -> {ok, maps:put(<<"type">>, <<"cat">>, Fields)};
         {error, _} = Err -> Err
     end;
-encode(Format, _Mod, {type, animal, 0}, #dog{} = Dog, _SpType, _Params) ->
+encode(Format, _Mod, {type, animal, 0}, #dog{} = Dog, _SpType, _Params, _Config) ->
     case spectra:encode(Format, ?MODULE, {type, dog, 0}, Dog, [pre_encoded]) of
         {ok, Fields} when is_map(Fields) -> {ok, maps:put(<<"type">>, <<"dog">>, Fields)};
         {error, _} = Err -> Err
     end;
-encode(_, _Mod, {type, animal, 0}, Data, _SpType, _Params) ->
+encode(_, _Mod, {type, animal, 0}, Data, _SpType, _Params, _Config) ->
     {error, [sp_error:type_mismatch({type, animal, 0}, Data)]};
-encode(_, _, _, _, _, _) ->
+encode(_, _, _, _, _, _, _) ->
     continue.
 
--spec decode(atom(), module(), spectra:sp_type_reference(), dynamic(), spectra:sp_type(), term()) ->
+-spec decode(
+    atom(),
+    module(),
+    spectra:sp_type_reference(),
+    dynamic(),
+    spectra:sp_type(),
+    term(),
+    spectra:sp_config()
+) ->
     spectra:codec_decode_result().
-decode(Format, _Mod, {type, animal, 0}, #{<<"type">> := <<"cat">>} = Json, _SpType, _Params) ->
+decode(
+    Format, _Mod, {type, animal, 0}, #{<<"type">> := <<"cat">>} = Json, _SpType, _Params, _Config
+) ->
     spectra:decode(Format, ?MODULE, {type, cat, 0}, maps:remove(<<"type">>, Json), [pre_decoded]);
-decode(Format, _Mod, {type, animal, 0}, #{<<"type">> := <<"dog">>} = Json, _SpType, _Params) ->
+decode(
+    Format, _Mod, {type, animal, 0}, #{<<"type">> := <<"dog">>} = Json, _SpType, _Params, _Config
+) ->
     spectra:decode(Format, ?MODULE, {type, dog, 0}, maps:remove(<<"type">>, Json), [pre_decoded]);
-decode(_, _Mod, {type, animal, 0}, Data, _SpType, _Params) ->
+decode(_, _Mod, {type, animal, 0}, Data, _SpType, _Params, _Config) ->
     {error, [sp_error:type_mismatch({type, animal, 0}, Data)]};
-decode(_, _, _, _, _, _) ->
+decode(_, _, _, _, _, _, _) ->
     continue.

--- a/test/codec_appenv_rec_codec.erl
+++ b/test/codec_appenv_rec_codec.erl
@@ -4,42 +4,64 @@
 
 -include("../include/spectra.hrl").
 
--export([encode/6, decode/6, schema/5]).
+-export([encode/7, decode/7, schema/6]).
 
--spec encode(atom(), module(), spectra:sp_type_reference(), dynamic(), spectra:sp_type(), term()) ->
+-spec encode(
+    atom(),
+    module(),
+    spectra:sp_type_reference(),
+    dynamic(),
+    spectra:sp_type(),
+    term(),
+    spectra:sp_config()
+) ->
     spectra:codec_encode_result().
-encode(json, codec_appenv_rec_module, {record, point2d}, #{x := X, y := Y}, _SpType, _Params) when
+encode(
+    json, codec_appenv_rec_module, {record, point2d}, #{x := X, y := Y}, _SpType, _Params, _Config
+) when
     is_number(X) andalso is_number(Y)
 ->
     {ok, [X, Y]};
-encode(json, codec_appenv_rec_module, {record, point2d}, {point2d, X, Y}, _SpType, _Params) when
+encode(
+    json, codec_appenv_rec_module, {record, point2d}, {point2d, X, Y}, _SpType, _Params, _Config
+) when
     is_number(X) andalso is_number(Y)
 ->
     {ok, [X, Y]};
-encode(json, codec_appenv_rec_module, {record, point2d}, Data, _SpType, _Params) ->
+encode(json, codec_appenv_rec_module, {record, point2d}, Data, _SpType, _Params, _Config) ->
     {error, [sp_error:type_mismatch({record, point2d}, Data)]};
-encode(_, _, _, _, _, _) ->
+encode(_, _, _, _, _, _, _) ->
     continue.
 
--spec decode(atom(), module(), spectra:sp_type_reference(), dynamic(), spectra:sp_type(), term()) ->
+-spec decode(
+    atom(),
+    module(),
+    spectra:sp_type_reference(),
+    dynamic(),
+    spectra:sp_type(),
+    term(),
+    spectra:sp_config()
+) ->
     spectra:codec_decode_result().
-decode(json, codec_appenv_rec_module, {record, point2d}, [X, Y], _SpType, _Params) when
+decode(json, codec_appenv_rec_module, {record, point2d}, [X, Y], _SpType, _Params, _Config) when
     is_number(X) andalso is_number(Y)
 ->
     {ok, #{x => X, y => Y}};
-decode(json, codec_appenv_rec_module, {record, point2d}, Data, _SpType, _Params) ->
+decode(json, codec_appenv_rec_module, {record, point2d}, Data, _SpType, _Params, _Config) ->
     {error, [sp_error:type_mismatch({record, point2d}, Data)]};
-decode(_, _, _, _, _, _) ->
+decode(_, _, _, _, _, _, _) ->
     continue.
 
--spec schema(atom(), module(), spectra:sp_type_reference(), spectra:sp_type(), term()) ->
+-spec schema(
+    atom(), module(), spectra:sp_type_reference(), spectra:sp_type(), term(), spectra:sp_config()
+) ->
     map() | continue.
-schema(json_schema, codec_appenv_rec_module, {record, point2d}, _SpType, _Params) ->
+schema(json_schema, codec_appenv_rec_module, {record, point2d}, _SpType, _Params, _Config) ->
     #{
         type => <<"array">>,
         items => #{type => <<"number">>},
         minItems => 2,
         maxItems => 2
     };
-schema(_, _, _, _, _) ->
+schema(_, _, _, _, _, _) ->
     continue.

--- a/test/codec_appenv_type_codec.erl
+++ b/test/codec_appenv_type_codec.erl
@@ -4,18 +4,34 @@
 
 -include("../include/spectra.hrl").
 
--export([encode/6, decode/6]).
+-export([encode/7, decode/7]).
 
--spec encode(atom(), module(), spectra:sp_type_reference(), dynamic(), spectra:sp_type(), term()) ->
+-spec encode(
+    atom(),
+    module(),
+    spectra:sp_type_reference(),
+    dynamic(),
+    spectra:sp_type(),
+    term(),
+    spectra:sp_config()
+) ->
     spectra:codec_encode_result().
-encode(_, _Mod, {type, token, 0}, {token, Bin}, _SpType, _Params) when is_binary(Bin) ->
+encode(_, _Mod, {type, token, 0}, {token, Bin}, _SpType, _Params, _Config) when is_binary(Bin) ->
     {ok, Bin};
-encode(_, _Mod, {type, token, 0}, Data, _SpType, _Params) ->
+encode(_, _Mod, {type, token, 0}, Data, _SpType, _Params, _Config) ->
     {error, [sp_error:type_mismatch({type, token, 0}, Data)]}.
 
--spec decode(atom(), module(), spectra:sp_type_reference(), dynamic(), spectra:sp_type(), term()) ->
+-spec decode(
+    atom(),
+    module(),
+    spectra:sp_type_reference(),
+    dynamic(),
+    spectra:sp_type(),
+    term(),
+    spectra:sp_config()
+) ->
     spectra:codec_decode_result().
-decode(_, _Mod, {type, token, 0}, Bin, _SpType, _Params) when is_binary(Bin) ->
+decode(_, _Mod, {type, token, 0}, Bin, _SpType, _Params, _Config) when is_binary(Bin) ->
     {ok, {token, Bin}};
-decode(_, _Mod, {type, token, 0}, Data, _SpType, _Params) ->
+decode(_, _Mod, {type, token, 0}, Data, _SpType, _Params, _Config) ->
     {error, [sp_error:type_mismatch({type, token, 0}, Data)]}.

--- a/test/codec_calendar_codec.erl
+++ b/test/codec_calendar_codec.erl
@@ -4,30 +4,48 @@
 
 -include("../include/spectra.hrl").
 
--export([encode/6, decode/6, schema/5]).
+-export([encode/7, decode/7, schema/6]).
 
--spec encode(atom(), module(), spectra:sp_type_reference(), dynamic(), spectra:sp_type(), term()) ->
+-spec encode(
+    atom(),
+    module(),
+    spectra:sp_type_reference(),
+    dynamic(),
+    spectra:sp_type(),
+    term(),
+    spectra:sp_config()
+) ->
     spectra:codec_encode_result().
-encode(_, _Mod, {type, datetime, 0}, {{Y, Mo, D}, {H, Mi, S}}, _SpType, _Params) ->
+encode(_, _Mod, {type, datetime, 0}, {{Y, Mo, D}, {H, Mi, S}}, _SpType, _Params, _Config) ->
     Bin = iolist_to_binary(
         io_lib:format("~4..0w-~2..0w-~2..0wT~2..0w:~2..0w:~2..0w", [Y, Mo, D, H, Mi, S])
     ),
     {ok, Bin};
-encode(_, _Mod, {type, datetime, 0}, Data, _SpType, _Params) ->
+encode(_, _Mod, {type, datetime, 0}, Data, _SpType, _Params, _Config) ->
     {error, [sp_error:type_mismatch({type, datetime, 0}, Data)]}.
 
--spec decode(atom(), module(), spectra:sp_type_reference(), dynamic(), spectra:sp_type(), term()) ->
+-spec decode(
+    atom(),
+    module(),
+    spectra:sp_type_reference(),
+    dynamic(),
+    spectra:sp_type(),
+    term(),
+    spectra:sp_config()
+) ->
     spectra:codec_decode_result().
-decode(_, _Mod, {type, datetime, 0}, Bin, _SpType, _Params) when is_binary(Bin) ->
+decode(_, _Mod, {type, datetime, 0}, Bin, _SpType, _Params, _Config) when is_binary(Bin) ->
     case parse_datetime(Bin) of
         {ok, DT} -> {ok, DT};
         error -> {error, [sp_error:type_mismatch({type, datetime, 0}, Bin)]}
     end;
-decode(_, _Mod, {type, datetime, 0}, Data, _SpType, _Params) ->
+decode(_, _Mod, {type, datetime, 0}, Data, _SpType, _Params, _Config) ->
     {error, [sp_error:type_mismatch({type, datetime, 0}, Data)]}.
 
--spec schema(atom(), module(), spectra:sp_type_reference(), spectra:sp_type(), term()) -> map().
-schema(json_schema, _Mod, {type, datetime, 0}, _SpType, _Params) ->
+-spec schema(
+    atom(), module(), spectra:sp_type_reference(), spectra:sp_type(), term(), spectra:sp_config()
+) -> map().
+schema(json_schema, _Mod, {type, datetime, 0}, _SpType, _Params, _Config) ->
     #{type => <<"string">>, format => <<"date-time">>}.
 
 parse_datetime(<<Y1, Y2, Y3, Y4, $-, Mo1, Mo2, $-, D1, D2, $T, H1, H2, $:, Mi1, Mi2, $:, S1, S2>>) ->

--- a/test/codec_geo_module.erl
+++ b/test/codec_geo_module.erl
@@ -19,33 +19,55 @@
 -export_type([
     point/0, maybe_point/0, named_point/0, location/0, point_with_status/1, active_passive_point/0
 ]).
--export([encode/6, decode/6, schema/5]).
+-export([encode/7, decode/7, schema/6]).
 
--spec encode(atom(), module(), spectra:sp_type_reference(), dynamic(), spectra:sp_type(), term()) ->
+-spec encode(
+    atom(),
+    module(),
+    spectra:sp_type_reference(),
+    dynamic(),
+    spectra:sp_type(),
+    term(),
+    spectra:sp_config()
+) ->
     spectra:codec_encode_result().
-encode(_, _Mod, {type, point, 0}, {X, Y}, _SpType, _Params) when is_number(X), is_number(Y) ->
+encode(_, _Mod, {type, point, 0}, {X, Y}, _SpType, _Params, _Config) when
+    is_number(X), is_number(Y)
+->
     {ok, [X, Y]};
-encode(_, _Mod, {type, point, 0}, Data, _SpType, _Params) ->
+encode(_, _Mod, {type, point, 0}, Data, _SpType, _Params, _Config) ->
     {error, [sp_error:type_mismatch({type, point, 0}, Data)]};
-encode(_, _, _, _, _, _) ->
+encode(_, _, _, _, _, _, _) ->
     continue.
 
--spec decode(atom(), module(), spectra:sp_type_reference(), dynamic(), spectra:sp_type(), term()) ->
+-spec decode(
+    atom(),
+    module(),
+    spectra:sp_type_reference(),
+    dynamic(),
+    spectra:sp_type(),
+    term(),
+    spectra:sp_config()
+) ->
     spectra:codec_decode_result().
-decode(_, _Mod, {type, point, 0}, [X, Y], _SpType, _Params) when is_number(X), is_number(Y) ->
+decode(_, _Mod, {type, point, 0}, [X, Y], _SpType, _Params, _Config) when
+    is_number(X), is_number(Y)
+->
     {ok, {X, Y}};
-decode(_, _Mod, {type, point, 0}, Data, _SpType, _Params) ->
+decode(_, _Mod, {type, point, 0}, Data, _SpType, _Params, _Config) ->
     {error, [sp_error:type_mismatch({type, point, 0}, Data)]};
-decode(_, _, _, _, _, _) ->
+decode(_, _, _, _, _, _, _) ->
     continue.
 
--spec schema(atom(), module(), spectra:sp_type_reference(), spectra:sp_type(), term()) -> map().
-schema(json_schema, _Mod, {type, point, 0}, _SpType, _Params) ->
+-spec schema(
+    atom(), module(), spectra:sp_type_reference(), spectra:sp_type(), term(), spectra:sp_config()
+) -> map().
+schema(json_schema, _Mod, {type, point, 0}, _SpType, _Params, _Config) ->
     #{
         type => <<"array">>,
         items => #{type => <<"number">>},
         minItems => 2,
         maxItems => 2
     };
-schema(_, _, _, _, _) ->
+schema(_, _, _, _, _, _) ->
     continue.

--- a/test/codec_multi_behaviour_module.erl
+++ b/test/codec_multi_behaviour_module.erl
@@ -8,32 +8,54 @@
 
 -include("../include/spectra.hrl").
 
--export([encode/6, decode/6, schema/5]).
+-export([encode/7, decode/7, schema/6]).
 
 -opaque point() :: {float(), float()}.
 -export_type([point/0]).
 
--spec encode(atom(), module(), spectra:sp_type_reference(), dynamic(), spectra:sp_type(), term()) ->
+-spec encode(
+    atom(),
+    module(),
+    spectra:sp_type_reference(),
+    dynamic(),
+    spectra:sp_type(),
+    term(),
+    spectra:sp_config()
+) ->
     spectra:codec_encode_result().
-encode(_, _Mod, {type, point, 0}, {X, Y}, _SpType, _Params) when is_number(X), is_number(Y) ->
+encode(_, _Mod, {type, point, 0}, {X, Y}, _SpType, _Params, _Config) when
+    is_number(X), is_number(Y)
+->
     {ok, [X, Y]};
-encode(_, _Mod, {type, point, 0}, Data, _SpType, _Params) ->
+encode(_, _Mod, {type, point, 0}, Data, _SpType, _Params, _Config) ->
     {error, [sp_error:type_mismatch({type, point, 0}, Data)]}.
 
--spec decode(atom(), module(), spectra:sp_type_reference(), dynamic(), spectra:sp_type(), term()) ->
+-spec decode(
+    atom(),
+    module(),
+    spectra:sp_type_reference(),
+    dynamic(),
+    spectra:sp_type(),
+    term(),
+    spectra:sp_config()
+) ->
     spectra:codec_decode_result().
-decode(_, _Mod, {type, point, 0}, [X, Y], _SpType, _Params) when is_number(X), is_number(Y) ->
+decode(_, _Mod, {type, point, 0}, [X, Y], _SpType, _Params, _Config) when
+    is_number(X), is_number(Y)
+->
     {ok, {X, Y}};
-decode(_, _Mod, {type, point, 0}, Data, _SpType, _Params) ->
+decode(_, _Mod, {type, point, 0}, Data, _SpType, _Params, _Config) ->
     {error, [sp_error:type_mismatch({type, point, 0}, Data)]}.
 
--spec schema(atom(), module(), spectra:sp_type_reference(), spectra:sp_type(), term()) -> dynamic().
-schema(json_schema, _Mod, {type, point, 0}, _SpType, _Params) ->
+-spec schema(
+    atom(), module(), spectra:sp_type_reference(), spectra:sp_type(), term(), spectra:sp_config()
+) -> dynamic().
+schema(json_schema, _Mod, {type, point, 0}, _SpType, _Params, _Config) ->
     #{
         type => <<"array">>,
         items => #{type => <<"number">>},
         minItems => 2,
         maxItems => 2
     };
-schema(_, _, _, _, _) ->
+schema(_, _, _, _, _, _) ->
     continue.

--- a/test/codec_no_schema_module.erl
+++ b/test/codec_no_schema_module.erl
@@ -8,18 +8,38 @@
 -opaque point() :: {float(), float()}.
 
 -export_type([point/0]).
--export([encode/6, decode/6]).
+-export([encode/7, decode/7]).
 
--spec encode(atom(), module(), spectra:sp_type_reference(), dynamic(), spectra:sp_type(), term()) ->
+-spec encode(
+    atom(),
+    module(),
+    spectra:sp_type_reference(),
+    dynamic(),
+    spectra:sp_type(),
+    term(),
+    spectra:sp_config()
+) ->
     spectra:codec_encode_result().
-encode(_, _Mod, {type, point, 0}, {X, Y}, _SpType, _Params) when is_number(X), is_number(Y) ->
+encode(_, _Mod, {type, point, 0}, {X, Y}, _SpType, _Params, _Config) when
+    is_number(X), is_number(Y)
+->
     {ok, [X, Y]};
-encode(_, _Mod, {type, point, 0}, Data, _SpType, _Params) ->
+encode(_, _Mod, {type, point, 0}, Data, _SpType, _Params, _Config) ->
     {error, [sp_error:type_mismatch({type, point, 0}, Data)]}.
 
--spec decode(atom(), module(), spectra:sp_type_reference(), dynamic(), spectra:sp_type(), term()) ->
+-spec decode(
+    atom(),
+    module(),
+    spectra:sp_type_reference(),
+    dynamic(),
+    spectra:sp_type(),
+    term(),
+    spectra:sp_config()
+) ->
     spectra:codec_decode_result().
-decode(_, _Mod, {type, point, 0}, [X, Y], _SpType, _Params) when is_number(X), is_number(Y) ->
+decode(_, _Mod, {type, point, 0}, [X, Y], _SpType, _Params, _Config) when
+    is_number(X), is_number(Y)
+->
     {ok, {X, Y}};
-decode(_, _Mod, {type, point, 0}, Data, _SpType, _Params) ->
+decode(_, _Mod, {type, point, 0}, Data, _SpType, _Params, _Config) ->
     {error, [sp_error:type_mismatch({type, point, 0}, Data)]}.

--- a/test/codec_remote_impl_module.erl
+++ b/test/codec_remote_impl_module.erl
@@ -7,11 +7,19 @@
 -opaque color() :: {non_neg_integer(), non_neg_integer(), non_neg_integer()}.
 
 -export_type([color/0]).
--export([encode/6, decode/6]).
+-export([encode/7, decode/7]).
 
--spec encode(atom(), module(), spectra:sp_type_reference(), dynamic(), spectra:sp_type(), term()) ->
+-spec encode(
+    atom(),
+    module(),
+    spectra:sp_type_reference(),
+    dynamic(),
+    spectra:sp_type(),
+    term(),
+    spectra:sp_config()
+) ->
     spectra:codec_encode_result().
-encode(_, _Mod, {type, color, 0}, {R, G, B}, _SpType, _Params) when
+encode(_, _Mod, {type, color, 0}, {R, G, B}, _SpType, _Params, _Config) when
     is_integer(R),
     is_integer(G),
     is_integer(B),
@@ -23,15 +31,23 @@ encode(_, _Mod, {type, color, 0}, {R, G, B}, _SpType, _Params) when
     B =< 255
 ->
     {ok, iolist_to_binary(io_lib:format("#~2.16.0B~2.16.0B~2.16.0B", [R, G, B]))};
-encode(_, _Mod, {type, color, 0}, Data, _SpType, _Params) ->
+encode(_, _Mod, {type, color, 0}, Data, _SpType, _Params, _Config) ->
     {error, [sp_error:type_mismatch({type, color, 0}, Data)]}.
 
--spec decode(atom(), module(), spectra:sp_type_reference(), dynamic(), spectra:sp_type(), term()) ->
+-spec decode(
+    atom(),
+    module(),
+    spectra:sp_type_reference(),
+    dynamic(),
+    spectra:sp_type(),
+    term(),
+    spectra:sp_config()
+) ->
     spectra:codec_decode_result().
-decode(_, _Mod, {type, color, 0}, <<"#", R1, R2, G1, G2, B1, B2>>, _SpType, _Params) ->
+decode(_, _Mod, {type, color, 0}, <<"#", R1, R2, G1, G2, B1, B2>>, _SpType, _Params, _Config) ->
     R = list_to_integer([R1, R2], 16),
     G = list_to_integer([G1, G2], 16),
     B = list_to_integer([B1, B2], 16),
     {ok, {R, G, B}};
-decode(_, _Mod, {type, color, 0}, Data, _SpType, _Params) ->
+decode(_, _Mod, {type, color, 0}, Data, _SpType, _Params, _Config) ->
     {error, [sp_error:type_mismatch({type, color, 0}, Data)]}.

--- a/test/codec_string_continue_module.erl
+++ b/test/codec_string_continue_module.erl
@@ -9,14 +9,30 @@
 -type name() :: binary().
 
 -export_type([name/0]).
--export([encode/6, decode/6]).
+-export([encode/7, decode/7]).
 
--spec encode(atom(), module(), spectra:sp_type_reference(), dynamic(), spectra:sp_type(), term()) ->
+-spec encode(
+    atom(),
+    module(),
+    spectra:sp_type_reference(),
+    dynamic(),
+    spectra:sp_type(),
+    term(),
+    spectra:sp_config()
+) ->
     spectra:codec_encode_result().
-encode(_, _, _, _, _, _) ->
+encode(_, _, _, _, _, _, _) ->
     continue.
 
--spec decode(atom(), module(), spectra:sp_type_reference(), dynamic(), spectra:sp_type(), term()) ->
+-spec decode(
+    atom(),
+    module(),
+    spectra:sp_type_reference(),
+    dynamic(),
+    spectra:sp_type(),
+    term(),
+    spectra:sp_config()
+) ->
     spectra:codec_decode_result().
-decode(_, _, _, _, _, _) ->
+decode(_, _, _, _, _, _, _) ->
     continue.

--- a/test/codec_string_token_codec.erl
+++ b/test/codec_string_token_codec.erl
@@ -4,18 +4,36 @@
 
 -include("../include/spectra.hrl").
 
--export([encode/6, decode/6]).
+-export([encode/7, decode/7]).
 
--spec encode(atom(), module(), spectra:sp_type_reference(), dynamic(), spectra:sp_type(), term()) ->
+-spec encode(
+    atom(),
+    module(),
+    spectra:sp_type_reference(),
+    dynamic(),
+    spectra:sp_type(),
+    term(),
+    spectra:sp_config()
+) ->
     spectra:codec_encode_result().
-encode(string, _Mod, {type, token, 0}, {token, Bin}, _SpType, _Params) when is_binary(Bin) ->
+encode(string, _Mod, {type, token, 0}, {token, Bin}, _SpType, _Params, _Config) when
+    is_binary(Bin)
+->
     {ok, binary_to_list(Bin)};
-encode(string, _Mod, {type, token, 0}, Data, _SpType, _Params) ->
+encode(string, _Mod, {type, token, 0}, Data, _SpType, _Params, _Config) ->
     {error, [sp_error:type_mismatch({type, token, 0}, Data)]}.
 
--spec decode(atom(), module(), spectra:sp_type_reference(), dynamic(), spectra:sp_type(), term()) ->
+-spec decode(
+    atom(),
+    module(),
+    spectra:sp_type_reference(),
+    dynamic(),
+    spectra:sp_type(),
+    term(),
+    spectra:sp_config()
+) ->
     spectra:codec_decode_result().
-decode(string, _Mod, {type, token, 0}, String, _SpType, _Params) when is_list(String) ->
+decode(string, _Mod, {type, token, 0}, String, _SpType, _Params, _Config) when is_list(String) ->
     {ok, {token, list_to_binary(String)}};
-decode(string, _Mod, {type, token, 0}, Data, _SpType, _Params) ->
+decode(string, _Mod, {type, token, 0}, Data, _SpType, _Params, _Config) ->
     {error, [sp_error:type_mismatch({type, token, 0}, Data)]}.

--- a/test/custom_codec_test.erl
+++ b/test/custom_codec_test.erl
@@ -155,7 +155,7 @@ animal_decode_unknown_tag_test() ->
     ).
 
 animal_type_ref_forms_test() ->
-    TypeInfo = spectra_module_types:get(codec_animal_codec),
+    TypeInfo = spectra_test_util:get_module_types(codec_animal_codec),
     AnimalSpType = spectra_type_info:get_type(TypeInfo, animal, 0),
 
     Cat = #cat{name = <<"Whiskers">>, indoor = true},
@@ -176,7 +176,7 @@ animal_type_ref_forms_test() ->
     ?assertEqual(DecAtom, DecSpType).
 
 cat_record_ref_forms_test() ->
-    TypeInfo = spectra_module_types:get(codec_animal_codec),
+    TypeInfo = spectra_test_util:get_module_types(codec_animal_codec),
     {ok, CatSpRec} = spectra_type_info:find_record(TypeInfo, cat),
 
     Cat = #cat{name = <<"Whiskers">>, indoor = true},
@@ -234,7 +234,7 @@ union_with_remote_codec_type_decode_test() ->
     ).
 
 schema_type_ref_forms_test() ->
-    TypeInfo = spectra_module_types:get(codec_geo_module),
+    TypeInfo = spectra_test_util:get_module_types(codec_geo_module),
     PointSpType = spectra_type_info:get_type(TypeInfo, point, 0),
 
     SchemaAtom = spectra:schema(json_schema, codec_geo_module, point),
@@ -244,7 +244,7 @@ schema_type_ref_forms_test() ->
     ?assertEqual(SchemaTupleRef, SchemaSpType).
 
 schema_record_ref_forms_test() ->
-    TypeInfo = spectra_module_types:get(record_test),
+    TypeInfo = spectra_test_util:get_module_types(record_test),
     {ok, PersonSpRec} = spectra_type_info:find_record(TypeInfo, person),
 
     SchemaRecordRef = spectra:schema(json_schema, record_test, {record, person}),

--- a/test/perf_benchmark.erl
+++ b/test/perf_benchmark.erl
@@ -76,7 +76,7 @@
 
 run() ->
     {ok, _} = application:ensure_all_started(spectra),
-    application:set_env(spectra, use_module_types_cache, true),
+    application:set_env(spectra, module_types_cache, persistent),
     io:format("~n=== Spectra Performance Benchmark ===~n"),
     io:format("Loading sample data from test/sample10k.json...~n"),
 

--- a/test/prefixed_id_codec.erl
+++ b/test/prefixed_id_codec.erl
@@ -1,7 +1,7 @@
 -module(prefixed_id_codec).
 -behaviour(spectra_codec).
 
--export([encode/6, decode/6, schema/5]).
+-export([encode/7, decode/7, schema/6]).
 
 %% This codec handles any binary type whose type_parameters is a prefix binary.
 %% The Erlang value is the raw ID (without prefix); the wire format includes the prefix.
@@ -16,21 +16,25 @@
 -export_type([user_id/0, org_id/0]).
 
 %% Strips the prefix on decode, re-attaches it on encode.
-decode(json, _Mod, TypeRef, Data, _SpType, Prefix) when is_binary(Data), is_binary(Prefix) ->
+decode(json, _Mod, TypeRef, Data, _SpType, Prefix, _Config) when
+    is_binary(Data), is_binary(Prefix)
+->
     PrefixLen = byte_size(Prefix),
     case Data of
         <<Prefix:PrefixLen/binary, Rest/binary>> -> {ok, Rest};
         _ -> {error, [sp_error:type_mismatch(TypeRef, Data)]}
     end;
-decode(_Format, _Mod, _TypeRef, _Data, _SpType, _Params) ->
+decode(_Format, _Mod, _TypeRef, _Data, _SpType, _Params, _Config) ->
     continue.
 
-encode(json, _Mod, _TypeRef, Data, _SpType, Prefix) when is_binary(Data), is_binary(Prefix) ->
+encode(json, _Mod, _TypeRef, Data, _SpType, Prefix, _Config) when
+    is_binary(Data), is_binary(Prefix)
+->
     {ok, <<Prefix/binary, Data/binary>>};
-encode(_Format, _Mod, _TypeRef, _Data, _SpType, _Params) ->
+encode(_Format, _Mod, _TypeRef, _Data, _SpType, _Params, _Config) ->
     continue.
 
-schema(json_schema, _Mod, _TypeRef, _SpType, Prefix) when is_binary(Prefix) ->
+schema(json_schema, _Mod, _TypeRef, _SpType, Prefix, _Config) when is_binary(Prefix) ->
     #{type => <<"string">>, pattern => <<"^", Prefix/binary>>};
-schema(_Format, _Mod, _TypeRef, _SpType, _Params) ->
+schema(_Format, _Mod, _TypeRef, _SpType, _Params, _Config) ->
     continue.

--- a/test/prop_base.erl
+++ b/test/prop_base.erl
@@ -14,7 +14,7 @@ prop_hej() ->
             ),
             case from_json(TypeInfo, Type, JsonValue) of
                 {ok, Data} ->
-                    case spectra_json:to_json(TypeInfo, Type, Data) of
+                    case spectra_test_util:to_json(TypeInfo, Type, Data) of
                         {ok, Value} ->
                             Json = iolist_to_binary(json:encode(Value)),
                             ?WHENFAIL(
@@ -39,7 +39,7 @@ prop_hej() ->
 
 from_json(TypeInfo, Type, JsonValue) ->
     try
-        spectra_json:from_json(TypeInfo, Type, JsonValue)
+        spectra_test_util:from_json(TypeInfo, Type, JsonValue)
     catch
         error:{type_not_supported, _} ->
             {error, type_not_supported};

--- a/test/prop_json_encode_schema_consistency.erl
+++ b/test/prop_json_encode_schema_consistency.erl
@@ -137,13 +137,13 @@ create_typeinfo_with_known_types(Type) ->
     ).
 
 safe_to_json(TypeInfo, Type, Data) ->
-    save(fun() -> spectra_json:to_json(TypeInfo, Type, Data) end).
+    save(fun() -> spectra_test_util:to_json(TypeInfo, Type, Data) end).
 
 safe_to_schema(TypeInfo, Type) ->
-    save(fun() -> spectra_json_schema:to_schema(TypeInfo, Type) end).
+    save(fun() -> spectra_test_util:to_schema(TypeInfo, Type) end).
 
 safe_from_json(TypeInfo, Type, JsonValue) ->
-    save(fun() -> spectra_json:from_json(TypeInfo, Type, JsonValue) end).
+    save(fun() -> spectra_test_util:from_json(TypeInfo, Type, JsonValue) end).
 
 save(Fun) ->
     try

--- a/test/prop_schema_consistency.erl
+++ b/test/prop_schema_consistency.erl
@@ -86,7 +86,7 @@ records_with_spectra() ->
     ]).
 
 prop_schema_consistency_for_types() ->
-    TypeInfo = spectra_module_types:get(?MODULE),
+    TypeInfo = spectra_test_util:get_module_types(?MODULE),
     ?FORALL(
         %% FIXME: instead of these silly types we should generate random types
         %% with -spectra attributes in sp_type_generator
@@ -112,7 +112,7 @@ prop_schema_consistency_for_types() ->
     ).
 
 prop_schema_consistency_for_records() ->
-    TypeInfo = spectra_module_types:get(?MODULE),
+    TypeInfo = spectra_test_util:get_module_types(?MODULE),
     ?FORALL(
         RecordName,
         records_with_spectra(),

--- a/test/spectra_abstract_code_test.erl
+++ b/test/spectra_abstract_code_test.erl
@@ -5,7 +5,7 @@
 -include("../include/spectra_internal.hrl").
 
 spectra_function_exported_test() ->
-    TypeInfo = spectra_module_types:get(spectra_test_module_with_spectra),
+    TypeInfo = spectra_test_util:get_module_types(spectra_test_module_with_spectra),
     ?assert(is_record(TypeInfo, type_info)),
     ?assertMatch(
         {ok, #sp_simple_type{type = string}}, spectra_type_info:find_type(TypeInfo, my_type, 0)
@@ -22,7 +22,7 @@ spectra_function_exported_test() ->
     ?assertMatch(#sp_rec{meta = #{doc := #{title := <<"My Record">>}}}, Record).
 
 spectra_function_with_partial_data_test() ->
-    TypeInfo = spectra_module_types:get(spectra_test_module_partial_spectra),
+    TypeInfo = spectra_test_util:get_module_types(spectra_test_module_partial_spectra),
     ?assert(is_record(TypeInfo, type_info)),
     ?assertMatch({ok, _}, spectra_type_info:find_type(TypeInfo, partial_type, 0)),
     ?assertEqual(error, spectra_type_info:find_record(TypeInfo, some_record)),
@@ -48,7 +48,7 @@ spectra_function_with_unloaded_module_test() ->
     code:purge(spectra_test_module_with_spectra),
     code:delete(spectra_test_module_with_spectra),
     ?assertEqual(false, code:is_loaded(spectra_test_module_with_spectra)),
-    TypeInfo = spectra_module_types:get(spectra_test_module_with_spectra),
+    TypeInfo = spectra_test_util:get_module_types(spectra_test_module_with_spectra),
     ?assertMatch(
         {ok, #sp_simple_type{type = string}}, spectra_type_info:find_type(TypeInfo, my_type, 0)
     ).

--- a/test/spectra_binary_string_test.erl
+++ b/test/spectra_binary_string_test.erl
@@ -41,7 +41,7 @@ simple_types_test() ->
     %% integer
     ?assertEqual(
         {ok, 42},
-        spectra_binary_string:from_binary_string(
+        spectra_test_util:from_binary_string(
             TypeInfo,
             #sp_simple_type{type = integer},
             <<"42">>
@@ -49,7 +49,7 @@ simple_types_test() ->
     ),
     ?assertEqual(
         {ok, -42},
-        spectra_binary_string:from_binary_string(
+        spectra_test_util:from_binary_string(
             TypeInfo,
             #sp_simple_type{type = integer},
             <<"-42">>
@@ -57,7 +57,7 @@ simple_types_test() ->
     ),
     ?assertMatch(
         {error, [#sp_error{type = type_mismatch}]},
-        spectra_binary_string:from_binary_string(
+        spectra_test_util:from_binary_string(
             TypeInfo,
             #sp_simple_type{type = integer},
             <<"not_a_number">>
@@ -65,7 +65,7 @@ simple_types_test() ->
     ),
     ?assertMatch(
         {error, [#sp_error{type = type_mismatch}]},
-        spectra_binary_string:from_binary_string(
+        spectra_test_util:from_binary_string(
             TypeInfo,
             #sp_simple_type{type = integer},
             <<"3.14">>
@@ -75,7 +75,7 @@ simple_types_test() ->
     %% float
     ?assertEqual(
         {ok, 3.14},
-        spectra_binary_string:from_binary_string(
+        spectra_test_util:from_binary_string(
             TypeInfo,
             #sp_simple_type{type = float},
             <<"3.14">>
@@ -83,7 +83,7 @@ simple_types_test() ->
     ),
     ?assertEqual(
         {ok, -3.14},
-        spectra_binary_string:from_binary_string(
+        spectra_test_util:from_binary_string(
             TypeInfo,
             #sp_simple_type{type = float},
             <<"-3.14">>
@@ -91,7 +91,7 @@ simple_types_test() ->
     ),
     ?assertMatch(
         {error, [#sp_error{type = type_mismatch}]},
-        spectra_binary_string:from_binary_string(
+        spectra_test_util:from_binary_string(
             TypeInfo,
             #sp_simple_type{type = float},
             <<"not_a_number">>
@@ -99,7 +99,7 @@ simple_types_test() ->
     ),
     ?assertMatch(
         {error, [#sp_error{type = type_mismatch}]},
-        spectra_binary_string:from_binary_string(
+        spectra_test_util:from_binary_string(
             TypeInfo,
             #sp_simple_type{type = float},
             <<"42">>
@@ -109,7 +109,7 @@ simple_types_test() ->
     %% number (tries integer first, then float)
     ?assertEqual(
         {ok, 42},
-        spectra_binary_string:from_binary_string(
+        spectra_test_util:from_binary_string(
             TypeInfo,
             #sp_simple_type{type = number},
             <<"42">>
@@ -117,7 +117,7 @@ simple_types_test() ->
     ),
     ?assertEqual(
         {ok, 3.14},
-        spectra_binary_string:from_binary_string(
+        spectra_test_util:from_binary_string(
             TypeInfo,
             #sp_simple_type{type = number},
             <<"3.14">>
@@ -125,7 +125,7 @@ simple_types_test() ->
     ),
     ?assertMatch(
         {error, [#sp_error{type = type_mismatch}]},
-        spectra_binary_string:from_binary_string(
+        spectra_test_util:from_binary_string(
             TypeInfo,
             #sp_simple_type{type = number},
             <<"not_a_number">>
@@ -135,7 +135,7 @@ simple_types_test() ->
     %% boolean
     ?assertEqual(
         {ok, true},
-        spectra_binary_string:from_binary_string(
+        spectra_test_util:from_binary_string(
             TypeInfo,
             #sp_simple_type{type = boolean},
             <<"true">>
@@ -143,7 +143,7 @@ simple_types_test() ->
     ),
     ?assertEqual(
         {ok, false},
-        spectra_binary_string:from_binary_string(
+        spectra_test_util:from_binary_string(
             TypeInfo,
             #sp_simple_type{type = boolean},
             <<"false">>
@@ -151,7 +151,7 @@ simple_types_test() ->
     ),
     ?assertMatch(
         {error, [#sp_error{type = type_mismatch}]},
-        spectra_binary_string:from_binary_string(
+        spectra_test_util:from_binary_string(
             TypeInfo,
             #sp_simple_type{type = boolean},
             <<"True">>
@@ -159,7 +159,7 @@ simple_types_test() ->
     ),
     ?assertMatch(
         {error, [#sp_error{type = type_mismatch}]},
-        spectra_binary_string:from_binary_string(
+        spectra_test_util:from_binary_string(
             TypeInfo,
             #sp_simple_type{type = boolean},
             <<"1">>
@@ -169,7 +169,7 @@ simple_types_test() ->
     %% atom
     ?assertEqual(
         {ok, hello},
-        spectra_binary_string:from_binary_string(
+        spectra_test_util:from_binary_string(
             TypeInfo,
             #sp_simple_type{type = atom},
             <<"hello">>
@@ -177,7 +177,7 @@ simple_types_test() ->
     ),
     ?assertEqual(
         {ok, 'hello world'},
-        spectra_binary_string:from_binary_string(
+        spectra_test_util:from_binary_string(
             TypeInfo,
             #sp_simple_type{type = atom},
             <<"hello world">>
@@ -185,7 +185,7 @@ simple_types_test() ->
     ),
     ?assertMatch(
         {error, [#sp_error{type = type_mismatch}]},
-        spectra_binary_string:from_binary_string(
+        spectra_test_util:from_binary_string(
             TypeInfo,
             #sp_simple_type{type = atom},
             <<"non_existing_atom_123456789">>
@@ -195,7 +195,7 @@ simple_types_test() ->
     %% string
     ?assertEqual(
         {ok, "hello"},
-        spectra_binary_string:from_binary_string(
+        spectra_test_util:from_binary_string(
             TypeInfo,
             #sp_simple_type{type = string},
             <<"hello">>
@@ -203,7 +203,7 @@ simple_types_test() ->
     ),
     ?assertEqual(
         {ok, ""},
-        spectra_binary_string:from_binary_string(
+        spectra_test_util:from_binary_string(
             TypeInfo,
             #sp_simple_type{type = string},
             <<"">>
@@ -211,7 +211,7 @@ simple_types_test() ->
     ),
     ?assertEqual(
         {ok, "hello world 123!"},
-        spectra_binary_string:from_binary_string(
+        spectra_test_util:from_binary_string(
             TypeInfo,
             #sp_simple_type{type = string},
             <<"hello world 123!">>
@@ -221,7 +221,7 @@ simple_types_test() ->
     %% nonempty_string
     ?assertEqual(
         {ok, "hello"},
-        spectra_binary_string:from_binary_string(
+        spectra_test_util:from_binary_string(
             TypeInfo,
             #sp_simple_type{type = nonempty_string},
             <<"hello">>
@@ -229,7 +229,7 @@ simple_types_test() ->
     ),
     ?assertMatch(
         {error, [#sp_error{type = type_mismatch}]},
-        spectra_binary_string:from_binary_string(
+        spectra_test_util:from_binary_string(
             TypeInfo,
             #sp_simple_type{type = nonempty_string},
             <<"">>
@@ -239,7 +239,7 @@ simple_types_test() ->
     %% binary
     ?assertEqual(
         {ok, <<"hello">>},
-        spectra_binary_string:from_binary_string(
+        spectra_test_util:from_binary_string(
             TypeInfo,
             #sp_simple_type{type = binary},
             <<"hello">>
@@ -247,7 +247,7 @@ simple_types_test() ->
     ),
     ?assertEqual(
         {ok, <<"">>},
-        spectra_binary_string:from_binary_string(
+        spectra_test_util:from_binary_string(
             TypeInfo,
             #sp_simple_type{type = binary},
             <<"">>
@@ -257,7 +257,7 @@ simple_types_test() ->
     %% nonempty_binary
     ?assertEqual(
         {ok, <<"hello">>},
-        spectra_binary_string:from_binary_string(
+        spectra_test_util:from_binary_string(
             TypeInfo,
             #sp_simple_type{type = nonempty_binary},
             <<"hello">>
@@ -265,7 +265,7 @@ simple_types_test() ->
     ),
     ?assertMatch(
         {error, [#sp_error{type = type_mismatch}]},
-        spectra_binary_string:from_binary_string(
+        spectra_test_util:from_binary_string(
             TypeInfo,
             #sp_simple_type{type = nonempty_binary},
             <<"">>
@@ -275,7 +275,7 @@ simple_types_test() ->
     %% non_neg_integer
     ?assertEqual(
         {ok, 42},
-        spectra_binary_string:from_binary_string(
+        spectra_test_util:from_binary_string(
             TypeInfo,
             #sp_simple_type{type = non_neg_integer},
             <<"42">>
@@ -283,7 +283,7 @@ simple_types_test() ->
     ),
     ?assertEqual(
         {ok, 0},
-        spectra_binary_string:from_binary_string(
+        spectra_test_util:from_binary_string(
             TypeInfo,
             #sp_simple_type{type = non_neg_integer},
             <<"0">>
@@ -291,7 +291,7 @@ simple_types_test() ->
     ),
     ?assertMatch(
         {error, [#sp_error{type = type_mismatch}]},
-        spectra_binary_string:from_binary_string(
+        spectra_test_util:from_binary_string(
             TypeInfo,
             #sp_simple_type{type = non_neg_integer},
             <<"-1">>
@@ -301,7 +301,7 @@ simple_types_test() ->
     %% pos_integer
     ?assertEqual(
         {ok, 42},
-        spectra_binary_string:from_binary_string(
+        spectra_test_util:from_binary_string(
             TypeInfo,
             #sp_simple_type{type = pos_integer},
             <<"42">>
@@ -309,7 +309,7 @@ simple_types_test() ->
     ),
     ?assertMatch(
         {error, [#sp_error{type = type_mismatch}]},
-        spectra_binary_string:from_binary_string(
+        spectra_test_util:from_binary_string(
             TypeInfo,
             #sp_simple_type{type = pos_integer},
             <<"0">>
@@ -317,7 +317,7 @@ simple_types_test() ->
     ),
     ?assertMatch(
         {error, [#sp_error{type = type_mismatch}]},
-        spectra_binary_string:from_binary_string(
+        spectra_test_util:from_binary_string(
             TypeInfo,
             #sp_simple_type{type = pos_integer},
             <<"-1">>
@@ -327,7 +327,7 @@ simple_types_test() ->
     %% neg_integer
     ?assertEqual(
         {ok, -42},
-        spectra_binary_string:from_binary_string(
+        spectra_test_util:from_binary_string(
             TypeInfo,
             #sp_simple_type{type = neg_integer},
             <<"-42">>
@@ -335,7 +335,7 @@ simple_types_test() ->
     ),
     ?assertMatch(
         {error, [#sp_error{type = type_mismatch}]},
-        spectra_binary_string:from_binary_string(
+        spectra_test_util:from_binary_string(
             TypeInfo,
             #sp_simple_type{type = neg_integer},
             <<"0">>
@@ -343,7 +343,7 @@ simple_types_test() ->
     ),
     ?assertMatch(
         {error, [#sp_error{type = type_mismatch}]},
-        spectra_binary_string:from_binary_string(
+        spectra_test_util:from_binary_string(
             TypeInfo,
             #sp_simple_type{type = neg_integer},
             <<"42">>
@@ -365,39 +365,39 @@ range_test() ->
     %% Valid values in range
     ?assertEqual(
         {ok, 1},
-        spectra_binary_string:from_binary_string(TypeInfo, Range, <<"1">>)
+        spectra_test_util:from_binary_string(TypeInfo, Range, <<"1">>)
     ),
     ?assertEqual(
         {ok, 5},
-        spectra_binary_string:from_binary_string(TypeInfo, Range, <<"5">>)
+        spectra_test_util:from_binary_string(TypeInfo, Range, <<"5">>)
     ),
     ?assertEqual(
         {ok, 10},
-        spectra_binary_string:from_binary_string(TypeInfo, Range, <<"10">>)
+        spectra_test_util:from_binary_string(TypeInfo, Range, <<"10">>)
     ),
 
     %% Invalid values outside range
     ?assertMatch(
         {error, [#sp_error{type = type_mismatch}]},
-        spectra_binary_string:from_binary_string(TypeInfo, Range, <<"0">>)
+        spectra_test_util:from_binary_string(TypeInfo, Range, <<"0">>)
     ),
     ?assertMatch(
         {error, [#sp_error{type = type_mismatch}]},
-        spectra_binary_string:from_binary_string(TypeInfo, Range, <<"11">>)
+        spectra_test_util:from_binary_string(TypeInfo, Range, <<"11">>)
     ),
     ?assertMatch(
         {error, [#sp_error{type = type_mismatch}]},
-        spectra_binary_string:from_binary_string(TypeInfo, Range, <<"-5">>)
+        spectra_test_util:from_binary_string(TypeInfo, Range, <<"-5">>)
     ),
 
     %% Invalid non-integer strings
     ?assertMatch(
         {error, [#sp_error{type = type_mismatch}]},
-        spectra_binary_string:from_binary_string(TypeInfo, Range, <<"not_a_number">>)
+        spectra_test_util:from_binary_string(TypeInfo, Range, <<"not_a_number">>)
     ),
     ?assertMatch(
         {error, [#sp_error{type = type_mismatch}]},
-        spectra_binary_string:from_binary_string(TypeInfo, Range, <<"5.5">>)
+        spectra_test_util:from_binary_string(TypeInfo, Range, <<"5.5">>)
     ),
 
     ok.
@@ -410,15 +410,15 @@ literal_test() ->
     AtomLiteral = #sp_literal{value = hello},
     ?assertEqual(
         {ok, hello},
-        spectra_binary_string:from_binary_string(TypeInfo, AtomLiteral, <<"hello">>)
+        spectra_test_util:from_binary_string(TypeInfo, AtomLiteral, <<"hello">>)
     ),
     ?assertMatch(
         {error, [#sp_error{type = type_mismatch}]},
-        spectra_binary_string:from_binary_string(TypeInfo, AtomLiteral, <<"world">>)
+        spectra_test_util:from_binary_string(TypeInfo, AtomLiteral, <<"world">>)
     ),
     ?assertMatch(
         {error, [#sp_error{type = type_mismatch}]},
-        spectra_binary_string:from_binary_string(
+        spectra_test_util:from_binary_string(
             TypeInfo,
             AtomLiteral,
             <<"non_existing_atom_123456789">>
@@ -429,15 +429,15 @@ literal_test() ->
     IntegerLiteral = #sp_literal{value = 42},
     ?assertEqual(
         {ok, 42},
-        spectra_binary_string:from_binary_string(TypeInfo, IntegerLiteral, <<"42">>)
+        spectra_test_util:from_binary_string(TypeInfo, IntegerLiteral, <<"42">>)
     ),
     ?assertMatch(
         {error, [#sp_error{type = type_mismatch}]},
-        spectra_binary_string:from_binary_string(TypeInfo, IntegerLiteral, <<"43">>)
+        spectra_test_util:from_binary_string(TypeInfo, IntegerLiteral, <<"43">>)
     ),
     ?assertMatch(
         {error, [#sp_error{type = type_mismatch}]},
-        spectra_binary_string:from_binary_string(
+        spectra_test_util:from_binary_string(
             TypeInfo,
             IntegerLiteral,
             <<"not_a_number">>
@@ -448,15 +448,15 @@ literal_test() ->
     BooleanLiteral = #sp_literal{value = true},
     ?assertEqual(
         {ok, true},
-        spectra_binary_string:from_binary_string(TypeInfo, BooleanLiteral, <<"true">>)
+        spectra_test_util:from_binary_string(TypeInfo, BooleanLiteral, <<"true">>)
     ),
     ?assertMatch(
         {error, [#sp_error{type = type_mismatch}]},
-        spectra_binary_string:from_binary_string(TypeInfo, BooleanLiteral, <<"false">>)
+        spectra_test_util:from_binary_string(TypeInfo, BooleanLiteral, <<"false">>)
     ),
     ?assertMatch(
         {error, [#sp_error{type = type_mismatch}]},
-        spectra_binary_string:from_binary_string(TypeInfo, BooleanLiteral, <<"True">>)
+        spectra_test_util:from_binary_string(TypeInfo, BooleanLiteral, <<"True">>)
     ),
 
     ok.
@@ -470,19 +470,19 @@ union_test() ->
         #sp_union{types = [#sp_simple_type{type = integer}, #sp_simple_type{type = boolean}]},
     ?assertEqual(
         {ok, 42},
-        spectra_binary_string:from_binary_string(TypeInfo, Union, <<"42">>)
+        spectra_test_util:from_binary_string(TypeInfo, Union, <<"42">>)
     ),
     ?assertEqual(
         {ok, true},
-        spectra_binary_string:from_binary_string(TypeInfo, Union, <<"true">>)
+        spectra_test_util:from_binary_string(TypeInfo, Union, <<"true">>)
     ),
     ?assertEqual(
         {ok, false},
-        spectra_binary_string:from_binary_string(TypeInfo, Union, <<"false">>)
+        spectra_test_util:from_binary_string(TypeInfo, Union, <<"false">>)
     ),
     ?assertMatch(
         {error, [#sp_error{type = no_match}]},
-        spectra_binary_string:from_binary_string(TypeInfo, Union, <<"not_matching">>)
+        spectra_test_util:from_binary_string(TypeInfo, Union, <<"not_matching">>)
     ),
 
     %% Complex union with literals: 1 | 2 | true | false
@@ -498,27 +498,27 @@ union_test() ->
         },
     ?assertEqual(
         {ok, 1},
-        spectra_binary_string:from_binary_string(TypeInfo, ComplexUnion, <<"1">>)
+        spectra_test_util:from_binary_string(TypeInfo, ComplexUnion, <<"1">>)
     ),
     ?assertEqual(
         {ok, 2},
-        spectra_binary_string:from_binary_string(TypeInfo, ComplexUnion, <<"2">>)
+        spectra_test_util:from_binary_string(TypeInfo, ComplexUnion, <<"2">>)
     ),
     ?assertEqual(
         {ok, true},
-        spectra_binary_string:from_binary_string(TypeInfo, ComplexUnion, <<"true">>)
+        spectra_test_util:from_binary_string(TypeInfo, ComplexUnion, <<"true">>)
     ),
     ?assertEqual(
         {ok, false},
-        spectra_binary_string:from_binary_string(TypeInfo, ComplexUnion, <<"false">>)
+        spectra_test_util:from_binary_string(TypeInfo, ComplexUnion, <<"false">>)
     ),
     ?assertMatch(
         {error, [#sp_error{type = no_match}]},
-        spectra_binary_string:from_binary_string(TypeInfo, ComplexUnion, <<"3">>)
+        spectra_test_util:from_binary_string(TypeInfo, ComplexUnion, <<"3">>)
     ),
     ?assertMatch(
         {error, [#sp_error{type = no_match}]},
-        spectra_binary_string:from_binary_string(TypeInfo, ComplexUnion, <<"maybe">>)
+        spectra_test_util:from_binary_string(TypeInfo, ComplexUnion, <<"maybe">>)
     ),
 
     ok.
@@ -530,7 +530,7 @@ type_reference_test() ->
     %% Test various type references from the module
     ?assertEqual(
         {ok, 42},
-        spectra_binary_string:from_binary_string(
+        spectra_test_util:from_binary_string(
             TypeInfo,
             resolve_type(TypeInfo, my_integer, 0),
             <<"42">>
@@ -538,7 +538,7 @@ type_reference_test() ->
     ),
     ?assertEqual(
         {ok, 3.14},
-        spectra_binary_string:from_binary_string(
+        spectra_test_util:from_binary_string(
             TypeInfo,
             resolve_type(TypeInfo, my_float, 0),
             <<"3.14">>
@@ -546,7 +546,7 @@ type_reference_test() ->
     ),
     ?assertEqual(
         {ok, 42},
-        spectra_binary_string:from_binary_string(
+        spectra_test_util:from_binary_string(
             TypeInfo,
             resolve_type(TypeInfo, my_number, 0),
             <<"42">>
@@ -554,7 +554,7 @@ type_reference_test() ->
     ),
     ?assertEqual(
         {ok, 3.14},
-        spectra_binary_string:from_binary_string(
+        spectra_test_util:from_binary_string(
             TypeInfo,
             resolve_type(TypeInfo, my_number, 0),
             <<"3.14">>
@@ -562,7 +562,7 @@ type_reference_test() ->
     ),
     ?assertEqual(
         {ok, true},
-        spectra_binary_string:from_binary_string(
+        spectra_test_util:from_binary_string(
             TypeInfo,
             resolve_type(TypeInfo, my_boolean, 0),
             <<"true">>
@@ -570,7 +570,7 @@ type_reference_test() ->
     ),
     ?assertEqual(
         {ok, hello},
-        spectra_binary_string:from_binary_string(
+        spectra_test_util:from_binary_string(
             TypeInfo,
             resolve_type(TypeInfo, my_atom, 0),
             <<"hello">>
@@ -578,7 +578,7 @@ type_reference_test() ->
     ),
     ?assertEqual(
         {ok, "test"},
-        spectra_binary_string:from_binary_string(
+        spectra_test_util:from_binary_string(
             TypeInfo,
             resolve_type(TypeInfo, my_string, 0),
             <<"test">>
@@ -586,7 +586,7 @@ type_reference_test() ->
     ),
     ?assertEqual(
         {ok, <<"test">>},
-        spectra_binary_string:from_binary_string(
+        spectra_test_util:from_binary_string(
             TypeInfo,
             resolve_type(TypeInfo, my_binary, 0),
             <<"test">>
@@ -596,7 +596,7 @@ type_reference_test() ->
     %% Test range type
     ?assertEqual(
         {ok, 5},
-        spectra_binary_string:from_binary_string(
+        spectra_test_util:from_binary_string(
             TypeInfo,
             resolve_type(TypeInfo, my_range, 0),
             <<"5">>
@@ -604,7 +604,7 @@ type_reference_test() ->
     ),
     ?assertMatch(
         {error, [#sp_error{type = type_mismatch}]},
-        spectra_binary_string:from_binary_string(
+        spectra_test_util:from_binary_string(
             TypeInfo,
             resolve_type(TypeInfo, my_range, 0),
             <<"15">>
@@ -614,7 +614,7 @@ type_reference_test() ->
     %% Test literal types
     ?assertEqual(
         {ok, hello},
-        spectra_binary_string:from_binary_string(
+        spectra_test_util:from_binary_string(
             TypeInfo,
             resolve_type(TypeInfo, my_literal_atom, 0),
             <<"hello">>
@@ -622,7 +622,7 @@ type_reference_test() ->
     ),
     ?assertEqual(
         {ok, 42},
-        spectra_binary_string:from_binary_string(
+        spectra_test_util:from_binary_string(
             TypeInfo,
             resolve_type(TypeInfo, my_literal_integer, 0),
             <<"42">>
@@ -630,7 +630,7 @@ type_reference_test() ->
     ),
     ?assertEqual(
         {ok, true},
-        spectra_binary_string:from_binary_string(
+        spectra_test_util:from_binary_string(
             TypeInfo,
             resolve_type(TypeInfo, my_literal_boolean, 0),
             <<"true">>
@@ -640,7 +640,7 @@ type_reference_test() ->
     %% Test union types
     ?assertEqual(
         {ok, 42},
-        spectra_binary_string:from_binary_string(
+        spectra_test_util:from_binary_string(
             TypeInfo,
             resolve_type(TypeInfo, my_union, 0),
             <<"42">>
@@ -648,7 +648,7 @@ type_reference_test() ->
     ),
     ?assertEqual(
         {ok, true},
-        spectra_binary_string:from_binary_string(
+        spectra_test_util:from_binary_string(
             TypeInfo,
             resolve_type(TypeInfo, my_union, 0),
             <<"true">>
@@ -656,7 +656,7 @@ type_reference_test() ->
     ),
     ?assertEqual(
         {ok, 1},
-        spectra_binary_string:from_binary_string(
+        spectra_test_util:from_binary_string(
             TypeInfo,
             resolve_type(TypeInfo, my_complex_union, 0),
             <<"1">>
@@ -664,7 +664,7 @@ type_reference_test() ->
     ),
     ?assertEqual(
         {ok, false},
-        spectra_binary_string:from_binary_string(
+        spectra_test_util:from_binary_string(
             TypeInfo,
             resolve_type(TypeInfo, my_complex_union, 0),
             <<"false">>
@@ -680,7 +680,7 @@ unsupported_test() ->
     %% Record types are not supported for binary string conversion
     ?assertError(
         {type_not_supported, _},
-        spectra_binary_string:from_binary_string(
+        spectra_test_util:from_binary_string(
             TypeInfo,
             #sp_rec{name = some_record, fields = [], arity = 0},
             <<"test">>
@@ -690,7 +690,7 @@ unsupported_test() ->
     %% Unsupported simple types should error
     ?assertError(
         {type_not_supported, _},
-        spectra_binary_string:from_binary_string(
+        spectra_test_util:from_binary_string(
             TypeInfo,
             #sp_simple_type{type = pid},
             <<"test">>
@@ -698,7 +698,7 @@ unsupported_test() ->
     ),
     ?assertError(
         {type_not_supported, _},
-        spectra_binary_string:from_binary_string(
+        spectra_test_util:from_binary_string(
             TypeInfo,
             #sp_simple_type{type = port},
             <<"test">>
@@ -706,7 +706,7 @@ unsupported_test() ->
     ),
     ?assertError(
         {type_not_supported, _},
-        spectra_binary_string:from_binary_string(
+        spectra_test_util:from_binary_string(
             TypeInfo,
             #sp_simple_type{type = reference},
             <<"test">>
@@ -714,7 +714,7 @@ unsupported_test() ->
     ),
     ?assertError(
         {type_not_supported, _},
-        spectra_binary_string:from_binary_string(
+        spectra_test_util:from_binary_string(
             TypeInfo,
             #sp_simple_type{type = bitstring},
             <<"test">>
@@ -722,7 +722,7 @@ unsupported_test() ->
     ),
     ?assertError(
         {type_not_supported, _},
-        spectra_binary_string:from_binary_string(
+        spectra_test_util:from_binary_string(
             TypeInfo,
             #sp_simple_type{
                 type =
@@ -733,7 +733,7 @@ unsupported_test() ->
     ),
     ?assertError(
         {type_not_supported, _},
-        spectra_binary_string:from_binary_string(
+        spectra_test_util:from_binary_string(
             TypeInfo,
             #sp_simple_type{type = none},
             <<"test">>
@@ -744,7 +744,7 @@ unsupported_test() ->
     UnknownType = #sp_tuple{fields = any},
     ?assertMatch(
         {error, [#sp_error{type = type_mismatch}]},
-        spectra_binary_string:from_binary_string(TypeInfo, UnknownType, <<"test">>)
+        spectra_test_util:from_binary_string(TypeInfo, UnknownType, <<"test">>)
     ),
 
     ok.
@@ -756,7 +756,7 @@ edge_cases_test() ->
     %% Empty strings
     ?assertEqual(
         {ok, ""},
-        spectra_binary_string:from_binary_string(
+        spectra_test_util:from_binary_string(
             TypeInfo,
             #sp_simple_type{type = string},
             <<"">>
@@ -764,7 +764,7 @@ edge_cases_test() ->
     ),
     ?assertEqual(
         {ok, <<"">>},
-        spectra_binary_string:from_binary_string(
+        spectra_test_util:from_binary_string(
             TypeInfo,
             #sp_simple_type{type = binary},
             <<"">>
@@ -772,7 +772,7 @@ edge_cases_test() ->
     ),
     ?assertMatch(
         {error, [#sp_error{type = type_mismatch}]},
-        spectra_binary_string:from_binary_string(
+        spectra_test_util:from_binary_string(
             TypeInfo,
             #sp_simple_type{type = nonempty_string},
             <<"">>
@@ -780,7 +780,7 @@ edge_cases_test() ->
     ),
     ?assertMatch(
         {error, [#sp_error{type = type_mismatch}]},
-        spectra_binary_string:from_binary_string(
+        spectra_test_util:from_binary_string(
             TypeInfo,
             #sp_simple_type{type = nonempty_binary},
             <<"">>
@@ -790,7 +790,7 @@ edge_cases_test() ->
     %% Large numbers
     ?assertEqual(
         {ok, 999999999999},
-        spectra_binary_string:from_binary_string(
+        spectra_test_util:from_binary_string(
             TypeInfo,
             #sp_simple_type{type = integer},
             <<"999999999999">>
@@ -798,7 +798,7 @@ edge_cases_test() ->
     ),
     ?assertEqual(
         {ok, -999999999999},
-        spectra_binary_string:from_binary_string(
+        spectra_test_util:from_binary_string(
             TypeInfo,
             #sp_simple_type{type = integer},
             <<"-999999999999">>
@@ -808,7 +808,7 @@ edge_cases_test() ->
     %% Special float values
     ?assertEqual(
         {ok, 0.0},
-        spectra_binary_string:from_binary_string(
+        spectra_test_util:from_binary_string(
             TypeInfo,
             #sp_simple_type{type = float},
             <<"0.0">>
@@ -816,7 +816,7 @@ edge_cases_test() ->
     ),
     ?assertEqual(
         {ok, -0.0},
-        spectra_binary_string:from_binary_string(
+        spectra_test_util:from_binary_string(
             TypeInfo,
             #sp_simple_type{type = float},
             <<"-0.0">>
@@ -832,19 +832,19 @@ edge_cases_test() ->
         },
     ?assertEqual(
         {ok, -5},
-        spectra_binary_string:from_binary_string(TypeInfo, Range, <<"-5">>)
+        spectra_test_util:from_binary_string(TypeInfo, Range, <<"-5">>)
     ),
     ?assertEqual(
         {ok, 5},
-        spectra_binary_string:from_binary_string(TypeInfo, Range, <<"5">>)
+        spectra_test_util:from_binary_string(TypeInfo, Range, <<"5">>)
     ),
     ?assertMatch(
         {error, [#sp_error{type = type_mismatch}]},
-        spectra_binary_string:from_binary_string(TypeInfo, Range, <<"-6">>)
+        spectra_test_util:from_binary_string(TypeInfo, Range, <<"-6">>)
     ),
     ?assertMatch(
         {error, [#sp_error{type = type_mismatch}]},
-        spectra_binary_string:from_binary_string(TypeInfo, Range, <<"6">>)
+        spectra_test_util:from_binary_string(TypeInfo, Range, <<"6">>)
     ),
 
     ok.
@@ -856,7 +856,7 @@ to_binary_string_simple_types_test() ->
     %% integer
     ?assertEqual(
         {ok, <<"42">>},
-        spectra_binary_string:to_binary_string(
+        spectra_test_util:to_binary_string(
             TypeInfo,
             #sp_simple_type{type = integer},
             42
@@ -864,7 +864,7 @@ to_binary_string_simple_types_test() ->
     ),
     ?assertEqual(
         {ok, <<"-42">>},
-        spectra_binary_string:to_binary_string(
+        spectra_test_util:to_binary_string(
             TypeInfo,
             #sp_simple_type{type = integer},
             -42
@@ -872,7 +872,7 @@ to_binary_string_simple_types_test() ->
     ),
     ?assertMatch(
         {error, [#sp_error{type = type_mismatch}]},
-        spectra_binary_string:to_binary_string(
+        spectra_test_util:to_binary_string(
             TypeInfo,
             #sp_simple_type{type = integer},
             "not_integer"
@@ -882,7 +882,7 @@ to_binary_string_simple_types_test() ->
     %% float
     ?assertEqual(
         {ok, <<"3.14000000000000012434e+00">>},
-        spectra_binary_string:to_binary_string(
+        spectra_test_util:to_binary_string(
             TypeInfo,
             #sp_simple_type{type = float},
             3.14
@@ -890,7 +890,7 @@ to_binary_string_simple_types_test() ->
     ),
     ?assertEqual(
         {ok, <<"-3.14000000000000012434e+00">>},
-        spectra_binary_string:to_binary_string(
+        spectra_test_util:to_binary_string(
             TypeInfo,
             #sp_simple_type{type = float},
             -3.14
@@ -898,7 +898,7 @@ to_binary_string_simple_types_test() ->
     ),
     ?assertMatch(
         {error, [#sp_error{type = type_mismatch}]},
-        spectra_binary_string:to_binary_string(
+        spectra_test_util:to_binary_string(
             TypeInfo,
             #sp_simple_type{type = float},
             42
@@ -908,7 +908,7 @@ to_binary_string_simple_types_test() ->
     %% number
     ?assertEqual(
         {ok, <<"42">>},
-        spectra_binary_string:to_binary_string(
+        spectra_test_util:to_binary_string(
             TypeInfo,
             #sp_simple_type{type = number},
             42
@@ -916,7 +916,7 @@ to_binary_string_simple_types_test() ->
     ),
     ?assertEqual(
         {ok, <<"3.14000000000000012434e+00">>},
-        spectra_binary_string:to_binary_string(
+        spectra_test_util:to_binary_string(
             TypeInfo,
             #sp_simple_type{type = number},
             3.14
@@ -924,7 +924,7 @@ to_binary_string_simple_types_test() ->
     ),
     ?assertMatch(
         {error, [#sp_error{type = type_mismatch}]},
-        spectra_binary_string:to_binary_string(
+        spectra_test_util:to_binary_string(
             TypeInfo,
             #sp_simple_type{type = number},
             "not_number"
@@ -934,7 +934,7 @@ to_binary_string_simple_types_test() ->
     %% boolean
     ?assertEqual(
         {ok, <<"true">>},
-        spectra_binary_string:to_binary_string(
+        spectra_test_util:to_binary_string(
             TypeInfo,
             #sp_simple_type{type = boolean},
             true
@@ -942,7 +942,7 @@ to_binary_string_simple_types_test() ->
     ),
     ?assertEqual(
         {ok, <<"false">>},
-        spectra_binary_string:to_binary_string(
+        spectra_test_util:to_binary_string(
             TypeInfo,
             #sp_simple_type{type = boolean},
             false
@@ -950,7 +950,7 @@ to_binary_string_simple_types_test() ->
     ),
     ?assertMatch(
         {error, [#sp_error{type = type_mismatch}]},
-        spectra_binary_string:to_binary_string(
+        spectra_test_util:to_binary_string(
             TypeInfo,
             #sp_simple_type{type = boolean},
             "true"
@@ -960,7 +960,7 @@ to_binary_string_simple_types_test() ->
     %% atom
     ?assertEqual(
         {ok, <<"hello">>},
-        spectra_binary_string:to_binary_string(
+        spectra_test_util:to_binary_string(
             TypeInfo,
             #sp_simple_type{type = atom},
             hello
@@ -968,7 +968,7 @@ to_binary_string_simple_types_test() ->
     ),
     ?assertEqual(
         {ok, <<"hello world">>},
-        spectra_binary_string:to_binary_string(
+        spectra_test_util:to_binary_string(
             TypeInfo,
             #sp_simple_type{type = atom},
             'hello world'
@@ -976,7 +976,7 @@ to_binary_string_simple_types_test() ->
     ),
     ?assertMatch(
         {error, [#sp_error{type = type_mismatch}]},
-        spectra_binary_string:to_binary_string(
+        spectra_test_util:to_binary_string(
             TypeInfo,
             #sp_simple_type{type = atom},
             "hello"
@@ -986,7 +986,7 @@ to_binary_string_simple_types_test() ->
     %% string
     ?assertEqual(
         {ok, <<"hello">>},
-        spectra_binary_string:to_binary_string(
+        spectra_test_util:to_binary_string(
             TypeInfo,
             #sp_simple_type{type = string},
             "hello"
@@ -994,7 +994,7 @@ to_binary_string_simple_types_test() ->
     ),
     ?assertEqual(
         {ok, <<"">>},
-        spectra_binary_string:to_binary_string(
+        spectra_test_util:to_binary_string(
             TypeInfo,
             #sp_simple_type{type = string},
             ""
@@ -1002,7 +1002,7 @@ to_binary_string_simple_types_test() ->
     ),
     ?assertMatch(
         {error, [#sp_error{type = type_mismatch}]},
-        spectra_binary_string:to_binary_string(
+        spectra_test_util:to_binary_string(
             TypeInfo,
             #sp_simple_type{type = string},
             <<"binary">>
@@ -1012,7 +1012,7 @@ to_binary_string_simple_types_test() ->
     %% nonempty_string
     ?assertEqual(
         {ok, <<"hello">>},
-        spectra_binary_string:to_binary_string(
+        spectra_test_util:to_binary_string(
             TypeInfo,
             #sp_simple_type{type = nonempty_string},
             "hello"
@@ -1020,7 +1020,7 @@ to_binary_string_simple_types_test() ->
     ),
     ?assertMatch(
         {error, [#sp_error{type = type_mismatch}]},
-        spectra_binary_string:to_binary_string(
+        spectra_test_util:to_binary_string(
             TypeInfo,
             #sp_simple_type{type = nonempty_string},
             ""
@@ -1030,7 +1030,7 @@ to_binary_string_simple_types_test() ->
     %% binary
     ?assertEqual(
         {ok, <<"hello">>},
-        spectra_binary_string:to_binary_string(
+        spectra_test_util:to_binary_string(
             TypeInfo,
             #sp_simple_type{type = binary},
             <<"hello">>
@@ -1038,7 +1038,7 @@ to_binary_string_simple_types_test() ->
     ),
     ?assertEqual(
         {ok, <<"">>},
-        spectra_binary_string:to_binary_string(
+        spectra_test_util:to_binary_string(
             TypeInfo,
             #sp_simple_type{type = binary},
             <<"">>
@@ -1046,7 +1046,7 @@ to_binary_string_simple_types_test() ->
     ),
     ?assertMatch(
         {error, [#sp_error{type = type_mismatch}]},
-        spectra_binary_string:to_binary_string(
+        spectra_test_util:to_binary_string(
             TypeInfo,
             #sp_simple_type{type = binary},
             "string"
@@ -1056,7 +1056,7 @@ to_binary_string_simple_types_test() ->
     %% nonempty_binary
     ?assertEqual(
         {ok, <<"hello">>},
-        spectra_binary_string:to_binary_string(
+        spectra_test_util:to_binary_string(
             TypeInfo,
             #sp_simple_type{type = nonempty_binary},
             <<"hello">>
@@ -1064,7 +1064,7 @@ to_binary_string_simple_types_test() ->
     ),
     ?assertMatch(
         {error, [#sp_error{type = type_mismatch}]},
-        spectra_binary_string:to_binary_string(
+        spectra_test_util:to_binary_string(
             TypeInfo,
             #sp_simple_type{type = nonempty_binary},
             <<"">>
@@ -1074,7 +1074,7 @@ to_binary_string_simple_types_test() ->
     %% non_neg_integer
     ?assertEqual(
         {ok, <<"42">>},
-        spectra_binary_string:to_binary_string(
+        spectra_test_util:to_binary_string(
             TypeInfo,
             #sp_simple_type{type = non_neg_integer},
             42
@@ -1082,7 +1082,7 @@ to_binary_string_simple_types_test() ->
     ),
     ?assertEqual(
         {ok, <<"0">>},
-        spectra_binary_string:to_binary_string(
+        spectra_test_util:to_binary_string(
             TypeInfo,
             #sp_simple_type{type = non_neg_integer},
             0
@@ -1090,7 +1090,7 @@ to_binary_string_simple_types_test() ->
     ),
     ?assertMatch(
         {error, [#sp_error{type = type_mismatch}]},
-        spectra_binary_string:to_binary_string(
+        spectra_test_util:to_binary_string(
             TypeInfo,
             #sp_simple_type{type = non_neg_integer},
             -1
@@ -1100,7 +1100,7 @@ to_binary_string_simple_types_test() ->
     %% pos_integer
     ?assertEqual(
         {ok, <<"42">>},
-        spectra_binary_string:to_binary_string(
+        spectra_test_util:to_binary_string(
             TypeInfo,
             #sp_simple_type{type = pos_integer},
             42
@@ -1108,7 +1108,7 @@ to_binary_string_simple_types_test() ->
     ),
     ?assertMatch(
         {error, [#sp_error{type = type_mismatch}]},
-        spectra_binary_string:to_binary_string(
+        spectra_test_util:to_binary_string(
             TypeInfo,
             #sp_simple_type{type = pos_integer},
             0
@@ -1116,7 +1116,7 @@ to_binary_string_simple_types_test() ->
     ),
     ?assertMatch(
         {error, [#sp_error{type = type_mismatch}]},
-        spectra_binary_string:to_binary_string(
+        spectra_test_util:to_binary_string(
             TypeInfo,
             #sp_simple_type{type = pos_integer},
             -1
@@ -1126,7 +1126,7 @@ to_binary_string_simple_types_test() ->
     %% neg_integer
     ?assertEqual(
         {ok, <<"-42">>},
-        spectra_binary_string:to_binary_string(
+        spectra_test_util:to_binary_string(
             TypeInfo,
             #sp_simple_type{type = neg_integer},
             -42
@@ -1134,7 +1134,7 @@ to_binary_string_simple_types_test() ->
     ),
     ?assertMatch(
         {error, [#sp_error{type = type_mismatch}]},
-        spectra_binary_string:to_binary_string(
+        spectra_test_util:to_binary_string(
             TypeInfo,
             #sp_simple_type{type = neg_integer},
             0
@@ -1142,7 +1142,7 @@ to_binary_string_simple_types_test() ->
     ),
     ?assertMatch(
         {error, [#sp_error{type = type_mismatch}]},
-        spectra_binary_string:to_binary_string(
+        spectra_test_util:to_binary_string(
             TypeInfo,
             #sp_simple_type{type = neg_integer},
             42
@@ -1162,35 +1162,35 @@ to_binary_string_range_test() ->
         },
 
     %% Valid values in range
-    ?assertEqual({ok, <<"1">>}, spectra_binary_string:to_binary_string(TypeInfo, Range, 1)),
-    ?assertEqual({ok, <<"5">>}, spectra_binary_string:to_binary_string(TypeInfo, Range, 5)),
+    ?assertEqual({ok, <<"1">>}, spectra_test_util:to_binary_string(TypeInfo, Range, 1)),
+    ?assertEqual({ok, <<"5">>}, spectra_test_util:to_binary_string(TypeInfo, Range, 5)),
     ?assertEqual(
         {ok, <<"10">>},
-        spectra_binary_string:to_binary_string(TypeInfo, Range, 10)
+        spectra_test_util:to_binary_string(TypeInfo, Range, 10)
     ),
 
     %% Invalid values outside range
     ?assertMatch(
         {error, [#sp_error{type = type_mismatch}]},
-        spectra_binary_string:to_binary_string(TypeInfo, Range, 0)
+        spectra_test_util:to_binary_string(TypeInfo, Range, 0)
     ),
     ?assertMatch(
         {error, [#sp_error{type = type_mismatch}]},
-        spectra_binary_string:to_binary_string(TypeInfo, Range, 11)
+        spectra_test_util:to_binary_string(TypeInfo, Range, 11)
     ),
     ?assertMatch(
         {error, [#sp_error{type = type_mismatch}]},
-        spectra_binary_string:to_binary_string(TypeInfo, Range, -5)
+        spectra_test_util:to_binary_string(TypeInfo, Range, -5)
     ),
 
     %% Invalid non-integer values
     ?assertMatch(
         {error, [#sp_error{type = type_mismatch}]},
-        spectra_binary_string:to_binary_string(TypeInfo, Range, "5")
+        spectra_test_util:to_binary_string(TypeInfo, Range, "5")
     ),
     ?assertMatch(
         {error, [#sp_error{type = type_mismatch}]},
-        spectra_binary_string:to_binary_string(TypeInfo, Range, 5.5)
+        spectra_test_util:to_binary_string(TypeInfo, Range, 5.5)
     ),
 
     ok.
@@ -1203,43 +1203,43 @@ to_binary_string_literal_test() ->
     AtomLiteral = #sp_literal{value = hello},
     ?assertEqual(
         {ok, <<"hello">>},
-        spectra_binary_string:to_binary_string(TypeInfo, AtomLiteral, hello)
+        spectra_test_util:to_binary_string(TypeInfo, AtomLiteral, hello)
     ),
     ?assertMatch(
         {error, [#sp_error{type = type_mismatch}]},
-        spectra_binary_string:to_binary_string(TypeInfo, AtomLiteral, world)
+        spectra_test_util:to_binary_string(TypeInfo, AtomLiteral, world)
     ),
 
     %% Literal integer
     IntegerLiteral = #sp_literal{value = 42},
     ?assertEqual(
         {ok, <<"42">>},
-        spectra_binary_string:to_binary_string(TypeInfo, IntegerLiteral, 42)
+        spectra_test_util:to_binary_string(TypeInfo, IntegerLiteral, 42)
     ),
     ?assertMatch(
         {error, [#sp_error{type = type_mismatch}]},
-        spectra_binary_string:to_binary_string(TypeInfo, IntegerLiteral, 43)
+        spectra_test_util:to_binary_string(TypeInfo, IntegerLiteral, 43)
     ),
 
     %% Literal boolean
     BooleanLiteralTrue = #sp_literal{value = true},
     ?assertEqual(
         {ok, <<"true">>},
-        spectra_binary_string:to_binary_string(TypeInfo, BooleanLiteralTrue, true)
+        spectra_test_util:to_binary_string(TypeInfo, BooleanLiteralTrue, true)
     ),
     ?assertMatch(
         {error, [#sp_error{type = type_mismatch}]},
-        spectra_binary_string:to_binary_string(TypeInfo, BooleanLiteralTrue, false)
+        spectra_test_util:to_binary_string(TypeInfo, BooleanLiteralTrue, false)
     ),
 
     BooleanLiteralFalse = #sp_literal{value = false},
     ?assertEqual(
         {ok, <<"false">>},
-        spectra_binary_string:to_binary_string(TypeInfo, BooleanLiteralFalse, false)
+        spectra_test_util:to_binary_string(TypeInfo, BooleanLiteralFalse, false)
     ),
     ?assertMatch(
         {error, [#sp_error{type = type_mismatch}]},
-        spectra_binary_string:to_binary_string(TypeInfo, BooleanLiteralFalse, true)
+        spectra_test_util:to_binary_string(TypeInfo, BooleanLiteralFalse, true)
     ),
 
     ok.
@@ -1253,19 +1253,19 @@ to_binary_string_union_test() ->
         #sp_union{types = [#sp_simple_type{type = integer}, #sp_simple_type{type = boolean}]},
     ?assertEqual(
         {ok, <<"42">>},
-        spectra_binary_string:to_binary_string(TypeInfo, Union, 42)
+        spectra_test_util:to_binary_string(TypeInfo, Union, 42)
     ),
     ?assertEqual(
         {ok, <<"true">>},
-        spectra_binary_string:to_binary_string(TypeInfo, Union, true)
+        spectra_test_util:to_binary_string(TypeInfo, Union, true)
     ),
     ?assertEqual(
         {ok, <<"false">>},
-        spectra_binary_string:to_binary_string(TypeInfo, Union, false)
+        spectra_test_util:to_binary_string(TypeInfo, Union, false)
     ),
     ?assertMatch(
         {error, [#sp_error{type = no_match}]},
-        spectra_binary_string:to_binary_string(TypeInfo, Union, "not_matching")
+        spectra_test_util:to_binary_string(TypeInfo, Union, "not_matching")
     ),
 
     %% Complex union with literals: 1 | 2 | true | false
@@ -1281,27 +1281,27 @@ to_binary_string_union_test() ->
         },
     ?assertEqual(
         {ok, <<"1">>},
-        spectra_binary_string:to_binary_string(TypeInfo, ComplexUnion, 1)
+        spectra_test_util:to_binary_string(TypeInfo, ComplexUnion, 1)
     ),
     ?assertEqual(
         {ok, <<"2">>},
-        spectra_binary_string:to_binary_string(TypeInfo, ComplexUnion, 2)
+        spectra_test_util:to_binary_string(TypeInfo, ComplexUnion, 2)
     ),
     ?assertEqual(
         {ok, <<"true">>},
-        spectra_binary_string:to_binary_string(TypeInfo, ComplexUnion, true)
+        spectra_test_util:to_binary_string(TypeInfo, ComplexUnion, true)
     ),
     ?assertEqual(
         {ok, <<"false">>},
-        spectra_binary_string:to_binary_string(TypeInfo, ComplexUnion, false)
+        spectra_test_util:to_binary_string(TypeInfo, ComplexUnion, false)
     ),
     ?assertMatch(
         {error, [#sp_error{type = no_match}]},
-        spectra_binary_string:to_binary_string(TypeInfo, ComplexUnion, 3)
+        spectra_test_util:to_binary_string(TypeInfo, ComplexUnion, 3)
     ),
     ?assertMatch(
         {error, [#sp_error{type = no_match}]},
-        spectra_binary_string:to_binary_string(TypeInfo, ComplexUnion, "maybe")
+        spectra_test_util:to_binary_string(TypeInfo, ComplexUnion, "maybe")
     ),
 
     ok.
@@ -1309,7 +1309,7 @@ to_binary_string_union_test() ->
 to_binary_string_union_error_accumulation_test() ->
     TypeInfo = spectra_abstract_code:types_in_module(?MODULE),
     Union = #sp_union{types = [#sp_simple_type{type = integer}, #sp_simple_type{type = boolean}]},
-    {error, [#sp_error{type = no_match, ctx = Ctx}]} = spectra_binary_string:to_binary_string(
+    {error, [#sp_error{type = no_match, ctx = Ctx}]} = spectra_test_util:to_binary_string(
         TypeInfo,
         Union,
         "not_matching"
@@ -1334,39 +1334,39 @@ to_binary_string_type_reference_test() ->
     %% Test various type references from the module
     ?assertEqual(
         {ok, <<"42">>},
-        spectra_binary_string:to_binary_string(TypeInfo, resolve_type(TypeInfo, my_integer, 0), 42)
+        spectra_test_util:to_binary_string(TypeInfo, resolve_type(TypeInfo, my_integer, 0), 42)
     ),
     ?assertEqual(
         {ok, <<"3.14000000000000012434e+00">>},
-        spectra_binary_string:to_binary_string(TypeInfo, resolve_type(TypeInfo, my_float, 0), 3.14)
+        spectra_test_util:to_binary_string(TypeInfo, resolve_type(TypeInfo, my_float, 0), 3.14)
     ),
     ?assertEqual(
         {ok, <<"42">>},
-        spectra_binary_string:to_binary_string(TypeInfo, resolve_type(TypeInfo, my_number, 0), 42)
+        spectra_test_util:to_binary_string(TypeInfo, resolve_type(TypeInfo, my_number, 0), 42)
     ),
     ?assertEqual(
         {ok, <<"3.14000000000000012434e+00">>},
-        spectra_binary_string:to_binary_string(TypeInfo, resolve_type(TypeInfo, my_number, 0), 3.14)
+        spectra_test_util:to_binary_string(TypeInfo, resolve_type(TypeInfo, my_number, 0), 3.14)
     ),
     ?assertEqual(
         {ok, <<"true">>},
-        spectra_binary_string:to_binary_string(
+        spectra_test_util:to_binary_string(
             TypeInfo, resolve_type(TypeInfo, my_boolean, 0), true
         )
     ),
     ?assertEqual(
         {ok, <<"hello">>},
-        spectra_binary_string:to_binary_string(TypeInfo, resolve_type(TypeInfo, my_atom, 0), hello)
+        spectra_test_util:to_binary_string(TypeInfo, resolve_type(TypeInfo, my_atom, 0), hello)
     ),
     ?assertEqual(
         {ok, <<"test">>},
-        spectra_binary_string:to_binary_string(
+        spectra_test_util:to_binary_string(
             TypeInfo, resolve_type(TypeInfo, my_string, 0), "test"
         )
     ),
     ?assertEqual(
         {ok, <<"test">>},
-        spectra_binary_string:to_binary_string(
+        spectra_test_util:to_binary_string(
             TypeInfo,
             resolve_type(TypeInfo, my_binary, 0),
             <<"test">>
@@ -1376,17 +1376,17 @@ to_binary_string_type_reference_test() ->
     %% Test range type
     ?assertEqual(
         {ok, <<"5">>},
-        spectra_binary_string:to_binary_string(TypeInfo, resolve_type(TypeInfo, my_range, 0), 5)
+        spectra_test_util:to_binary_string(TypeInfo, resolve_type(TypeInfo, my_range, 0), 5)
     ),
     ?assertMatch(
         {error, [#sp_error{type = type_mismatch}]},
-        spectra_binary_string:to_binary_string(TypeInfo, resolve_type(TypeInfo, my_range, 0), 15)
+        spectra_test_util:to_binary_string(TypeInfo, resolve_type(TypeInfo, my_range, 0), 15)
     ),
 
     %% Test literal types
     ?assertEqual(
         {ok, <<"hello">>},
-        spectra_binary_string:to_binary_string(
+        spectra_test_util:to_binary_string(
             TypeInfo,
             resolve_type(TypeInfo, my_literal_atom, 0),
             hello
@@ -1394,7 +1394,7 @@ to_binary_string_type_reference_test() ->
     ),
     ?assertEqual(
         {ok, <<"42">>},
-        spectra_binary_string:to_binary_string(
+        spectra_test_util:to_binary_string(
             TypeInfo,
             resolve_type(TypeInfo, my_literal_integer, 0),
             42
@@ -1402,7 +1402,7 @@ to_binary_string_type_reference_test() ->
     ),
     ?assertEqual(
         {ok, <<"true">>},
-        spectra_binary_string:to_binary_string(
+        spectra_test_util:to_binary_string(
             TypeInfo,
             resolve_type(TypeInfo, my_literal_boolean, 0),
             true
@@ -1412,15 +1412,15 @@ to_binary_string_type_reference_test() ->
     %% Test union types
     ?assertEqual(
         {ok, <<"42">>},
-        spectra_binary_string:to_binary_string(TypeInfo, resolve_type(TypeInfo, my_union, 0), 42)
+        spectra_test_util:to_binary_string(TypeInfo, resolve_type(TypeInfo, my_union, 0), 42)
     ),
     ?assertEqual(
         {ok, <<"true">>},
-        spectra_binary_string:to_binary_string(TypeInfo, resolve_type(TypeInfo, my_union, 0), true)
+        spectra_test_util:to_binary_string(TypeInfo, resolve_type(TypeInfo, my_union, 0), true)
     ),
     ?assertEqual(
         {ok, <<"1">>},
-        spectra_binary_string:to_binary_string(
+        spectra_test_util:to_binary_string(
             TypeInfo,
             resolve_type(TypeInfo, my_complex_union, 0),
             1
@@ -1428,7 +1428,7 @@ to_binary_string_type_reference_test() ->
     ),
     ?assertEqual(
         {ok, <<"false">>},
-        spectra_binary_string:to_binary_string(
+        spectra_test_util:to_binary_string(
             TypeInfo,
             resolve_type(TypeInfo, my_complex_union, 0),
             false
@@ -1444,7 +1444,7 @@ to_binary_string_unsupported_test() ->
     %% Record types are not supported for binary string conversion
     ?assertError(
         {type_not_supported, _},
-        spectra_binary_string:to_binary_string(
+        spectra_test_util:to_binary_string(
             TypeInfo,
             #sp_rec{name = some_record, fields = [], arity = 0},
             some_value
@@ -1454,7 +1454,7 @@ to_binary_string_unsupported_test() ->
     %% Unsupported simple types should error
     ?assertError(
         {type_not_supported, _},
-        spectra_binary_string:to_binary_string(
+        spectra_test_util:to_binary_string(
             TypeInfo,
             #sp_simple_type{type = pid},
             self()
@@ -1462,7 +1462,7 @@ to_binary_string_unsupported_test() ->
     ),
     ?assertError(
         {type_not_supported, _},
-        spectra_binary_string:to_binary_string(
+        spectra_test_util:to_binary_string(
             TypeInfo,
             #sp_simple_type{type = port},
             test
@@ -1470,7 +1470,7 @@ to_binary_string_unsupported_test() ->
     ),
     ?assertError(
         {type_not_supported, _},
-        spectra_binary_string:to_binary_string(
+        spectra_test_util:to_binary_string(
             TypeInfo,
             #sp_simple_type{type = reference},
             test
@@ -1478,7 +1478,7 @@ to_binary_string_unsupported_test() ->
     ),
     ?assertError(
         {type_not_supported, _},
-        spectra_binary_string:to_binary_string(
+        spectra_test_util:to_binary_string(
             TypeInfo,
             #sp_simple_type{type = bitstring},
             test
@@ -1486,7 +1486,7 @@ to_binary_string_unsupported_test() ->
     ),
     ?assertError(
         {type_not_supported, _},
-        spectra_binary_string:to_binary_string(
+        spectra_test_util:to_binary_string(
             TypeInfo,
             #sp_simple_type{
                 type =
@@ -1497,7 +1497,7 @@ to_binary_string_unsupported_test() ->
     ),
     ?assertError(
         {type_not_supported, _},
-        spectra_binary_string:to_binary_string(
+        spectra_test_util:to_binary_string(
             TypeInfo,
             #sp_simple_type{type = none},
             test
@@ -1508,7 +1508,7 @@ to_binary_string_unsupported_test() ->
     UnknownType = #sp_tuple{fields = any},
     ?assertMatch(
         {error, [#sp_error{type = type_mismatch}]},
-        spectra_binary_string:to_binary_string(TypeInfo, UnknownType, some_value)
+        spectra_test_util:to_binary_string(TypeInfo, UnknownType, some_value)
     ),
 
     ok.
@@ -1521,33 +1521,33 @@ literal_edge_cases_test() ->
     StringLiteral = #sp_literal{value = "hello"},
     ?assertMatch(
         {error, [#sp_error{type = type_mismatch}]},
-        spectra_binary_string:from_binary_string(TypeInfo, StringLiteral, <<"hello">>)
+        spectra_test_util:from_binary_string(TypeInfo, StringLiteral, <<"hello">>)
     ),
     ?assertMatch(
         {error, [#sp_error{type = type_mismatch}]},
-        spectra_binary_string:to_binary_string(TypeInfo, StringLiteral, "hello")
+        spectra_test_util:to_binary_string(TypeInfo, StringLiteral, "hello")
     ),
 
     %% Test float literal
     FloatLiteral = #sp_literal{value = 3.14},
     ?assertMatch(
         {error, [#sp_error{type = type_mismatch}]},
-        spectra_binary_string:from_binary_string(TypeInfo, FloatLiteral, <<"3.14">>)
+        spectra_test_util:from_binary_string(TypeInfo, FloatLiteral, <<"3.14">>)
     ),
     ?assertMatch(
         {error, [#sp_error{type = type_mismatch}]},
-        spectra_binary_string:to_binary_string(TypeInfo, FloatLiteral, 3.14)
+        spectra_test_util:to_binary_string(TypeInfo, FloatLiteral, 3.14)
     ),
 
     %% Test list literal
     ListLiteral = #sp_literal{value = [1, 2, 3]},
     ?assertMatch(
         {error, [#sp_error{type = type_mismatch}]},
-        spectra_binary_string:from_binary_string(TypeInfo, ListLiteral, <<"[1,2,3]">>)
+        spectra_test_util:from_binary_string(TypeInfo, ListLiteral, <<"[1,2,3]">>)
     ),
     ?assertMatch(
         {error, [#sp_error{type = type_mismatch}]},
-        spectra_binary_string:to_binary_string(TypeInfo, ListLiteral, [1, 2, 3])
+        spectra_test_util:to_binary_string(TypeInfo, ListLiteral, [1, 2, 3])
     ),
 
     ok.
@@ -1565,9 +1565,9 @@ remote_type_test() ->
     %% This should fail when trying to get the module types
     ?assertError(
         _,
-        spectra_binary_string:from_binary_string(TypeInfo, RemoteType, <<"test">>)
+        spectra_test_util:from_binary_string(TypeInfo, RemoteType, <<"test">>)
     ),
-    ?assertError(_, spectra_binary_string:to_binary_string(TypeInfo, RemoteType, test)),
+    ?assertError(_, spectra_test_util:to_binary_string(TypeInfo, RemoteType, test)),
 
     ok.
 
@@ -1587,11 +1587,11 @@ type_variables_test() ->
     Var = #sp_var{name = 'T'},
     ?assertMatch(
         {error, [#sp_error{type = type_mismatch}]},
-        spectra_binary_string:from_binary_string(TypeInfo, Var, <<"test">>)
+        spectra_test_util:from_binary_string(TypeInfo, Var, <<"test">>)
     ),
     ?assertMatch(
         {error, [#sp_error{type = type_mismatch}]},
-        spectra_binary_string:to_binary_string(TypeInfo, Var, test)
+        spectra_test_util:to_binary_string(TypeInfo, Var, test)
     ),
 
     %% Test parameterized type without concrete instantiation
@@ -1599,11 +1599,11 @@ type_variables_test() ->
     ParamType = #sp_type_with_variables{vars = ['T'], type = #sp_var{name = 'T'}},
     ?assertMatch(
         {error, [#sp_error{type = type_mismatch}]},
-        spectra_binary_string:from_binary_string(TypeInfo, ParamType, <<"42">>)
+        spectra_test_util:from_binary_string(TypeInfo, ParamType, <<"42">>)
     ),
     ?assertMatch(
         {error, [#sp_error{type = type_mismatch}]},
-        spectra_binary_string:to_binary_string(TypeInfo, ParamType, 42)
+        spectra_test_util:to_binary_string(TypeInfo, ParamType, 42)
     ),
 
     %% Test that the apply_args function exists and works (indirectly through the module interface)
@@ -1612,7 +1612,7 @@ type_variables_test() ->
     %% by checking they're parsed correctly (they don't crash, but need type arguments to work)
     ?assertMatch(
         {error, [#sp_error{type = type_mismatch}]},
-        spectra_binary_string:from_binary_string(
+        spectra_test_util:from_binary_string(
             TypeInfo,
             resolve_type(TypeInfo, my_parameterized, 1),
             <<"42">>
@@ -1622,7 +1622,7 @@ type_variables_test() ->
     %% Test constrained type variable - this should work like a regular integer type
     ?assertEqual(
         {ok, 42},
-        spectra_binary_string:from_binary_string(
+        spectra_test_util:from_binary_string(
             TypeInfo,
             resolve_type(TypeInfo, my_var_integer, 0),
             <<"42">>
@@ -1630,7 +1630,7 @@ type_variables_test() ->
     ),
     ?assertEqual(
         {ok, <<"42">>},
-        spectra_binary_string:to_binary_string(
+        spectra_test_util:to_binary_string(
             TypeInfo, resolve_type(TypeInfo, my_var_integer, 0), 42
         )
     ),
@@ -1638,7 +1638,7 @@ type_variables_test() ->
     %% Test that it rejects non-integer values
     ?assertMatch(
         {error, [#sp_error{type = type_mismatch}]},
-        spectra_binary_string:from_binary_string(
+        spectra_test_util:from_binary_string(
             TypeInfo,
             resolve_type(TypeInfo, my_var_integer, 0),
             <<"not_a_number">>
@@ -1655,7 +1655,7 @@ from_binary_string_invalid_input_test() ->
     %% Passing string instead of binary
     ?assertMatch(
         {error, [#sp_error{type = type_mismatch}]},
-        spectra_binary_string:from_binary_string(
+        spectra_test_util:from_binary_string(
             TypeInfo,
             #sp_simple_type{type = binary},
             "string"
@@ -1665,7 +1665,7 @@ from_binary_string_invalid_input_test() ->
     %% Passing integer instead of binary
     ?assertMatch(
         {error, [#sp_error{type = type_mismatch}]},
-        spectra_binary_string:from_binary_string(
+        spectra_test_util:from_binary_string(
             TypeInfo,
             #sp_simple_type{type = integer},
             42
@@ -1675,7 +1675,7 @@ from_binary_string_invalid_input_test() ->
     %% Passing atom instead of binary
     ?assertMatch(
         {error, [#sp_error{type = type_mismatch}]},
-        spectra_binary_string:from_binary_string(
+        spectra_test_util:from_binary_string(
             TypeInfo,
             #sp_simple_type{type = atom},
             hello
@@ -1692,7 +1692,7 @@ to_binary_string_invalid_input_test() ->
     %% Passing string when expecting to convert from binary
     ?assertMatch(
         {error, [#sp_error{type = type_mismatch}]},
-        spectra_binary_string:to_binary_string(
+        spectra_test_util:to_binary_string(
             TypeInfo,
             #sp_simple_type{type = binary},
             "string"
@@ -1702,7 +1702,7 @@ to_binary_string_invalid_input_test() ->
     %% Passing binary when expecting to convert from string
     ?assertMatch(
         {error, [#sp_error{type = type_mismatch}]},
-        spectra_binary_string:to_binary_string(
+        spectra_test_util:to_binary_string(
             TypeInfo,
             #sp_simple_type{type = string},
             <<"binary">>
@@ -1712,7 +1712,7 @@ to_binary_string_invalid_input_test() ->
     %% Passing list when expecting integer
     ?assertMatch(
         {error, [#sp_error{type = type_mismatch}]},
-        spectra_binary_string:to_binary_string(
+        spectra_test_util:to_binary_string(
             TypeInfo,
             #sp_simple_type{type = integer},
             [1, 2, 3]
@@ -1722,7 +1722,7 @@ to_binary_string_invalid_input_test() ->
     %% Passing string when expecting atom
     ?assertMatch(
         {error, [#sp_error{type = type_mismatch}]},
-        spectra_binary_string:to_binary_string(
+        spectra_test_util:to_binary_string(
             TypeInfo,
             #sp_simple_type{type = atom},
             "hello"

--- a/test/spectra_json_schema_doc_test.erl
+++ b/test/spectra_json_schema_doc_test.erl
@@ -220,7 +220,7 @@ record_ref_with_own_doc_test() ->
 
 %% Test passing sp_rec{} directly to to_schema
 record_sp_rec_direct_test() ->
-    TypeInfo = spectra_module_types:get(?MODULE),
+    TypeInfo = spectra_test_util:get_module_types(?MODULE),
     {ok, UserRec} = spectra_type_info:find_record(TypeInfo, user),
     SchemaJson = spectra:schema(json_schema, TypeInfo, UserRec),
     Schema = json:decode(iolist_to_binary(SchemaJson)),
@@ -245,7 +245,7 @@ record_sp_rec_direct_test() ->
 
 %% Test passing sp_rec_ref{} directly to to_schema
 record_sp_rec_ref_direct_test() ->
-    TypeInfo = spectra_module_types:get(?MODULE),
+    TypeInfo = spectra_test_util:get_module_types(?MODULE),
     % Get the user_ref type which is #sp_rec_ref{}
     UserRefType = spectra_type_info:get_type(TypeInfo, user_ref, 0),
     SchemaJson = spectra:schema(json_schema, TypeInfo, UserRefType),

--- a/test/spectra_json_sp_types_test.erl
+++ b/test/spectra_json_sp_types_test.erl
@@ -2,8 +2,6 @@
 
 -include_lib("eunit/include/eunit.hrl").
 
--include("../include/spectra.hrl").
-
 -compile(nowarn_unused_type).
 
 %% Test types for sp_types testing

--- a/test/spectra_json_sp_types_test.erl
+++ b/test/spectra_json_sp_types_test.erl
@@ -27,29 +27,29 @@ sp_types_to_json_test() ->
 
     %% Test simple types
     IntegerType = spectra_type_info:get_type(TypeInfo, my_integer, 0),
-    ?assertEqual({ok, 42}, spectra_json:to_json(TypeInfo, IntegerType, 42)),
+    ?assertEqual({ok, 42}, spectra_test_util:to_json(TypeInfo, IntegerType, 42)),
 
     StringType = spectra_type_info:get_type(TypeInfo, my_string, 0),
-    ?assertEqual({ok, <<"hello">>}, spectra_json:to_json(TypeInfo, StringType, "hello")),
+    ?assertEqual({ok, <<"hello">>}, spectra_test_util:to_json(TypeInfo, StringType, "hello")),
 
     BooleanType = spectra_type_info:get_type(TypeInfo, my_boolean, 0),
-    ?assertEqual({ok, true}, spectra_json:to_json(TypeInfo, BooleanType, true)),
+    ?assertEqual({ok, true}, spectra_test_util:to_json(TypeInfo, BooleanType, true)),
 
     %% Test list types
     ListType = spectra_type_info:get_type(TypeInfo, my_list_of_integers, 0),
-    ?assertEqual({ok, [1, 2, 3]}, spectra_json:to_json(TypeInfo, ListType, [1, 2, 3])),
+    ?assertEqual({ok, [1, 2, 3]}, spectra_test_util:to_json(TypeInfo, ListType, [1, 2, 3])),
 
     %% Test union types
     UnionType = spectra_type_info:get_type(TypeInfo, my_union, 0),
-    ?assertEqual({ok, 42}, spectra_json:to_json(TypeInfo, UnionType, 42)),
-    ?assertEqual({ok, <<"hello">>}, spectra_json:to_json(TypeInfo, UnionType, "hello")),
+    ?assertEqual({ok, 42}, spectra_test_util:to_json(TypeInfo, UnionType, 42)),
+    ?assertEqual({ok, <<"hello">>}, spectra_test_util:to_json(TypeInfo, UnionType, "hello")),
 
     %% Test map types
     MapType = spectra_type_info:get_type(TypeInfo, my_map, 0),
     MapData = #{name => "John", age => 30},
     ?assertEqual(
         {ok, #{<<"name">> => <<"John">>, <<"age">> => 30}},
-        spectra_json:to_json(TypeInfo, MapType, MapData)
+        spectra_test_util:to_json(TypeInfo, MapType, MapData)
     ).
 
 %% Test using sp_types directly with spectra_json:from_json/3
@@ -58,29 +58,29 @@ sp_types_from_json_test() ->
 
     %% Test simple types
     IntegerType = spectra_type_info:get_type(TypeInfo, my_integer, 0),
-    ?assertEqual({ok, 42}, spectra_json:from_json(TypeInfo, IntegerType, 42)),
+    ?assertEqual({ok, 42}, spectra_test_util:from_json(TypeInfo, IntegerType, 42)),
 
     StringType = spectra_type_info:get_type(TypeInfo, my_string, 0),
-    ?assertEqual({ok, "hello"}, spectra_json:from_json(TypeInfo, StringType, <<"hello">>)),
+    ?assertEqual({ok, "hello"}, spectra_test_util:from_json(TypeInfo, StringType, <<"hello">>)),
 
     BooleanType = spectra_type_info:get_type(TypeInfo, my_boolean, 0),
-    ?assertEqual({ok, true}, spectra_json:from_json(TypeInfo, BooleanType, true)),
+    ?assertEqual({ok, true}, spectra_test_util:from_json(TypeInfo, BooleanType, true)),
 
     %% Test list types
     ListType = spectra_type_info:get_type(TypeInfo, my_list_of_integers, 0),
-    ?assertEqual({ok, [1, 2, 3]}, spectra_json:from_json(TypeInfo, ListType, [1, 2, 3])),
+    ?assertEqual({ok, [1, 2, 3]}, spectra_test_util:from_json(TypeInfo, ListType, [1, 2, 3])),
 
     %% Test union types
     UnionType = spectra_type_info:get_type(TypeInfo, my_union, 0),
-    ?assertEqual({ok, 42}, spectra_json:from_json(TypeInfo, UnionType, 42)),
-    ?assertEqual({ok, "hello"}, spectra_json:from_json(TypeInfo, UnionType, <<"hello">>)),
+    ?assertEqual({ok, 42}, spectra_test_util:from_json(TypeInfo, UnionType, 42)),
+    ?assertEqual({ok, "hello"}, spectra_test_util:from_json(TypeInfo, UnionType, <<"hello">>)),
 
     %% Test map types
     MapType = spectra_type_info:get_type(TypeInfo, my_map, 0),
     JsonData = #{<<"name">> => <<"John">>, <<"age">> => 30},
     ?assertEqual(
         {ok, #{name => "John", age => 30}},
-        spectra_json:from_json(TypeInfo, MapType, JsonData)
+        spectra_test_util:from_json(TypeInfo, MapType, JsonData)
     ).
 
 %% Test using sp_rec directly with spectra_json functions
@@ -102,7 +102,7 @@ sp_record_types_test() ->
             <<"name">> => <<"Alice">>,
             <<"email">> => <<"alice@example.com">>
         }},
-        spectra_json:to_json(TypeInfo, UserRecord, UserData)
+        spectra_test_util:to_json(TypeInfo, UserRecord, UserData)
     ),
 
     %% Test record deserialization using sp_rec
@@ -112,7 +112,7 @@ sp_record_types_test() ->
             <<"name">> => <<"Alice">>,
             <<"email">> => <<"alice@example.com">>
         },
-    ?assertEqual({ok, UserData}, spectra_json:from_json(TypeInfo, UserRecord, JsonData)).
+    ?assertEqual({ok, UserData}, spectra_test_util:from_json(TypeInfo, UserRecord, JsonData)).
 
 %% Test literal sp_types (extracted from types)
 literal_sp_types_test() ->
@@ -120,16 +120,16 @@ literal_sp_types_test() ->
 
     %% Test literal atom
     AtomLiteralType = spectra_type_info:get_type(TypeInfo, my_literal_atom, 0),
-    ?assertEqual({ok, <<"hello">>}, spectra_json:to_json(TypeInfo, AtomLiteralType, hello)),
+    ?assertEqual({ok, <<"hello">>}, spectra_test_util:to_json(TypeInfo, AtomLiteralType, hello)),
     ?assertEqual(
         {ok, hello},
-        spectra_json:from_json(TypeInfo, AtomLiteralType, <<"hello">>)
+        spectra_test_util:from_json(TypeInfo, AtomLiteralType, <<"hello">>)
     ),
 
     %% Test literal integer
     IntLiteralType = spectra_type_info:get_type(TypeInfo, my_literal_integer, 0),
-    ?assertEqual({ok, 42}, spectra_json:to_json(TypeInfo, IntLiteralType, 42)),
-    ?assertEqual({ok, 42}, spectra_json:from_json(TypeInfo, IntLiteralType, 42)).
+    ?assertEqual({ok, 42}, spectra_test_util:to_json(TypeInfo, IntLiteralType, 42)),
+    ?assertEqual({ok, 42}, spectra_test_util:from_json(TypeInfo, IntLiteralType, 42)).
 
 %% Test range sp_types (extracted from types)
 range_sp_types_test() ->
@@ -137,12 +137,12 @@ range_sp_types_test() ->
 
     %% Test integer range
     RangeType = spectra_type_info:get_type(TypeInfo, my_range, 0),
-    ?assertEqual({ok, 5}, spectra_json:to_json(TypeInfo, RangeType, 5)),
-    ?assertEqual({ok, 5}, spectra_json:from_json(TypeInfo, RangeType, 5)),
+    ?assertEqual({ok, 5}, spectra_test_util:to_json(TypeInfo, RangeType, 5)),
+    ?assertEqual({ok, 5}, spectra_test_util:from_json(TypeInfo, RangeType, 5)),
 
     %% Test out of range values
-    ?assertMatch({error, _}, spectra_json:to_json(TypeInfo, RangeType, 15)),
-    ?assertMatch({error, _}, spectra_json:from_json(TypeInfo, RangeType, 15)).
+    ?assertMatch({error, _}, spectra_test_util:to_json(TypeInfo, RangeType, 15)),
+    ?assertMatch({error, _}, spectra_test_util:from_json(TypeInfo, RangeType, 15)).
 
 %% Test nonempty list sp_types (extracted from types)
 nonempty_list_sp_types_test() ->
@@ -152,16 +152,16 @@ nonempty_list_sp_types_test() ->
     NonEmptyListType = spectra_type_info:get_type(TypeInfo, my_nonempty_list, 0),
     ?assertEqual(
         {ok, [1, 2, 3]},
-        spectra_json:to_json(TypeInfo, NonEmptyListType, [1, 2, 3])
+        spectra_test_util:to_json(TypeInfo, NonEmptyListType, [1, 2, 3])
     ),
     ?assertEqual(
         {ok, [1, 2, 3]},
-        spectra_json:from_json(TypeInfo, NonEmptyListType, [1, 2, 3])
+        spectra_test_util:from_json(TypeInfo, NonEmptyListType, [1, 2, 3])
     ),
 
     %% Test empty list should fail
-    ?assertMatch({error, _}, spectra_json:to_json(TypeInfo, NonEmptyListType, [])),
-    ?assertMatch({error, _}, spectra_json:from_json(TypeInfo, NonEmptyListType, [])).
+    ?assertMatch({error, _}, spectra_test_util:to_json(TypeInfo, NonEmptyListType, [])),
+    ?assertMatch({error, _}, spectra_test_util:from_json(TypeInfo, NonEmptyListType, [])).
 
 %% Test with type info from different module
 cross_module_sp_types_test() ->
@@ -170,8 +170,8 @@ cross_module_sp_types_test() ->
 
     %% Get a type from the other module and use it
     MyIntegerType = spectra_type_info:get_type(OtherModuleTypeInfo, my_integer, 0),
-    ?assertEqual({ok, 42}, spectra_json:to_json(OtherModuleTypeInfo, MyIntegerType, 42)),
-    ?assertEqual({ok, 42}, spectra_json:from_json(OtherModuleTypeInfo, MyIntegerType, 42)).
+    ?assertEqual({ok, 42}, spectra_test_util:to_json(OtherModuleTypeInfo, MyIntegerType, 42)),
+    ?assertEqual({ok, 42}, spectra_test_util:from_json(OtherModuleTypeInfo, MyIntegerType, 42)).
 
 %% Test passing TypeInfo vs passing module directly
 typeinfo_vs_module_test() ->
@@ -180,12 +180,12 @@ typeinfo_vs_module_test() ->
 
     %% These two should give the same result
     Result1 = spectra:encode(json, ?MODULE, IntegerType, 42, [pre_encoded]),
-    Result2 = spectra_json:to_json(TypeInfo, IntegerType, 42),
+    Result2 = spectra_test_util:to_json(TypeInfo, IntegerType, 42),
     ?assertEqual(Result1, Result2),
     ?assertEqual({ok, 42}, Result1),
 
     %% Same for from_json
     JsonResult1 = spectra:decode(json, ?MODULE, IntegerType, 42, [pre_decoded]),
-    JsonResult2 = spectra_json:from_json(TypeInfo, IntegerType, 42),
+    JsonResult2 = spectra_test_util:from_json(TypeInfo, IntegerType, 42),
     ?assertEqual(JsonResult1, JsonResult2),
     ?assertEqual({ok, 42}, JsonResult1).

--- a/test/spectra_module_types_test.erl
+++ b/test/spectra_module_types_test.erl
@@ -88,3 +88,15 @@ get_module_with_type_info_fun_with_persistent_cache_test() ->
     ),
     ?assertEqual(TypeInfo1, TypeInfo2),
     spectra_module_types:clear(spectra_test_module_with_spectra).
+
+local_cache_cleared_after_spectra_decode_test() ->
+    %% The local cache is stored in the process dictionary; verify it is
+    %% absent after a spectra:decode/4 call returns (try...after cleanup).
+    spectra_module_types:clear_local(),
+    _ = spectra:decode(json, other, account, <<"null">>),
+    ?assertEqual(undefined, erlang:get({spectra_module_types, local_cache})).
+
+local_cache_cleared_after_spectra_encode_test() ->
+    spectra_module_types:clear_local(),
+    _ = spectra:encode(json, other, account, undefined),
+    ?assertEqual(undefined, erlang:get({spectra_module_types, local_cache})).

--- a/test/spectra_module_types_test.erl
+++ b/test/spectra_module_types_test.erl
@@ -5,47 +5,66 @@
 -include("../include/spectra_internal.hrl").
 
 get_module_types_without_cache_test() ->
-    application:set_env(spectra, use_module_types_cache, false),
+    application:set_env(spectra, module_types_cache, none),
     TypeInfo = spectra_module_types:get(other),
     ?assert(is_record(TypeInfo, type_info)),
     ?assertMatch({ok, _}, spectra_type_info:find_type(TypeInfo, account, 0)).
 
-get_module_types_with_cache_test() ->
-    application:set_env(spectra, use_module_types_cache, true),
+get_module_types_with_persistent_cache_test() ->
+    application:set_env(spectra, module_types_cache, persistent),
     spectra_module_types:clear(other),
     TypeInfo1 = spectra_module_types:get(other),
     ?assert(is_record(TypeInfo1, type_info)),
     TypeInfo2 = spectra_module_types:get(other),
     ?assertEqual(TypeInfo1, TypeInfo2),
-    application:set_env(spectra, use_module_types_cache, false),
+    application:set_env(spectra, module_types_cache, none),
     spectra_module_types:clear(other).
 
+get_module_types_with_local_cache_test() ->
+    application:set_env(spectra, module_types_cache, local),
+    spectra_module_types:clear_local(),
+    TypeInfo1 = spectra_module_types:get(other),
+    ?assert(is_record(TypeInfo1, type_info)),
+    TypeInfo2 = spectra_module_types:get(other),
+    ?assertEqual(TypeInfo1, TypeInfo2),
+    application:set_env(spectra, module_types_cache, none),
+    spectra_module_types:clear_local().
+
 cache_clear_test() ->
-    application:set_env(spectra, use_module_types_cache, true),
+    application:set_env(spectra, module_types_cache, persistent),
     _TypeInfo1 = spectra_module_types:get(other),
     ok = spectra_module_types:clear(other),
     TypeInfo2 = spectra_module_types:get(other),
     ?assert(is_record(TypeInfo2, type_info)),
-    application:set_env(spectra, use_module_types_cache, false),
+    application:set_env(spectra, module_types_cache, none),
     spectra_module_types:clear(other).
 
+local_cache_clear_test() ->
+    application:set_env(spectra, module_types_cache, local),
+    _TypeInfo1 = spectra_module_types:get(other),
+    ok = spectra_module_types:clear_local(),
+    TypeInfo2 = spectra_module_types:get(other),
+    ?assert(is_record(TypeInfo2, type_info)),
+    application:set_env(spectra, module_types_cache, none),
+    spectra_module_types:clear_local().
+
 get_nonexistent_module_test() ->
-    application:set_env(spectra, use_module_types_cache, false),
+    application:set_env(spectra, module_types_cache, none),
     ?assertError(
         {module_types_not_found, nonexistent_module_xyz, nofile},
         spectra_module_types:get(nonexistent_module_xyz)
     ).
 
-get_nonexistent_module_with_cache_test() ->
-    application:set_env(spectra, use_module_types_cache, true),
+get_nonexistent_module_with_persistent_cache_test() ->
+    application:set_env(spectra, module_types_cache, persistent),
     ?assertError(
         {module_types_not_found, nonexistent_module_abc, nofile},
         spectra_module_types:get(nonexistent_module_abc)
     ),
-    application:set_env(spectra, use_module_types_cache, false).
+    application:set_env(spectra, module_types_cache, none).
 
 cache_consistency_test() ->
-    application:set_env(spectra, use_module_types_cache, true),
+    application:set_env(spectra, module_types_cache, persistent),
     spectra_module_types:clear(other),
     TypeInfo1 = spectra_module_types:get(other),
     TypeInfo2 = spectra_module_types:get(other),
@@ -53,21 +72,32 @@ cache_consistency_test() ->
     ?assertEqual(TypeInfo1, TypeInfo2),
     ?assertEqual(TypeInfo2, TypeInfo3),
     _AccountType = spectra_type_info:get_type(TypeInfo3, account, 0),
-    application:set_env(spectra, use_module_types_cache, false),
+    application:set_env(spectra, module_types_cache, none),
     spectra_module_types:clear(other).
 
+local_cache_consistency_test() ->
+    application:set_env(spectra, module_types_cache, local),
+    spectra_module_types:clear_local(),
+    TypeInfo1 = spectra_module_types:get(other),
+    TypeInfo2 = spectra_module_types:get(other),
+    TypeInfo3 = spectra_module_types:get(other),
+    ?assertEqual(TypeInfo1, TypeInfo2),
+    ?assertEqual(TypeInfo2, TypeInfo3),
+    application:set_env(spectra, module_types_cache, none),
+    spectra_module_types:clear_local().
+
 get_module_with_type_info_fun_without_cache_test() ->
-    application:set_env(spectra, use_module_types_cache, false),
+    application:set_env(spectra, module_types_cache, none),
     TypeInfo = spectra_module_types:get(spectra_test_module_with_spectra),
     ?assert(is_record(TypeInfo, type_info)),
     ?assertMatch({ok, _}, spectra_type_info:find_type(TypeInfo, my_type, 0)).
 
-get_module_with_type_info_fun_with_cache_test() ->
-    application:set_env(spectra, use_module_types_cache, true),
+get_module_with_type_info_fun_with_persistent_cache_test() ->
+    application:set_env(spectra, module_types_cache, persistent),
     spectra_module_types:clear(spectra_test_module_with_spectra),
     TypeInfo1 = spectra_module_types:get(spectra_test_module_with_spectra),
     ?assert(is_record(TypeInfo1, type_info)),
     TypeInfo2 = spectra_module_types:get(spectra_test_module_with_spectra),
     ?assertEqual(TypeInfo1, TypeInfo2),
-    application:set_env(spectra, use_module_types_cache, false),
+    application:set_env(spectra, module_types_cache, none),
     spectra_module_types:clear(spectra_test_module_with_spectra).

--- a/test/spectra_module_types_test.erl
+++ b/test/spectra_module_types_test.erl
@@ -5,99 +5,86 @@
 -include("../include/spectra_internal.hrl").
 
 get_module_types_without_cache_test() ->
-    application:set_env(spectra, module_types_cache, none),
-    TypeInfo = spectra_module_types:get(other),
+    TypeInfo = spectra_module_types:get(other, #sp_config{module_types_cache = none}),
     ?assert(is_record(TypeInfo, type_info)),
     ?assertMatch({ok, _}, spectra_type_info:find_type(TypeInfo, account, 0)).
 
 get_module_types_with_persistent_cache_test() ->
-    application:set_env(spectra, module_types_cache, persistent),
     spectra_module_types:clear(other),
-    TypeInfo1 = spectra_module_types:get(other),
+    TypeInfo1 = spectra_module_types:get(other, #sp_config{module_types_cache = persistent}),
     ?assert(is_record(TypeInfo1, type_info)),
-    TypeInfo2 = spectra_module_types:get(other),
+    TypeInfo2 = spectra_module_types:get(other, #sp_config{module_types_cache = persistent}),
     ?assertEqual(TypeInfo1, TypeInfo2),
-    application:set_env(spectra, module_types_cache, none),
     spectra_module_types:clear(other).
 
 get_module_types_with_local_cache_test() ->
-    application:set_env(spectra, module_types_cache, local),
     spectra_module_types:clear_local(),
-    TypeInfo1 = spectra_module_types:get(other),
+    TypeInfo1 = spectra_module_types:get(other, #sp_config{module_types_cache = local}),
     ?assert(is_record(TypeInfo1, type_info)),
-    TypeInfo2 = spectra_module_types:get(other),
+    TypeInfo2 = spectra_module_types:get(other, #sp_config{module_types_cache = local}),
     ?assertEqual(TypeInfo1, TypeInfo2),
-    application:set_env(spectra, module_types_cache, none),
     spectra_module_types:clear_local().
 
 cache_clear_test() ->
-    application:set_env(spectra, module_types_cache, persistent),
-    _TypeInfo1 = spectra_module_types:get(other),
+    _TypeInfo1 = spectra_module_types:get(other, #sp_config{module_types_cache = persistent}),
     ok = spectra_module_types:clear(other),
-    TypeInfo2 = spectra_module_types:get(other),
+    TypeInfo2 = spectra_module_types:get(other, #sp_config{module_types_cache = persistent}),
     ?assert(is_record(TypeInfo2, type_info)),
-    application:set_env(spectra, module_types_cache, none),
     spectra_module_types:clear(other).
 
 local_cache_clear_test() ->
-    application:set_env(spectra, module_types_cache, local),
-    _TypeInfo1 = spectra_module_types:get(other),
+    _TypeInfo1 = spectra_module_types:get(other, #sp_config{module_types_cache = local}),
     ok = spectra_module_types:clear_local(),
-    TypeInfo2 = spectra_module_types:get(other),
+    TypeInfo2 = spectra_module_types:get(other, #sp_config{module_types_cache = local}),
     ?assert(is_record(TypeInfo2, type_info)),
-    application:set_env(spectra, module_types_cache, none),
     spectra_module_types:clear_local().
 
 get_nonexistent_module_test() ->
-    application:set_env(spectra, module_types_cache, none),
     ?assertError(
         {module_types_not_found, nonexistent_module_xyz, nofile},
-        spectra_module_types:get(nonexistent_module_xyz)
+        spectra_module_types:get(nonexistent_module_xyz, #sp_config{module_types_cache = none})
     ).
 
 get_nonexistent_module_with_persistent_cache_test() ->
-    application:set_env(spectra, module_types_cache, persistent),
     ?assertError(
         {module_types_not_found, nonexistent_module_abc, nofile},
-        spectra_module_types:get(nonexistent_module_abc)
-    ),
-    application:set_env(spectra, module_types_cache, none).
+        spectra_module_types:get(nonexistent_module_abc, #sp_config{module_types_cache = persistent})
+    ).
 
 cache_consistency_test() ->
-    application:set_env(spectra, module_types_cache, persistent),
     spectra_module_types:clear(other),
-    TypeInfo1 = spectra_module_types:get(other),
-    TypeInfo2 = spectra_module_types:get(other),
-    TypeInfo3 = spectra_module_types:get(other),
+    TypeInfo1 = spectra_module_types:get(other, #sp_config{module_types_cache = persistent}),
+    TypeInfo2 = spectra_module_types:get(other, #sp_config{module_types_cache = persistent}),
+    TypeInfo3 = spectra_module_types:get(other, #sp_config{module_types_cache = persistent}),
     ?assertEqual(TypeInfo1, TypeInfo2),
     ?assertEqual(TypeInfo2, TypeInfo3),
     _AccountType = spectra_type_info:get_type(TypeInfo3, account, 0),
-    application:set_env(spectra, module_types_cache, none),
     spectra_module_types:clear(other).
 
 local_cache_consistency_test() ->
-    application:set_env(spectra, module_types_cache, local),
     spectra_module_types:clear_local(),
-    TypeInfo1 = spectra_module_types:get(other),
-    TypeInfo2 = spectra_module_types:get(other),
-    TypeInfo3 = spectra_module_types:get(other),
+    TypeInfo1 = spectra_module_types:get(other, #sp_config{module_types_cache = local}),
+    TypeInfo2 = spectra_module_types:get(other, #sp_config{module_types_cache = local}),
+    TypeInfo3 = spectra_module_types:get(other, #sp_config{module_types_cache = local}),
     ?assertEqual(TypeInfo1, TypeInfo2),
     ?assertEqual(TypeInfo2, TypeInfo3),
-    application:set_env(spectra, module_types_cache, none),
     spectra_module_types:clear_local().
 
 get_module_with_type_info_fun_without_cache_test() ->
-    application:set_env(spectra, module_types_cache, none),
-    TypeInfo = spectra_module_types:get(spectra_test_module_with_spectra),
+    TypeInfo = spectra_module_types:get(
+        spectra_test_module_with_spectra, #sp_config{module_types_cache = none}
+    ),
     ?assert(is_record(TypeInfo, type_info)),
     ?assertMatch({ok, _}, spectra_type_info:find_type(TypeInfo, my_type, 0)).
 
 get_module_with_type_info_fun_with_persistent_cache_test() ->
-    application:set_env(spectra, module_types_cache, persistent),
     spectra_module_types:clear(spectra_test_module_with_spectra),
-    TypeInfo1 = spectra_module_types:get(spectra_test_module_with_spectra),
+    TypeInfo1 = spectra_module_types:get(
+        spectra_test_module_with_spectra, #sp_config{module_types_cache = persistent}
+    ),
     ?assert(is_record(TypeInfo1, type_info)),
-    TypeInfo2 = spectra_module_types:get(spectra_test_module_with_spectra),
+    TypeInfo2 = spectra_module_types:get(
+        spectra_test_module_with_spectra, #sp_config{module_types_cache = persistent}
+    ),
     ?assertEqual(TypeInfo1, TypeInfo2),
-    application:set_env(spectra, module_types_cache, none),
     spectra_module_types:clear(spectra_test_module_with_spectra).

--- a/test/spectra_string_test.erl
+++ b/test/spectra_string_test.erl
@@ -448,7 +448,9 @@ type_reference_test() ->
     ),
     ?assertEqual(
         {ok, true},
-        spectra_test_util:from_string(TypeInfo, resolve_type(TypeInfo, my_literal_boolean, 0), "true")
+        spectra_test_util:from_string(
+            TypeInfo, resolve_type(TypeInfo, my_literal_boolean, 0), "true"
+        )
     ),
 
     %% Test union types
@@ -465,7 +467,9 @@ type_reference_test() ->
     ),
     ?assertEqual(
         {ok, false},
-        spectra_test_util:from_string(TypeInfo, resolve_type(TypeInfo, my_complex_union, 0), "false")
+        spectra_test_util:from_string(
+            TypeInfo, resolve_type(TypeInfo, my_complex_union, 0), "false"
+        )
     ),
 
     ok.

--- a/test/spectra_string_test.erl
+++ b/test/spectra_string_test.erl
@@ -39,15 +39,15 @@ simple_types_test() ->
     %% integer
     ?assertEqual(
         {ok, 42},
-        spectra_string:from_string(TypeInfo, #sp_simple_type{type = integer}, "42")
+        spectra_test_util:from_string(TypeInfo, #sp_simple_type{type = integer}, "42")
     ),
     ?assertEqual(
         {ok, -42},
-        spectra_string:from_string(TypeInfo, #sp_simple_type{type = integer}, "-42")
+        spectra_test_util:from_string(TypeInfo, #sp_simple_type{type = integer}, "-42")
     ),
     ?assertMatch(
         {error, [#sp_error{type = type_mismatch}]},
-        spectra_string:from_string(
+        spectra_test_util:from_string(
             TypeInfo,
             #sp_simple_type{type = integer},
             "not_a_number"
@@ -55,21 +55,21 @@ simple_types_test() ->
     ),
     ?assertMatch(
         {error, [#sp_error{type = type_mismatch}]},
-        spectra_string:from_string(TypeInfo, #sp_simple_type{type = integer}, "3.14")
+        spectra_test_util:from_string(TypeInfo, #sp_simple_type{type = integer}, "3.14")
     ),
 
     %% float
     ?assertEqual(
         {ok, 3.14},
-        spectra_string:from_string(TypeInfo, #sp_simple_type{type = float}, "3.14")
+        spectra_test_util:from_string(TypeInfo, #sp_simple_type{type = float}, "3.14")
     ),
     ?assertEqual(
         {ok, -3.14},
-        spectra_string:from_string(TypeInfo, #sp_simple_type{type = float}, "-3.14")
+        spectra_test_util:from_string(TypeInfo, #sp_simple_type{type = float}, "-3.14")
     ),
     ?assertMatch(
         {error, [#sp_error{type = type_mismatch}]},
-        spectra_string:from_string(
+        spectra_test_util:from_string(
             TypeInfo,
             #sp_simple_type{type = float},
             "not_a_number"
@@ -77,21 +77,21 @@ simple_types_test() ->
     ),
     ?assertMatch(
         {error, [#sp_error{type = type_mismatch}]},
-        spectra_string:from_string(TypeInfo, #sp_simple_type{type = float}, "42")
+        spectra_test_util:from_string(TypeInfo, #sp_simple_type{type = float}, "42")
     ),
 
     %% number (tries integer first, then float)
     ?assertEqual(
         {ok, 42},
-        spectra_string:from_string(TypeInfo, #sp_simple_type{type = number}, "42")
+        spectra_test_util:from_string(TypeInfo, #sp_simple_type{type = number}, "42")
     ),
     ?assertEqual(
         {ok, 3.14},
-        spectra_string:from_string(TypeInfo, #sp_simple_type{type = number}, "3.14")
+        spectra_test_util:from_string(TypeInfo, #sp_simple_type{type = number}, "3.14")
     ),
     ?assertMatch(
         {error, [#sp_error{type = type_mismatch}]},
-        spectra_string:from_string(
+        spectra_test_util:from_string(
             TypeInfo,
             #sp_simple_type{type = number},
             "not_a_number"
@@ -101,29 +101,29 @@ simple_types_test() ->
     %% boolean
     ?assertEqual(
         {ok, true},
-        spectra_string:from_string(TypeInfo, #sp_simple_type{type = boolean}, "true")
+        spectra_test_util:from_string(TypeInfo, #sp_simple_type{type = boolean}, "true")
     ),
     ?assertEqual(
         {ok, false},
-        spectra_string:from_string(TypeInfo, #sp_simple_type{type = boolean}, "false")
+        spectra_test_util:from_string(TypeInfo, #sp_simple_type{type = boolean}, "false")
     ),
     ?assertMatch(
         {error, [#sp_error{type = type_mismatch}]},
-        spectra_string:from_string(TypeInfo, #sp_simple_type{type = boolean}, "True")
+        spectra_test_util:from_string(TypeInfo, #sp_simple_type{type = boolean}, "True")
     ),
     ?assertMatch(
         {error, [#sp_error{type = type_mismatch}]},
-        spectra_string:from_string(TypeInfo, #sp_simple_type{type = boolean}, "1")
+        spectra_test_util:from_string(TypeInfo, #sp_simple_type{type = boolean}, "1")
     ),
 
     %% atom
     ?assertEqual(
         {ok, hello},
-        spectra_string:from_string(TypeInfo, #sp_simple_type{type = atom}, "hello")
+        spectra_test_util:from_string(TypeInfo, #sp_simple_type{type = atom}, "hello")
     ),
     ?assertEqual(
         {ok, 'hello world'},
-        spectra_string:from_string(
+        spectra_test_util:from_string(
             TypeInfo,
             #sp_simple_type{type = atom},
             "hello world"
@@ -131,7 +131,7 @@ simple_types_test() ->
     ),
     ?assertMatch(
         {error, [#sp_error{type = type_mismatch}]},
-        spectra_string:from_string(
+        spectra_test_util:from_string(
             TypeInfo,
             #sp_simple_type{type = atom},
             "non_existing_atom_123456789"
@@ -141,15 +141,15 @@ simple_types_test() ->
     %% string
     ?assertEqual(
         {ok, "hello"},
-        spectra_string:from_string(TypeInfo, #sp_simple_type{type = string}, "hello")
+        spectra_test_util:from_string(TypeInfo, #sp_simple_type{type = string}, "hello")
     ),
     ?assertEqual(
         {ok, ""},
-        spectra_string:from_string(TypeInfo, #sp_simple_type{type = string}, "")
+        spectra_test_util:from_string(TypeInfo, #sp_simple_type{type = string}, "")
     ),
     ?assertEqual(
         {ok, "hello world 123!"},
-        spectra_string:from_string(
+        spectra_test_util:from_string(
             TypeInfo,
             #sp_simple_type{type = string},
             "hello world 123!"
@@ -159,7 +159,7 @@ simple_types_test() ->
     %% nonempty_string
     ?assertEqual(
         {ok, "hello"},
-        spectra_string:from_string(
+        spectra_test_util:from_string(
             TypeInfo,
             #sp_simple_type{type = nonempty_string},
             "hello"
@@ -167,7 +167,7 @@ simple_types_test() ->
     ),
     ?assertMatch(
         {error, [#sp_error{type = type_mismatch}]},
-        spectra_string:from_string(
+        spectra_test_util:from_string(
             TypeInfo,
             #sp_simple_type{type = nonempty_string},
             ""
@@ -177,17 +177,17 @@ simple_types_test() ->
     %% binary
     ?assertEqual(
         {ok, <<"hello">>},
-        spectra_string:from_string(TypeInfo, #sp_simple_type{type = binary}, "hello")
+        spectra_test_util:from_string(TypeInfo, #sp_simple_type{type = binary}, "hello")
     ),
     ?assertEqual(
         {ok, <<"">>},
-        spectra_string:from_string(TypeInfo, #sp_simple_type{type = binary}, "")
+        spectra_test_util:from_string(TypeInfo, #sp_simple_type{type = binary}, "")
     ),
 
     %% nonempty_binary
     ?assertEqual(
         {ok, <<"hello">>},
-        spectra_string:from_string(
+        spectra_test_util:from_string(
             TypeInfo,
             #sp_simple_type{type = nonempty_binary},
             "hello"
@@ -195,7 +195,7 @@ simple_types_test() ->
     ),
     ?assertMatch(
         {error, [#sp_error{type = type_mismatch}]},
-        spectra_string:from_string(
+        spectra_test_util:from_string(
             TypeInfo,
             #sp_simple_type{type = nonempty_binary},
             ""
@@ -205,7 +205,7 @@ simple_types_test() ->
     %% non_neg_integer
     ?assertEqual(
         {ok, 42},
-        spectra_string:from_string(
+        spectra_test_util:from_string(
             TypeInfo,
             #sp_simple_type{type = non_neg_integer},
             "42"
@@ -213,7 +213,7 @@ simple_types_test() ->
     ),
     ?assertEqual(
         {ok, 0},
-        spectra_string:from_string(
+        spectra_test_util:from_string(
             TypeInfo,
             #sp_simple_type{type = non_neg_integer},
             "0"
@@ -221,7 +221,7 @@ simple_types_test() ->
     ),
     ?assertMatch(
         {error, [#sp_error{type = type_mismatch}]},
-        spectra_string:from_string(
+        spectra_test_util:from_string(
             TypeInfo,
             #sp_simple_type{type = non_neg_integer},
             "-1"
@@ -231,21 +231,21 @@ simple_types_test() ->
     %% pos_integer
     ?assertEqual(
         {ok, 42},
-        spectra_string:from_string(TypeInfo, #sp_simple_type{type = pos_integer}, "42")
+        spectra_test_util:from_string(TypeInfo, #sp_simple_type{type = pos_integer}, "42")
     ),
     ?assertMatch(
         {error, [#sp_error{type = type_mismatch}]},
-        spectra_string:from_string(TypeInfo, #sp_simple_type{type = pos_integer}, "0")
+        spectra_test_util:from_string(TypeInfo, #sp_simple_type{type = pos_integer}, "0")
     ),
     ?assertMatch(
         {error, [#sp_error{type = type_mismatch}]},
-        spectra_string:from_string(TypeInfo, #sp_simple_type{type = pos_integer}, "-1")
+        spectra_test_util:from_string(TypeInfo, #sp_simple_type{type = pos_integer}, "-1")
     ),
 
     %% neg_integer
     ?assertEqual(
         {ok, -42},
-        spectra_string:from_string(
+        spectra_test_util:from_string(
             TypeInfo,
             #sp_simple_type{type = neg_integer},
             "-42"
@@ -253,11 +253,11 @@ simple_types_test() ->
     ),
     ?assertMatch(
         {error, [#sp_error{type = type_mismatch}]},
-        spectra_string:from_string(TypeInfo, #sp_simple_type{type = neg_integer}, "0")
+        spectra_test_util:from_string(TypeInfo, #sp_simple_type{type = neg_integer}, "0")
     ),
     ?assertMatch(
         {error, [#sp_error{type = type_mismatch}]},
-        spectra_string:from_string(TypeInfo, #sp_simple_type{type = neg_integer}, "42")
+        spectra_test_util:from_string(TypeInfo, #sp_simple_type{type = neg_integer}, "42")
     ),
 
     ok.
@@ -273,32 +273,32 @@ range_test() ->
         },
 
     %% Valid values in range
-    ?assertEqual({ok, 1}, spectra_string:from_string(TypeInfo, Range, "1")),
-    ?assertEqual({ok, 5}, spectra_string:from_string(TypeInfo, Range, "5")),
-    ?assertEqual({ok, 10}, spectra_string:from_string(TypeInfo, Range, "10")),
+    ?assertEqual({ok, 1}, spectra_test_util:from_string(TypeInfo, Range, "1")),
+    ?assertEqual({ok, 5}, spectra_test_util:from_string(TypeInfo, Range, "5")),
+    ?assertEqual({ok, 10}, spectra_test_util:from_string(TypeInfo, Range, "10")),
 
     %% Invalid values outside range
     ?assertMatch(
         {error, [#sp_error{type = type_mismatch}]},
-        spectra_string:from_string(TypeInfo, Range, "0")
+        spectra_test_util:from_string(TypeInfo, Range, "0")
     ),
     ?assertMatch(
         {error, [#sp_error{type = type_mismatch}]},
-        spectra_string:from_string(TypeInfo, Range, "11")
+        spectra_test_util:from_string(TypeInfo, Range, "11")
     ),
     ?assertMatch(
         {error, [#sp_error{type = type_mismatch}]},
-        spectra_string:from_string(TypeInfo, Range, "-5")
+        spectra_test_util:from_string(TypeInfo, Range, "-5")
     ),
 
     %% Invalid non-integer strings
     ?assertMatch(
         {error, [#sp_error{type = type_mismatch}]},
-        spectra_string:from_string(TypeInfo, Range, "not_a_number")
+        spectra_test_util:from_string(TypeInfo, Range, "not_a_number")
     ),
     ?assertMatch(
         {error, [#sp_error{type = type_mismatch}]},
-        spectra_string:from_string(TypeInfo, Range, "5.5")
+        spectra_test_util:from_string(TypeInfo, Range, "5.5")
     ),
 
     ok.
@@ -309,14 +309,14 @@ literal_test() ->
 
     %% Literal atom
     AtomLiteral = #sp_literal{value = hello},
-    ?assertEqual({ok, hello}, spectra_string:from_string(TypeInfo, AtomLiteral, "hello")),
+    ?assertEqual({ok, hello}, spectra_test_util:from_string(TypeInfo, AtomLiteral, "hello")),
     ?assertMatch(
         {error, [#sp_error{type = type_mismatch}]},
-        spectra_string:from_string(TypeInfo, AtomLiteral, "world")
+        spectra_test_util:from_string(TypeInfo, AtomLiteral, "world")
     ),
     ?assertMatch(
         {error, [#sp_error{type = type_mismatch}]},
-        spectra_string:from_string(
+        spectra_test_util:from_string(
             TypeInfo,
             AtomLiteral,
             "non_existing_atom_123456789"
@@ -325,26 +325,26 @@ literal_test() ->
 
     %% Literal integer
     IntegerLiteral = #sp_literal{value = 42},
-    ?assertEqual({ok, 42}, spectra_string:from_string(TypeInfo, IntegerLiteral, "42")),
+    ?assertEqual({ok, 42}, spectra_test_util:from_string(TypeInfo, IntegerLiteral, "42")),
     ?assertMatch(
         {error, [#sp_error{type = type_mismatch}]},
-        spectra_string:from_string(TypeInfo, IntegerLiteral, "43")
+        spectra_test_util:from_string(TypeInfo, IntegerLiteral, "43")
     ),
     ?assertMatch(
         {error, [#sp_error{type = type_mismatch}]},
-        spectra_string:from_string(TypeInfo, IntegerLiteral, "not_a_number")
+        spectra_test_util:from_string(TypeInfo, IntegerLiteral, "not_a_number")
     ),
 
     %% Literal boolean
     BooleanLiteral = #sp_literal{value = true},
-    ?assertEqual({ok, true}, spectra_string:from_string(TypeInfo, BooleanLiteral, "true")),
+    ?assertEqual({ok, true}, spectra_test_util:from_string(TypeInfo, BooleanLiteral, "true")),
     ?assertMatch(
         {error, [#sp_error{type = type_mismatch}]},
-        spectra_string:from_string(TypeInfo, BooleanLiteral, "false")
+        spectra_test_util:from_string(TypeInfo, BooleanLiteral, "false")
     ),
     ?assertMatch(
         {error, [#sp_error{type = type_mismatch}]},
-        spectra_string:from_string(TypeInfo, BooleanLiteral, "True")
+        spectra_test_util:from_string(TypeInfo, BooleanLiteral, "True")
     ),
 
     ok.
@@ -356,12 +356,12 @@ union_test() ->
     %% Simple union: integer | boolean
     Union =
         #sp_union{types = [#sp_simple_type{type = integer}, #sp_simple_type{type = boolean}]},
-    ?assertEqual({ok, 42}, spectra_string:from_string(TypeInfo, Union, "42")),
-    ?assertEqual({ok, true}, spectra_string:from_string(TypeInfo, Union, "true")),
-    ?assertEqual({ok, false}, spectra_string:from_string(TypeInfo, Union, "false")),
+    ?assertEqual({ok, 42}, spectra_test_util:from_string(TypeInfo, Union, "42")),
+    ?assertEqual({ok, true}, spectra_test_util:from_string(TypeInfo, Union, "true")),
+    ?assertEqual({ok, false}, spectra_test_util:from_string(TypeInfo, Union, "false")),
     ?assertMatch(
         {error, [#sp_error{type = no_match}]},
-        spectra_string:from_string(TypeInfo, Union, "not_matching")
+        spectra_test_util:from_string(TypeInfo, Union, "not_matching")
     ),
 
     %% Complex union with literals: 1 | 2 | true | false
@@ -375,17 +375,17 @@ union_test() ->
                     #sp_literal{value = false}
                 ]
         },
-    ?assertEqual({ok, 1}, spectra_string:from_string(TypeInfo, ComplexUnion, "1")),
-    ?assertEqual({ok, 2}, spectra_string:from_string(TypeInfo, ComplexUnion, "2")),
-    ?assertEqual({ok, true}, spectra_string:from_string(TypeInfo, ComplexUnion, "true")),
-    ?assertEqual({ok, false}, spectra_string:from_string(TypeInfo, ComplexUnion, "false")),
+    ?assertEqual({ok, 1}, spectra_test_util:from_string(TypeInfo, ComplexUnion, "1")),
+    ?assertEqual({ok, 2}, spectra_test_util:from_string(TypeInfo, ComplexUnion, "2")),
+    ?assertEqual({ok, true}, spectra_test_util:from_string(TypeInfo, ComplexUnion, "true")),
+    ?assertEqual({ok, false}, spectra_test_util:from_string(TypeInfo, ComplexUnion, "false")),
     ?assertMatch(
         {error, [#sp_error{type = no_match}]},
-        spectra_string:from_string(TypeInfo, ComplexUnion, "3")
+        spectra_test_util:from_string(TypeInfo, ComplexUnion, "3")
     ),
     ?assertMatch(
         {error, [#sp_error{type = no_match}]},
-        spectra_string:from_string(TypeInfo, ComplexUnion, "maybe")
+        spectra_test_util:from_string(TypeInfo, ComplexUnion, "maybe")
     ),
 
     ok.
@@ -397,75 +397,75 @@ type_reference_test() ->
     %% Test various type references from the module
     ?assertEqual(
         {ok, 42},
-        spectra_string:from_string(TypeInfo, resolve_type(TypeInfo, my_integer, 0), "42")
+        spectra_test_util:from_string(TypeInfo, resolve_type(TypeInfo, my_integer, 0), "42")
     ),
     ?assertEqual(
         {ok, 3.14},
-        spectra_string:from_string(TypeInfo, resolve_type(TypeInfo, my_float, 0), "3.14")
+        spectra_test_util:from_string(TypeInfo, resolve_type(TypeInfo, my_float, 0), "3.14")
     ),
     ?assertEqual(
         {ok, 42},
-        spectra_string:from_string(TypeInfo, resolve_type(TypeInfo, my_number, 0), "42")
+        spectra_test_util:from_string(TypeInfo, resolve_type(TypeInfo, my_number, 0), "42")
     ),
     ?assertEqual(
         {ok, 3.14},
-        spectra_string:from_string(TypeInfo, resolve_type(TypeInfo, my_number, 0), "3.14")
+        spectra_test_util:from_string(TypeInfo, resolve_type(TypeInfo, my_number, 0), "3.14")
     ),
     ?assertEqual(
         {ok, true},
-        spectra_string:from_string(TypeInfo, resolve_type(TypeInfo, my_boolean, 0), "true")
+        spectra_test_util:from_string(TypeInfo, resolve_type(TypeInfo, my_boolean, 0), "true")
     ),
     ?assertEqual(
         {ok, hello},
-        spectra_string:from_string(TypeInfo, resolve_type(TypeInfo, my_atom, 0), "hello")
+        spectra_test_util:from_string(TypeInfo, resolve_type(TypeInfo, my_atom, 0), "hello")
     ),
     ?assertEqual(
         {ok, "test"},
-        spectra_string:from_string(TypeInfo, resolve_type(TypeInfo, my_string, 0), "test")
+        spectra_test_util:from_string(TypeInfo, resolve_type(TypeInfo, my_string, 0), "test")
     ),
     ?assertEqual(
         {ok, <<"test">>},
-        spectra_string:from_string(TypeInfo, resolve_type(TypeInfo, my_binary, 0), "test")
+        spectra_test_util:from_string(TypeInfo, resolve_type(TypeInfo, my_binary, 0), "test")
     ),
 
     %% Test range type
     ?assertEqual(
-        {ok, 5}, spectra_string:from_string(TypeInfo, resolve_type(TypeInfo, my_range, 0), "5")
+        {ok, 5}, spectra_test_util:from_string(TypeInfo, resolve_type(TypeInfo, my_range, 0), "5")
     ),
     ?assertMatch(
         {error, [#sp_error{type = type_mismatch}]},
-        spectra_string:from_string(TypeInfo, resolve_type(TypeInfo, my_range, 0), "15")
+        spectra_test_util:from_string(TypeInfo, resolve_type(TypeInfo, my_range, 0), "15")
     ),
 
     %% Test literal types
     ?assertEqual(
         {ok, hello},
-        spectra_string:from_string(TypeInfo, resolve_type(TypeInfo, my_literal_atom, 0), "hello")
+        spectra_test_util:from_string(TypeInfo, resolve_type(TypeInfo, my_literal_atom, 0), "hello")
     ),
     ?assertEqual(
         {ok, 42},
-        spectra_string:from_string(TypeInfo, resolve_type(TypeInfo, my_literal_integer, 0), "42")
+        spectra_test_util:from_string(TypeInfo, resolve_type(TypeInfo, my_literal_integer, 0), "42")
     ),
     ?assertEqual(
         {ok, true},
-        spectra_string:from_string(TypeInfo, resolve_type(TypeInfo, my_literal_boolean, 0), "true")
+        spectra_test_util:from_string(TypeInfo, resolve_type(TypeInfo, my_literal_boolean, 0), "true")
     ),
 
     %% Test union types
     ?assertEqual(
-        {ok, 42}, spectra_string:from_string(TypeInfo, resolve_type(TypeInfo, my_union, 0), "42")
+        {ok, 42}, spectra_test_util:from_string(TypeInfo, resolve_type(TypeInfo, my_union, 0), "42")
     ),
     ?assertEqual(
         {ok, true},
-        spectra_string:from_string(TypeInfo, resolve_type(TypeInfo, my_union, 0), "true")
+        spectra_test_util:from_string(TypeInfo, resolve_type(TypeInfo, my_union, 0), "true")
     ),
     ?assertEqual(
         {ok, 1},
-        spectra_string:from_string(TypeInfo, resolve_type(TypeInfo, my_complex_union, 0), "1")
+        spectra_test_util:from_string(TypeInfo, resolve_type(TypeInfo, my_complex_union, 0), "1")
     ),
     ?assertEqual(
         {ok, false},
-        spectra_string:from_string(TypeInfo, resolve_type(TypeInfo, my_complex_union, 0), "false")
+        spectra_test_util:from_string(TypeInfo, resolve_type(TypeInfo, my_complex_union, 0), "false")
     ),
 
     ok.
@@ -477,7 +477,7 @@ unsupported_test() ->
     %% Record types are not supported for string conversion
     ?assertError(
         {type_not_supported, _},
-        spectra_string:from_string(
+        spectra_test_util:from_string(
             TypeInfo, #sp_rec{name = some_record, fields = [], arity = 0}, "test"
         )
     ),
@@ -485,23 +485,23 @@ unsupported_test() ->
     %% Unsupported simple types should error
     ?assertError(
         {type_not_supported, _},
-        spectra_string:from_string(TypeInfo, #sp_simple_type{type = pid}, "test")
+        spectra_test_util:from_string(TypeInfo, #sp_simple_type{type = pid}, "test")
     ),
     ?assertError(
         {type_not_supported, _},
-        spectra_string:from_string(TypeInfo, #sp_simple_type{type = port}, "test")
+        spectra_test_util:from_string(TypeInfo, #sp_simple_type{type = port}, "test")
     ),
     ?assertError(
         {type_not_supported, _},
-        spectra_string:from_string(TypeInfo, #sp_simple_type{type = reference}, "test")
+        spectra_test_util:from_string(TypeInfo, #sp_simple_type{type = reference}, "test")
     ),
     ?assertError(
         {type_not_supported, _},
-        spectra_string:from_string(TypeInfo, #sp_simple_type{type = bitstring}, "test")
+        spectra_test_util:from_string(TypeInfo, #sp_simple_type{type = bitstring}, "test")
     ),
     ?assertError(
         {type_not_supported, _},
-        spectra_string:from_string(
+        spectra_test_util:from_string(
             TypeInfo,
             #sp_simple_type{type = nonempty_bitstring},
             "test"
@@ -509,14 +509,14 @@ unsupported_test() ->
     ),
     ?assertError(
         {type_not_supported, _},
-        spectra_string:from_string(TypeInfo, #sp_simple_type{type = none}, "test")
+        spectra_test_util:from_string(TypeInfo, #sp_simple_type{type = none}, "test")
     ),
 
     %% Unknown type should give type mismatch error
     UnknownType = #sp_tuple{fields = any},
     ?assertMatch(
         {error, [#sp_error{type = type_mismatch}]},
-        spectra_string:from_string(TypeInfo, UnknownType, "test")
+        spectra_test_util:from_string(TypeInfo, UnknownType, "test")
     ),
 
     ok.
@@ -528,15 +528,15 @@ edge_cases_test() ->
     %% Empty strings
     ?assertEqual(
         {ok, ""},
-        spectra_string:from_string(TypeInfo, #sp_simple_type{type = string}, "")
+        spectra_test_util:from_string(TypeInfo, #sp_simple_type{type = string}, "")
     ),
     ?assertEqual(
         {ok, <<"">>},
-        spectra_string:from_string(TypeInfo, #sp_simple_type{type = binary}, "")
+        spectra_test_util:from_string(TypeInfo, #sp_simple_type{type = binary}, "")
     ),
     ?assertMatch(
         {error, [#sp_error{type = type_mismatch}]},
-        spectra_string:from_string(
+        spectra_test_util:from_string(
             TypeInfo,
             #sp_simple_type{type = nonempty_string},
             ""
@@ -544,7 +544,7 @@ edge_cases_test() ->
     ),
     ?assertMatch(
         {error, [#sp_error{type = type_mismatch}]},
-        spectra_string:from_string(
+        spectra_test_util:from_string(
             TypeInfo,
             #sp_simple_type{type = nonempty_binary},
             ""
@@ -554,7 +554,7 @@ edge_cases_test() ->
     %% Large numbers
     ?assertEqual(
         {ok, 999999999999},
-        spectra_string:from_string(
+        spectra_test_util:from_string(
             TypeInfo,
             #sp_simple_type{type = integer},
             "999999999999"
@@ -562,7 +562,7 @@ edge_cases_test() ->
     ),
     ?assertEqual(
         {ok, -999999999999},
-        spectra_string:from_string(
+        spectra_test_util:from_string(
             TypeInfo,
             #sp_simple_type{type = integer},
             "-999999999999"
@@ -572,11 +572,11 @@ edge_cases_test() ->
     %% Special float values
     ?assertEqual(
         {ok, 0.0},
-        spectra_string:from_string(TypeInfo, #sp_simple_type{type = float}, "0.0")
+        spectra_test_util:from_string(TypeInfo, #sp_simple_type{type = float}, "0.0")
     ),
     ?assertEqual(
         {ok, -0.0},
-        spectra_string:from_string(TypeInfo, #sp_simple_type{type = float}, "-0.0")
+        spectra_test_util:from_string(TypeInfo, #sp_simple_type{type = float}, "-0.0")
     ),
 
     %% Boundary values for ranges
@@ -586,15 +586,15 @@ edge_cases_test() ->
             lower_bound = -5,
             upper_bound = 5
         },
-    ?assertEqual({ok, -5}, spectra_string:from_string(TypeInfo, Range, "-5")),
-    ?assertEqual({ok, 5}, spectra_string:from_string(TypeInfo, Range, "5")),
+    ?assertEqual({ok, -5}, spectra_test_util:from_string(TypeInfo, Range, "-5")),
+    ?assertEqual({ok, 5}, spectra_test_util:from_string(TypeInfo, Range, "5")),
     ?assertMatch(
         {error, [#sp_error{type = type_mismatch}]},
-        spectra_string:from_string(TypeInfo, Range, "-6")
+        spectra_test_util:from_string(TypeInfo, Range, "-6")
     ),
     ?assertMatch(
         {error, [#sp_error{type = type_mismatch}]},
-        spectra_string:from_string(TypeInfo, Range, "6")
+        spectra_test_util:from_string(TypeInfo, Range, "6")
     ),
 
     ok.
@@ -606,15 +606,15 @@ to_string_simple_types_test() ->
     %% integer
     ?assertEqual(
         {ok, "42"},
-        spectra_string:to_string(TypeInfo, #sp_simple_type{type = integer}, 42)
+        spectra_test_util:to_string(TypeInfo, #sp_simple_type{type = integer}, 42)
     ),
     ?assertEqual(
         {ok, "-42"},
-        spectra_string:to_string(TypeInfo, #sp_simple_type{type = integer}, -42)
+        spectra_test_util:to_string(TypeInfo, #sp_simple_type{type = integer}, -42)
     ),
     ?assertMatch(
         {error, [#sp_error{type = type_mismatch}]},
-        spectra_string:to_string(
+        spectra_test_util:to_string(
             TypeInfo,
             #sp_simple_type{type = integer},
             "not_integer"
@@ -624,29 +624,29 @@ to_string_simple_types_test() ->
     %% float
     ?assertEqual(
         {ok, "3.14000000000000012434e+00"},
-        spectra_string:to_string(TypeInfo, #sp_simple_type{type = float}, 3.14)
+        spectra_test_util:to_string(TypeInfo, #sp_simple_type{type = float}, 3.14)
     ),
     ?assertEqual(
         {ok, "-3.14000000000000012434e+00"},
-        spectra_string:to_string(TypeInfo, #sp_simple_type{type = float}, -3.14)
+        spectra_test_util:to_string(TypeInfo, #sp_simple_type{type = float}, -3.14)
     ),
     ?assertMatch(
         {error, [#sp_error{type = type_mismatch}]},
-        spectra_string:to_string(TypeInfo, #sp_simple_type{type = float}, 42)
+        spectra_test_util:to_string(TypeInfo, #sp_simple_type{type = float}, 42)
     ),
 
     %% number
     ?assertEqual(
         {ok, "42"},
-        spectra_string:to_string(TypeInfo, #sp_simple_type{type = number}, 42)
+        spectra_test_util:to_string(TypeInfo, #sp_simple_type{type = number}, 42)
     ),
     ?assertEqual(
         {ok, "3.14000000000000012434e+00"},
-        spectra_string:to_string(TypeInfo, #sp_simple_type{type = number}, 3.14)
+        spectra_test_util:to_string(TypeInfo, #sp_simple_type{type = number}, 3.14)
     ),
     ?assertMatch(
         {error, [#sp_error{type = type_mismatch}]},
-        spectra_string:to_string(
+        spectra_test_util:to_string(
             TypeInfo,
             #sp_simple_type{type = number},
             "not_number"
@@ -656,43 +656,43 @@ to_string_simple_types_test() ->
     %% boolean
     ?assertEqual(
         {ok, "true"},
-        spectra_string:to_string(TypeInfo, #sp_simple_type{type = boolean}, true)
+        spectra_test_util:to_string(TypeInfo, #sp_simple_type{type = boolean}, true)
     ),
     ?assertEqual(
         {ok, "false"},
-        spectra_string:to_string(TypeInfo, #sp_simple_type{type = boolean}, false)
+        spectra_test_util:to_string(TypeInfo, #sp_simple_type{type = boolean}, false)
     ),
     ?assertMatch(
         {error, [#sp_error{type = type_mismatch}]},
-        spectra_string:to_string(TypeInfo, #sp_simple_type{type = boolean}, "true")
+        spectra_test_util:to_string(TypeInfo, #sp_simple_type{type = boolean}, "true")
     ),
 
     %% atom
     ?assertEqual(
         {ok, "hello"},
-        spectra_string:to_string(TypeInfo, #sp_simple_type{type = atom}, hello)
+        spectra_test_util:to_string(TypeInfo, #sp_simple_type{type = atom}, hello)
     ),
     ?assertEqual(
         {ok, "hello world"},
-        spectra_string:to_string(TypeInfo, #sp_simple_type{type = atom}, 'hello world')
+        spectra_test_util:to_string(TypeInfo, #sp_simple_type{type = atom}, 'hello world')
     ),
     ?assertMatch(
         {error, [#sp_error{type = type_mismatch}]},
-        spectra_string:to_string(TypeInfo, #sp_simple_type{type = atom}, "hello")
+        spectra_test_util:to_string(TypeInfo, #sp_simple_type{type = atom}, "hello")
     ),
 
     %% string
     ?assertEqual(
         {ok, "hello"},
-        spectra_string:to_string(TypeInfo, #sp_simple_type{type = string}, "hello")
+        spectra_test_util:to_string(TypeInfo, #sp_simple_type{type = string}, "hello")
     ),
     ?assertEqual(
         {ok, ""},
-        spectra_string:to_string(TypeInfo, #sp_simple_type{type = string}, "")
+        spectra_test_util:to_string(TypeInfo, #sp_simple_type{type = string}, "")
     ),
     ?assertMatch(
         {error, [#sp_error{type = type_mismatch}]},
-        spectra_string:to_string(
+        spectra_test_util:to_string(
             TypeInfo,
             #sp_simple_type{type = string},
             <<"binary">>
@@ -702,7 +702,7 @@ to_string_simple_types_test() ->
     %% nonempty_string
     ?assertEqual(
         {ok, "hello"},
-        spectra_string:to_string(
+        spectra_test_util:to_string(
             TypeInfo,
             #sp_simple_type{type = nonempty_string},
             "hello"
@@ -710,27 +710,27 @@ to_string_simple_types_test() ->
     ),
     ?assertMatch(
         {error, [#sp_error{type = type_mismatch}]},
-        spectra_string:to_string(TypeInfo, #sp_simple_type{type = nonempty_string}, "")
+        spectra_test_util:to_string(TypeInfo, #sp_simple_type{type = nonempty_string}, "")
     ),
 
     %% binary
     ?assertEqual(
         {ok, "hello"},
-        spectra_string:to_string(TypeInfo, #sp_simple_type{type = binary}, <<"hello">>)
+        spectra_test_util:to_string(TypeInfo, #sp_simple_type{type = binary}, <<"hello">>)
     ),
     ?assertEqual(
         {ok, ""},
-        spectra_string:to_string(TypeInfo, #sp_simple_type{type = binary}, <<"">>)
+        spectra_test_util:to_string(TypeInfo, #sp_simple_type{type = binary}, <<"">>)
     ),
     ?assertMatch(
         {error, [#sp_error{type = type_mismatch}]},
-        spectra_string:to_string(TypeInfo, #sp_simple_type{type = binary}, "string")
+        spectra_test_util:to_string(TypeInfo, #sp_simple_type{type = binary}, "string")
     ),
 
     %% nonempty_binary
     ?assertEqual(
         {ok, "hello"},
-        spectra_string:to_string(
+        spectra_test_util:to_string(
             TypeInfo,
             #sp_simple_type{type = nonempty_binary},
             <<"hello">>
@@ -738,7 +738,7 @@ to_string_simple_types_test() ->
     ),
     ?assertMatch(
         {error, [#sp_error{type = type_mismatch}]},
-        spectra_string:to_string(
+        spectra_test_util:to_string(
             TypeInfo,
             #sp_simple_type{type = nonempty_binary},
             <<"">>
@@ -748,43 +748,43 @@ to_string_simple_types_test() ->
     %% non_neg_integer
     ?assertEqual(
         {ok, "42"},
-        spectra_string:to_string(TypeInfo, #sp_simple_type{type = non_neg_integer}, 42)
+        spectra_test_util:to_string(TypeInfo, #sp_simple_type{type = non_neg_integer}, 42)
     ),
     ?assertEqual(
         {ok, "0"},
-        spectra_string:to_string(TypeInfo, #sp_simple_type{type = non_neg_integer}, 0)
+        spectra_test_util:to_string(TypeInfo, #sp_simple_type{type = non_neg_integer}, 0)
     ),
     ?assertMatch(
         {error, [#sp_error{type = type_mismatch}]},
-        spectra_string:to_string(TypeInfo, #sp_simple_type{type = non_neg_integer}, -1)
+        spectra_test_util:to_string(TypeInfo, #sp_simple_type{type = non_neg_integer}, -1)
     ),
 
     %% pos_integer
     ?assertEqual(
         {ok, "42"},
-        spectra_string:to_string(TypeInfo, #sp_simple_type{type = pos_integer}, 42)
+        spectra_test_util:to_string(TypeInfo, #sp_simple_type{type = pos_integer}, 42)
     ),
     ?assertMatch(
         {error, [#sp_error{type = type_mismatch}]},
-        spectra_string:to_string(TypeInfo, #sp_simple_type{type = pos_integer}, 0)
+        spectra_test_util:to_string(TypeInfo, #sp_simple_type{type = pos_integer}, 0)
     ),
     ?assertMatch(
         {error, [#sp_error{type = type_mismatch}]},
-        spectra_string:to_string(TypeInfo, #sp_simple_type{type = pos_integer}, -1)
+        spectra_test_util:to_string(TypeInfo, #sp_simple_type{type = pos_integer}, -1)
     ),
 
     %% neg_integer
     ?assertEqual(
         {ok, "-42"},
-        spectra_string:to_string(TypeInfo, #sp_simple_type{type = neg_integer}, -42)
+        spectra_test_util:to_string(TypeInfo, #sp_simple_type{type = neg_integer}, -42)
     ),
     ?assertMatch(
         {error, [#sp_error{type = type_mismatch}]},
-        spectra_string:to_string(TypeInfo, #sp_simple_type{type = neg_integer}, 0)
+        spectra_test_util:to_string(TypeInfo, #sp_simple_type{type = neg_integer}, 0)
     ),
     ?assertMatch(
         {error, [#sp_error{type = type_mismatch}]},
-        spectra_string:to_string(TypeInfo, #sp_simple_type{type = neg_integer}, 42)
+        spectra_test_util:to_string(TypeInfo, #sp_simple_type{type = neg_integer}, 42)
     ),
 
     ok.
@@ -800,32 +800,32 @@ to_string_range_test() ->
         },
 
     %% Valid values in range
-    ?assertEqual({ok, "1"}, spectra_string:to_string(TypeInfo, Range, 1)),
-    ?assertEqual({ok, "5"}, spectra_string:to_string(TypeInfo, Range, 5)),
-    ?assertEqual({ok, "10"}, spectra_string:to_string(TypeInfo, Range, 10)),
+    ?assertEqual({ok, "1"}, spectra_test_util:to_string(TypeInfo, Range, 1)),
+    ?assertEqual({ok, "5"}, spectra_test_util:to_string(TypeInfo, Range, 5)),
+    ?assertEqual({ok, "10"}, spectra_test_util:to_string(TypeInfo, Range, 10)),
 
     %% Invalid values outside range
     ?assertMatch(
         {error, [#sp_error{type = type_mismatch}]},
-        spectra_string:to_string(TypeInfo, Range, 0)
+        spectra_test_util:to_string(TypeInfo, Range, 0)
     ),
     ?assertMatch(
         {error, [#sp_error{type = type_mismatch}]},
-        spectra_string:to_string(TypeInfo, Range, 11)
+        spectra_test_util:to_string(TypeInfo, Range, 11)
     ),
     ?assertMatch(
         {error, [#sp_error{type = type_mismatch}]},
-        spectra_string:to_string(TypeInfo, Range, -5)
+        spectra_test_util:to_string(TypeInfo, Range, -5)
     ),
 
     %% Invalid non-integer values
     ?assertMatch(
         {error, [#sp_error{type = type_mismatch}]},
-        spectra_string:to_string(TypeInfo, Range, "5")
+        spectra_test_util:to_string(TypeInfo, Range, "5")
     ),
     ?assertMatch(
         {error, [#sp_error{type = type_mismatch}]},
-        spectra_string:to_string(TypeInfo, Range, 5.5)
+        spectra_test_util:to_string(TypeInfo, Range, 5.5)
     ),
 
     ok.
@@ -836,39 +836,39 @@ to_string_literal_test() ->
 
     %% Literal atom
     AtomLiteral = #sp_literal{value = hello},
-    ?assertEqual({ok, "hello"}, spectra_string:to_string(TypeInfo, AtomLiteral, hello)),
+    ?assertEqual({ok, "hello"}, spectra_test_util:to_string(TypeInfo, AtomLiteral, hello)),
     ?assertMatch(
         {error, [#sp_error{type = type_mismatch}]},
-        spectra_string:to_string(TypeInfo, AtomLiteral, world)
+        spectra_test_util:to_string(TypeInfo, AtomLiteral, world)
     ),
 
     %% Literal integer
     IntegerLiteral = #sp_literal{value = 42},
-    ?assertEqual({ok, "42"}, spectra_string:to_string(TypeInfo, IntegerLiteral, 42)),
+    ?assertEqual({ok, "42"}, spectra_test_util:to_string(TypeInfo, IntegerLiteral, 42)),
     ?assertMatch(
         {error, [#sp_error{type = type_mismatch}]},
-        spectra_string:to_string(TypeInfo, IntegerLiteral, 43)
+        spectra_test_util:to_string(TypeInfo, IntegerLiteral, 43)
     ),
 
     %% Literal boolean
     BooleanLiteralTrue = #sp_literal{value = true},
     ?assertEqual(
         {ok, "true"},
-        spectra_string:to_string(TypeInfo, BooleanLiteralTrue, true)
+        spectra_test_util:to_string(TypeInfo, BooleanLiteralTrue, true)
     ),
     ?assertMatch(
         {error, [#sp_error{type = type_mismatch}]},
-        spectra_string:to_string(TypeInfo, BooleanLiteralTrue, false)
+        spectra_test_util:to_string(TypeInfo, BooleanLiteralTrue, false)
     ),
 
     BooleanLiteralFalse = #sp_literal{value = false},
     ?assertEqual(
         {ok, "false"},
-        spectra_string:to_string(TypeInfo, BooleanLiteralFalse, false)
+        spectra_test_util:to_string(TypeInfo, BooleanLiteralFalse, false)
     ),
     ?assertMatch(
         {error, [#sp_error{type = type_mismatch}]},
-        spectra_string:to_string(TypeInfo, BooleanLiteralFalse, true)
+        spectra_test_util:to_string(TypeInfo, BooleanLiteralFalse, true)
     ),
 
     ok.
@@ -880,12 +880,12 @@ to_string_union_test() ->
     %% Simple union: integer | boolean
     Union =
         #sp_union{types = [#sp_simple_type{type = integer}, #sp_simple_type{type = boolean}]},
-    ?assertEqual({ok, "42"}, spectra_string:to_string(TypeInfo, Union, 42)),
-    ?assertEqual({ok, "true"}, spectra_string:to_string(TypeInfo, Union, true)),
-    ?assertEqual({ok, "false"}, spectra_string:to_string(TypeInfo, Union, false)),
+    ?assertEqual({ok, "42"}, spectra_test_util:to_string(TypeInfo, Union, 42)),
+    ?assertEqual({ok, "true"}, spectra_test_util:to_string(TypeInfo, Union, true)),
+    ?assertEqual({ok, "false"}, spectra_test_util:to_string(TypeInfo, Union, false)),
     ?assertMatch(
         {error, [#sp_error{type = no_match}]},
-        spectra_string:to_string(TypeInfo, Union, "not_matching")
+        spectra_test_util:to_string(TypeInfo, Union, "not_matching")
     ),
 
     %% Complex union with literals: 1 | 2 | true | false
@@ -899,17 +899,17 @@ to_string_union_test() ->
                     #sp_literal{value = false}
                 ]
         },
-    ?assertEqual({ok, "1"}, spectra_string:to_string(TypeInfo, ComplexUnion, 1)),
-    ?assertEqual({ok, "2"}, spectra_string:to_string(TypeInfo, ComplexUnion, 2)),
-    ?assertEqual({ok, "true"}, spectra_string:to_string(TypeInfo, ComplexUnion, true)),
-    ?assertEqual({ok, "false"}, spectra_string:to_string(TypeInfo, ComplexUnion, false)),
+    ?assertEqual({ok, "1"}, spectra_test_util:to_string(TypeInfo, ComplexUnion, 1)),
+    ?assertEqual({ok, "2"}, spectra_test_util:to_string(TypeInfo, ComplexUnion, 2)),
+    ?assertEqual({ok, "true"}, spectra_test_util:to_string(TypeInfo, ComplexUnion, true)),
+    ?assertEqual({ok, "false"}, spectra_test_util:to_string(TypeInfo, ComplexUnion, false)),
     ?assertMatch(
         {error, [#sp_error{type = no_match}]},
-        spectra_string:to_string(TypeInfo, ComplexUnion, 3)
+        spectra_test_util:to_string(TypeInfo, ComplexUnion, 3)
     ),
     ?assertMatch(
         {error, [#sp_error{type = no_match}]},
-        spectra_string:to_string(TypeInfo, ComplexUnion, "maybe")
+        spectra_test_util:to_string(TypeInfo, ComplexUnion, "maybe")
     ),
 
     ok.
@@ -917,7 +917,7 @@ to_string_union_test() ->
 to_string_union_error_accumulation_test() ->
     TypeInfo = spectra_abstract_code:types_in_module(?MODULE),
     Union = #sp_union{types = [#sp_simple_type{type = integer}, #sp_simple_type{type = boolean}]},
-    {error, [#sp_error{type = no_match, ctx = Ctx}]} = spectra_string:to_string(
+    {error, [#sp_error{type = no_match, ctx = Ctx}]} = spectra_test_util:to_string(
         TypeInfo,
         Union,
         "not_matching"
@@ -941,74 +941,74 @@ to_string_type_reference_test() ->
 
     %% Test various type references from the module
     ?assertEqual(
-        {ok, "42"}, spectra_string:to_string(TypeInfo, resolve_type(TypeInfo, my_integer, 0), 42)
+        {ok, "42"}, spectra_test_util:to_string(TypeInfo, resolve_type(TypeInfo, my_integer, 0), 42)
     ),
     ?assertEqual(
         {ok, "3.14000000000000012434e+00"},
-        spectra_string:to_string(TypeInfo, resolve_type(TypeInfo, my_float, 0), 3.14)
+        spectra_test_util:to_string(TypeInfo, resolve_type(TypeInfo, my_float, 0), 3.14)
     ),
     ?assertEqual(
-        {ok, "42"}, spectra_string:to_string(TypeInfo, resolve_type(TypeInfo, my_number, 0), 42)
+        {ok, "42"}, spectra_test_util:to_string(TypeInfo, resolve_type(TypeInfo, my_number, 0), 42)
     ),
     ?assertEqual(
         {ok, "3.14000000000000012434e+00"},
-        spectra_string:to_string(TypeInfo, resolve_type(TypeInfo, my_number, 0), 3.14)
+        spectra_test_util:to_string(TypeInfo, resolve_type(TypeInfo, my_number, 0), 3.14)
     ),
     ?assertEqual(
         {ok, "true"},
-        spectra_string:to_string(TypeInfo, resolve_type(TypeInfo, my_boolean, 0), true)
+        spectra_test_util:to_string(TypeInfo, resolve_type(TypeInfo, my_boolean, 0), true)
     ),
     ?assertEqual(
         {ok, "hello"},
-        spectra_string:to_string(TypeInfo, resolve_type(TypeInfo, my_atom, 0), hello)
+        spectra_test_util:to_string(TypeInfo, resolve_type(TypeInfo, my_atom, 0), hello)
     ),
     ?assertEqual(
         {ok, "test"},
-        spectra_string:to_string(TypeInfo, resolve_type(TypeInfo, my_string, 0), "test")
+        spectra_test_util:to_string(TypeInfo, resolve_type(TypeInfo, my_string, 0), "test")
     ),
     ?assertEqual(
         {ok, "test"},
-        spectra_string:to_string(TypeInfo, resolve_type(TypeInfo, my_binary, 0), <<"test">>)
+        spectra_test_util:to_string(TypeInfo, resolve_type(TypeInfo, my_binary, 0), <<"test">>)
     ),
 
     %% Test range type
     ?assertEqual(
-        {ok, "5"}, spectra_string:to_string(TypeInfo, resolve_type(TypeInfo, my_range, 0), 5)
+        {ok, "5"}, spectra_test_util:to_string(TypeInfo, resolve_type(TypeInfo, my_range, 0), 5)
     ),
     ?assertMatch(
         {error, [#sp_error{type = type_mismatch}]},
-        spectra_string:to_string(TypeInfo, resolve_type(TypeInfo, my_range, 0), 15)
+        spectra_test_util:to_string(TypeInfo, resolve_type(TypeInfo, my_range, 0), 15)
     ),
 
     %% Test literal types
     ?assertEqual(
         {ok, "hello"},
-        spectra_string:to_string(TypeInfo, resolve_type(TypeInfo, my_literal_atom, 0), hello)
+        spectra_test_util:to_string(TypeInfo, resolve_type(TypeInfo, my_literal_atom, 0), hello)
     ),
     ?assertEqual(
         {ok, "42"},
-        spectra_string:to_string(TypeInfo, resolve_type(TypeInfo, my_literal_integer, 0), 42)
+        spectra_test_util:to_string(TypeInfo, resolve_type(TypeInfo, my_literal_integer, 0), 42)
     ),
     ?assertEqual(
         {ok, "true"},
-        spectra_string:to_string(TypeInfo, resolve_type(TypeInfo, my_literal_boolean, 0), true)
+        spectra_test_util:to_string(TypeInfo, resolve_type(TypeInfo, my_literal_boolean, 0), true)
     ),
 
     %% Test union types
     ?assertEqual(
-        {ok, "42"}, spectra_string:to_string(TypeInfo, resolve_type(TypeInfo, my_union, 0), 42)
+        {ok, "42"}, spectra_test_util:to_string(TypeInfo, resolve_type(TypeInfo, my_union, 0), 42)
     ),
     ?assertEqual(
         {ok, "true"},
-        spectra_string:to_string(TypeInfo, resolve_type(TypeInfo, my_union, 0), true)
+        spectra_test_util:to_string(TypeInfo, resolve_type(TypeInfo, my_union, 0), true)
     ),
     ?assertEqual(
         {ok, "1"},
-        spectra_string:to_string(TypeInfo, resolve_type(TypeInfo, my_complex_union, 0), 1)
+        spectra_test_util:to_string(TypeInfo, resolve_type(TypeInfo, my_complex_union, 0), 1)
     ),
     ?assertEqual(
         {ok, "false"},
-        spectra_string:to_string(TypeInfo, resolve_type(TypeInfo, my_complex_union, 0), false)
+        spectra_test_util:to_string(TypeInfo, resolve_type(TypeInfo, my_complex_union, 0), false)
     ),
 
     ok.
@@ -1020,7 +1020,7 @@ to_string_unsupported_test() ->
     %% Record types are not supported for string conversion
     ?assertError(
         {type_not_supported, _},
-        spectra_string:to_string(
+        spectra_test_util:to_string(
             TypeInfo, #sp_rec{name = some_record, fields = [], arity = 0}, some_value
         )
     ),
@@ -1028,23 +1028,23 @@ to_string_unsupported_test() ->
     %% Unsupported simple types should error
     ?assertError(
         {type_not_supported, _},
-        spectra_string:to_string(TypeInfo, #sp_simple_type{type = pid}, self())
+        spectra_test_util:to_string(TypeInfo, #sp_simple_type{type = pid}, self())
     ),
     ?assertError(
         {type_not_supported, _},
-        spectra_string:to_string(TypeInfo, #sp_simple_type{type = port}, test)
+        spectra_test_util:to_string(TypeInfo, #sp_simple_type{type = port}, test)
     ),
     ?assertError(
         {type_not_supported, _},
-        spectra_string:to_string(TypeInfo, #sp_simple_type{type = reference}, test)
+        spectra_test_util:to_string(TypeInfo, #sp_simple_type{type = reference}, test)
     ),
     ?assertError(
         {type_not_supported, _},
-        spectra_string:to_string(TypeInfo, #sp_simple_type{type = bitstring}, test)
+        spectra_test_util:to_string(TypeInfo, #sp_simple_type{type = bitstring}, test)
     ),
     ?assertError(
         {type_not_supported, _},
-        spectra_string:to_string(
+        spectra_test_util:to_string(
             TypeInfo,
             #sp_simple_type{type = nonempty_bitstring},
             test
@@ -1052,14 +1052,14 @@ to_string_unsupported_test() ->
     ),
     ?assertError(
         {type_not_supported, _},
-        spectra_string:to_string(TypeInfo, #sp_simple_type{type = none}, test)
+        spectra_test_util:to_string(TypeInfo, #sp_simple_type{type = none}, test)
     ),
 
     %% Unknown type should give type mismatch error
     UnknownType = #sp_tuple{fields = any},
     ?assertMatch(
         {error, [#sp_error{type = type_mismatch}]},
-        spectra_string:to_string(TypeInfo, UnknownType, some_value)
+        spectra_test_util:to_string(TypeInfo, UnknownType, some_value)
     ),
 
     ok.
@@ -1072,7 +1072,7 @@ from_string_invalid_input_test() ->
     %% Passing binary instead of string
     ?assertMatch(
         {error, [#sp_error{type = type_mismatch}]},
-        spectra_string:from_string(
+        spectra_test_util:from_string(
             TypeInfo,
             #sp_simple_type{type = string},
             <<"binary">>
@@ -1082,13 +1082,13 @@ from_string_invalid_input_test() ->
     %% Passing integer instead of string
     ?assertMatch(
         {error, [#sp_error{type = type_mismatch}]},
-        spectra_string:from_string(TypeInfo, #sp_simple_type{type = integer}, 42)
+        spectra_test_util:from_string(TypeInfo, #sp_simple_type{type = integer}, 42)
     ),
 
     %% Passing atom instead of string
     ?assertMatch(
         {error, [#sp_error{type = type_mismatch}]},
-        spectra_string:from_string(TypeInfo, #sp_simple_type{type = atom}, hello)
+        spectra_test_util:from_string(TypeInfo, #sp_simple_type{type = atom}, hello)
     ),
 
     ok.
@@ -1101,7 +1101,7 @@ to_string_invalid_input_test() ->
     %% Passing binary when expecting to convert from string
     ?assertMatch(
         {error, [#sp_error{type = type_mismatch}]},
-        spectra_string:to_string(
+        spectra_test_util:to_string(
             TypeInfo,
             #sp_simple_type{type = string},
             <<"binary">>
@@ -1111,19 +1111,19 @@ to_string_invalid_input_test() ->
     %% Passing string when expecting to convert from binary
     ?assertMatch(
         {error, [#sp_error{type = type_mismatch}]},
-        spectra_string:to_string(TypeInfo, #sp_simple_type{type = binary}, "string")
+        spectra_test_util:to_string(TypeInfo, #sp_simple_type{type = binary}, "string")
     ),
 
     %% Passing list when expecting integer
     ?assertMatch(
         {error, [#sp_error{type = type_mismatch}]},
-        spectra_string:to_string(TypeInfo, #sp_simple_type{type = integer}, [1, 2, 3])
+        spectra_test_util:to_string(TypeInfo, #sp_simple_type{type = integer}, [1, 2, 3])
     ),
 
     %% Passing string when expecting atom
     ?assertMatch(
         {error, [#sp_error{type = type_mismatch}]},
-        spectra_string:to_string(TypeInfo, #sp_simple_type{type = atom}, "hello")
+        spectra_test_util:to_string(TypeInfo, #sp_simple_type{type = atom}, "hello")
     ),
 
     ok.

--- a/test/spectra_test.erl
+++ b/test/spectra_test.erl
@@ -3,6 +3,7 @@
 -include_lib("eunit/include/eunit.hrl").
 
 -include("../include/spectra.hrl").
+-include("../include/spectra_internal.hrl").
 
 -compile(nowarn_unused_type).
 
@@ -711,3 +712,24 @@ round_trip_string_test() ->
     {ok, Str3} = spectra:encode(string, ?MODULE, status, Data3),
     {ok, Result3} = spectra:decode(string, ?MODULE, status, Str3),
     ?assertEqual(Data3, Result3).
+
+%%====================================================================
+%% get_config/0 tests
+%%====================================================================
+
+get_config_returns_sp_config_test() ->
+    Config = spectra:get_config(),
+    ?assert(is_record(Config, sp_config)).
+
+get_config_default_cache_test() ->
+    %% Default from app.src is local
+    Config = spectra:get_config(),
+    ?assertEqual(local, Config#sp_config.module_types_cache).
+
+get_config_default_check_unicode_test() ->
+    Config = spectra:get_config(),
+    ?assertEqual(false, Config#sp_config.check_unicode).
+
+get_config_default_codecs_test() ->
+    Config = spectra:get_config(),
+    ?assertEqual(#{}, Config#sp_config.codecs).

--- a/test/spectra_test.erl
+++ b/test/spectra_test.erl
@@ -733,3 +733,14 @@ get_config_default_check_unicode_test() ->
 get_config_default_codecs_test() ->
     Config = spectra:get_config(),
     ?assertEqual(#{}, Config#sp_config.codecs).
+
+get_config_invalid_module_types_cache_test() ->
+    application:set_env(spectra, module_types_cache, bad_value),
+    try
+        ?assertError(
+            {invalid_config, module_types_cache, bad_value},
+            spectra:get_config()
+        )
+    after
+        application:unset_env(spectra, module_types_cache)
+    end.

--- a/test/spectra_test.erl
+++ b/test/spectra_test.erl
@@ -334,7 +334,7 @@ encode_with_type_reference_test() ->
 
 decode_with_type_info_test() ->
     % Get type info once and reuse it
-    TypeInfo = spectra_module_types:get(?MODULE),
+    TypeInfo = spectra_test_util:get_module_types(?MODULE),
 
     % Use it for multiple operations
     Json = <<"123">>,
@@ -351,7 +351,7 @@ decode_with_type_info_test() ->
 
 encode_with_type_info_test() ->
     % Get type info once and reuse it
-    TypeInfo = spectra_module_types:get(?MODULE),
+    TypeInfo = spectra_test_util:get_module_types(?MODULE),
 
     % Use it for multiple operations
     ?assertEqual({ok, <<"123">>}, spectra:encode(json, TypeInfo, user_id, 123)),

--- a/test/spectra_test_util.erl
+++ b/test/spectra_test_util.erl
@@ -1,0 +1,40 @@
+-module(spectra_test_util).
+
+%% Test utility module providing default-config wrappers around internal
+%% codec functions. These wrappers replace the removed 3/4-arity stubs that
+%% used to read application env and construct #sp_config{} inline.
+
+-compile(nowarn_missing_spec).
+
+-include("../include/spectra_internal.hrl").
+
+-export([
+    to_json/3,
+    from_json/3,
+    to_schema/2,
+    to_string/3,
+    from_string/3,
+    to_binary_string/3,
+    from_binary_string/3
+]).
+
+to_json(TypeInfo, Type, Data) ->
+    spectra_json:to_json(TypeInfo, Type, Data, #sp_config{}).
+
+from_json(TypeInfo, Type, Json) ->
+    spectra_json:from_json(TypeInfo, Type, Json, #sp_config{}).
+
+to_schema(TypeInfo, Type) ->
+    spectra_json_schema:to_schema(TypeInfo, Type, #sp_config{}).
+
+to_string(TypeInfo, Type, Data) ->
+    spectra_string:to_string(TypeInfo, Type, Data, #sp_config{}).
+
+from_string(TypeInfo, Type, String) ->
+    spectra_string:from_string(TypeInfo, Type, String, #sp_config{}).
+
+to_binary_string(TypeInfo, Type, Data) ->
+    spectra_binary_string:to_binary_string(TypeInfo, Type, Data, #{}, #sp_config{}).
+
+from_binary_string(TypeInfo, Type, BinaryString) ->
+    spectra_binary_string:from_binary_string(TypeInfo, Type, BinaryString, #{}, #sp_config{}).

--- a/test/spectra_test_util.erl
+++ b/test/spectra_test_util.erl
@@ -9,6 +9,7 @@
 -include("../include/spectra_internal.hrl").
 
 -export([
+    test_config/0,
     get_module_types/1,
     to_json/3,
     from_json/3,
@@ -19,26 +20,29 @@
     from_binary_string/3
 ]).
 
+test_config() ->
+    #sp_config{module_types_cache = none}.
+
 get_module_types(Module) ->
-    spectra_module_types:get(Module, #sp_config{}).
+    spectra_module_types:get(Module, test_config()).
 
 to_json(TypeInfo, Type, Data) ->
-    spectra_json:to_json(TypeInfo, Type, Data, #sp_config{}).
+    spectra_json:to_json(TypeInfo, Type, Data, test_config()).
 
 from_json(TypeInfo, Type, Json) ->
-    spectra_json:from_json(TypeInfo, Type, Json, #sp_config{}).
+    spectra_json:from_json(TypeInfo, Type, Json, test_config()).
 
 to_schema(TypeInfo, Type) ->
-    spectra_json_schema:to_schema(TypeInfo, Type, #sp_config{}).
+    spectra_json_schema:to_schema(TypeInfo, Type, test_config()).
 
 to_string(TypeInfo, Type, Data) ->
-    spectra_string:to_string(TypeInfo, Type, Data, #sp_config{}).
+    spectra_string:to_string(TypeInfo, Type, Data, test_config()).
 
 from_string(TypeInfo, Type, String) ->
-    spectra_string:from_string(TypeInfo, Type, String, #sp_config{}).
+    spectra_string:from_string(TypeInfo, Type, String, test_config()).
 
 to_binary_string(TypeInfo, Type, Data) ->
-    spectra_binary_string:to_binary_string(TypeInfo, Type, Data, #{}, #sp_config{}).
+    spectra_binary_string:to_binary_string(TypeInfo, Type, Data, #{}, test_config()).
 
 from_binary_string(TypeInfo, Type, BinaryString) ->
-    spectra_binary_string:from_binary_string(TypeInfo, Type, BinaryString, #{}, #sp_config{}).
+    spectra_binary_string:from_binary_string(TypeInfo, Type, BinaryString, #{}, test_config()).

--- a/test/spectra_test_util.erl
+++ b/test/spectra_test_util.erl
@@ -9,6 +9,7 @@
 -include("../include/spectra_internal.hrl").
 
 -export([
+    get_module_types/1,
     to_json/3,
     from_json/3,
     to_schema/2,
@@ -17,6 +18,9 @@
     to_binary_string/3,
     from_binary_string/3
 ]).
+
+get_module_types(Module) ->
+    spectra_module_types:get(Module, #sp_config{}).
 
 to_json(TypeInfo, Type, Data) ->
     spectra_json:to_json(TypeInfo, Type, Data, #sp_config{}).

--- a/test/string_constraints_test.erl
+++ b/test/string_constraints_test.erl
@@ -154,7 +154,7 @@ unknown_constraint_key_crashes_test() ->
         {ok, Type} = spectra_type_info:find_type(TypeInfo, my_binary, 0),
         ?assertError(
             {invalid_string_constraint, unknown_key, 1},
-            spectra_json:from_json(TypeInfo, Type, <<"hello">>, #sp_config{})
+            spectra_test_util:from_json(TypeInfo, Type, <<"hello">>)
         )
     after
         code:purge(bad_constraints_module),

--- a/test/string_constraints_test.erl
+++ b/test/string_constraints_test.erl
@@ -4,6 +4,8 @@
 
 -include_lib("eunit/include/eunit.hrl").
 
+-include("../include/spectra_internal.hrl").
+
 %% -----------------------------------------------------------------------
 %% JSON Schema generation — constraints appear in output
 %% -----------------------------------------------------------------------
@@ -152,7 +154,7 @@ unknown_constraint_key_crashes_test() ->
         {ok, Type} = spectra_type_info:find_type(TypeInfo, my_binary, 0),
         ?assertError(
             {invalid_string_constraint, unknown_key, 1},
-            spectra_json:from_json(TypeInfo, Type, <<"hello">>)
+            spectra_json:from_json(TypeInfo, Type, <<"hello">>, #sp_config{})
         )
     after
         code:purge(bad_constraints_module),

--- a/test/type_params_codec.erl
+++ b/test/type_params_codec.erl
@@ -7,36 +7,54 @@
 
 -include("../include/spectra.hrl").
 
--export([encode/6, decode/6, schema/5]).
+-export([encode/7, decode/7, schema/6]).
 
--spec encode(atom(), module(), spectra:sp_type_reference(), dynamic(), spectra:sp_type(), term()) ->
+-spec encode(
+    atom(),
+    module(),
+    spectra:sp_type_reference(),
+    dynamic(),
+    spectra:sp_type(),
+    term(),
+    spectra:sp_config()
+) ->
     spectra:codec_encode_result().
-encode(_Format, _Mod, {type, parameterized_type, 0}, Data, _SpType, Params) ->
+encode(_Format, _Mod, {type, parameterized_type, 0}, Data, _SpType, Params, _Config) ->
     {ok, {encoded, Params, Data}};
-encode(_Format, _Mod, {type, no_params_type, 0}, Data, _SpType, Params) ->
+encode(_Format, _Mod, {type, no_params_type, 0}, Data, _SpType, Params, _Config) ->
     {ok, {encoded, Params, Data}};
-encode(_Format, _Mod, {record, parameterized_rec}, Data, _SpType, Params) ->
+encode(_Format, _Mod, {record, parameterized_rec}, Data, _SpType, Params, _Config) ->
     {ok, {encoded, Params, Data}};
-encode(_, _, _, _, _, _) ->
+encode(_, _, _, _, _, _, _) ->
     continue.
 
--spec decode(atom(), module(), spectra:sp_type_reference(), dynamic(), spectra:sp_type(), term()) ->
+-spec decode(
+    atom(),
+    module(),
+    spectra:sp_type_reference(),
+    dynamic(),
+    spectra:sp_type(),
+    term(),
+    spectra:sp_config()
+) ->
     spectra:codec_decode_result().
-decode(_Format, _Mod, {type, parameterized_type, 0}, Data, _SpType, Params) ->
+decode(_Format, _Mod, {type, parameterized_type, 0}, Data, _SpType, Params, _Config) ->
     {ok, {decoded, Params, Data}};
-decode(_Format, _Mod, {type, no_params_type, 0}, Data, _SpType, Params) ->
+decode(_Format, _Mod, {type, no_params_type, 0}, Data, _SpType, Params, _Config) ->
     {ok, {decoded, Params, Data}};
-decode(_Format, _Mod, {record, parameterized_rec}, Data, _SpType, Params) ->
+decode(_Format, _Mod, {record, parameterized_rec}, Data, _SpType, Params, _Config) ->
     {ok, {decoded, Params, Data}};
-decode(_, _, _, _, _, _) ->
+decode(_, _, _, _, _, _, _) ->
     continue.
 
--spec schema(atom(), module(), spectra:sp_type_reference(), spectra:sp_type(), term()) -> dynamic().
-schema(json_schema, _Mod, {type, parameterized_type, 0}, _SpType, Params) ->
+-spec schema(
+    atom(), module(), spectra:sp_type_reference(), spectra:sp_type(), term(), spectra:sp_config()
+) -> dynamic().
+schema(json_schema, _Mod, {type, parameterized_type, 0}, _SpType, Params, _Config) ->
     #{<<"type">> => <<"string">>, <<"params">> => Params};
-schema(json_schema, _Mod, {type, no_params_type, 0}, _SpType, Params) ->
+schema(json_schema, _Mod, {type, no_params_type, 0}, _SpType, Params, _Config) ->
     #{<<"type">> => <<"string">>, <<"params">> => Params};
-schema(json_schema, _Mod, {record, parameterized_rec}, _SpType, Params) ->
+schema(json_schema, _Mod, {record, parameterized_rec}, _SpType, Params, _Config) ->
     #{<<"type">> => <<"object">>, <<"params">> => Params};
-schema(_, _, _, _, _) ->
+schema(_, _, _, _, _, _) ->
     continue.


### PR DESCRIPTION
## Summary

- **Replace unreliable VSN cache check** with a three-mode enum (`persistent | local | none`). `get/1` is removed; `get/2` now accepts `#sp_config{}`. The old boolean `use_module_types_cache` config key is replaced by `module_types_cache`. `local` (the new default) caches per-call in the process dictionary and is automatically cleared on return; `persistent` uses `persistent_term`; `none` always re-extracts.
- **Add `#sp_config{}` record** (`include/spectra_internal.hrl`) holding `module_types_cache`, `check_unicode`, and `codecs` — read once at the `spectra.erl` entry point via `get_config/0` and threaded down instead of re-reading app env on every recursive call.
- **Thread Config through the call chain**: `spectra_json`, `spectra_binary_string`, `spectra_string`, `spectra_codec`, `spectra_type_info`, `spectra_json_schema`, and `spectra_openapi` all accept and propagate `Config`.
- **Codec callback arity bump** (breaking for custom codec implementors): `encode/6→7`, `decode/6→7`, `schema/5→6` — each callback now receives `Config` as the last argument.

## Changed modules

| Module | Change |
|---|---|
| `include/spectra_internal.hrl` | Add `#sp_config{}` record |
| `src/spectra.erl` | Export `get_config/0`; thread Config through decode/encode/schema; `try...after` for guaranteed local cache cleanup |
| `src/spectra_module_types.erl` | Remove VSN check; `get/1` → `get/2` accepting `#sp_config{}`; add `clear_local/0` |
| `src/spectra_codec.erl` | `try_codec_encode/decode/schema` accept Config; codec callbacks bump to `/7`, `/7`, `/6` |
| `src/spectra_type_info.erl` | `find_codec/2` → `find_codec/3` (accept full Config) |
| `src/spectra_json.erl` | `to_json/from_json` `/3`→`/4` with Config |
| `src/spectra_binary_string.erl` | `from/to_binary_string` `/4`→`/5` with Config |
| `src/spectra_string.erl` | `from/to_string` `/3`→`/4` with Config |
| `src/spectra_json_schema.erl` | `to_schema` `/2`→`/3` with Config |
| `src/spectra_openapi.erl` | Use `spectra:get_config()`; add `try...after clear_local()` for local cache cleanup |

## Notes

- 672 unit tests and 6 property-based tests pass.
- `spectra_util:normalize_type_ref/2` is used directly in `spectra.erl` (replacing the short-lived `atom_to_type_ref/2`) to preserve identical error terms.