### PR TITLE
Pass type refs explicitly to codec dispatch

### DIFF
--- a/src/spectra.erl
+++ b/src/spectra.erl
@@ -228,14 +228,14 @@ do_decode(Format, TypeInfo, RefAtom, Data, Options, Config) when is_atom(RefAtom
     do_decode(Format, TypeInfo, TypeRef, Data, Options, Config);
 do_decode(Format, TypeInfo, {type, _, _} = TypeRef, Data, Options, Config) ->
     SpType = resolve_type_ref(TypeInfo, TypeRef),
-    maybe_codec_decode(Format, TypeInfo, SpType, Data, Options, Config);
+    maybe_codec_decode(Format, TypeInfo, TypeRef, SpType, Data, Options, Config);
 do_decode(Format, TypeInfo, {record, _} = TypeRef, Data, Options, Config) ->
     SpType = resolve_type_ref(TypeInfo, TypeRef),
-    maybe_codec_decode(Format, TypeInfo, SpType, Data, Options, Config);
+    maybe_codec_decode(Format, TypeInfo, TypeRef, SpType, Data, Options, Config);
 do_decode(Format, TypeInfo, SpType, Data, Options, Config) when is_record(TypeInfo, type_info) ->
     case type_ref_from_meta(SpType) of
-        {ok, _TypeRef} ->
-            maybe_codec_decode(Format, TypeInfo, SpType, Data, Options, Config);
+        {ok, TypeRef} ->
+            maybe_codec_decode(Format, TypeInfo, TypeRef, SpType, Data, Options, Config);
         error ->
             default_decode(Format, TypeInfo, SpType, Data, Options, Config)
     end;
@@ -368,14 +368,14 @@ do_encode(Format, TypeInfo, TypeAtom, Data, Options, Config) when is_atom(TypeAt
     do_encode(Format, TypeInfo, TypeRef, Data, Options, Config);
 do_encode(Format, TypeInfo, {type, _, _} = TypeRef, Data, Options, Config) ->
     SpType = resolve_type_ref(TypeInfo, TypeRef),
-    maybe_codec_encode(Format, TypeInfo, SpType, Data, Options, Config);
+    maybe_codec_encode(Format, TypeInfo, TypeRef, SpType, Data, Options, Config);
 do_encode(Format, TypeInfo, {record, _} = TypeRef, Data, Options, Config) ->
     SpType = resolve_type_ref(TypeInfo, TypeRef),
-    maybe_codec_encode(Format, TypeInfo, SpType, Data, Options, Config);
+    maybe_codec_encode(Format, TypeInfo, TypeRef, SpType, Data, Options, Config);
 do_encode(Format, TypeInfo, SpType, Data, Options, Config) when is_record(TypeInfo, type_info) ->
     case type_ref_from_meta(SpType) of
-        {ok, _TypeRef} ->
-            maybe_codec_encode(Format, TypeInfo, SpType, Data, Options, Config);
+        {ok, TypeRef} ->
+            maybe_codec_encode(Format, TypeInfo, TypeRef, SpType, Data, Options, Config);
         error ->
             default_encode(Format, TypeInfo, SpType, Data, Options, Config)
     end;
@@ -486,11 +486,10 @@ resolve_type_ref(TypeInfo, {type, TypeName, TypeArity}) ->
 resolve_type_ref(TypeInfo, {record, RecordName}) ->
     spectra_type_info:get_record(TypeInfo, RecordName).
 
--spec maybe_codec_schema(atom(), type_info(), sp_type_reference(), sp_config()) ->
+-spec maybe_codec_schema(atom(), type_info(), sp_type_reference(), sp_type(), sp_config()) ->
     spectra_json_schema:json_schema_object().
-maybe_codec_schema(Format, TypeInfo, TypeRef, Config) ->
-    SpType = resolve_type_ref(TypeInfo, TypeRef),
-    case spectra_codec:try_codec_schema(TypeInfo, Format, SpType, SpType, Config) of
+maybe_codec_schema(Format, TypeInfo, TypeRef, SpType, Config) ->
+    case spectra_codec:try_codec_schema(TypeInfo, Format, TypeRef, SpType, SpType, Config) of
         continue -> default_schema(Format, TypeInfo, SpType, Config);
         Schema -> Schema
     end.
@@ -515,16 +514,18 @@ finalize_schema(Format, _SchemaMap, _Options) ->
 -spec maybe_codec_decode(
     Format :: atom(),
     TypeInfo :: type_info(),
+    TypeRef :: sp_type_reference(),
     SpType :: sp_type(),
     Data :: dynamic(),
     Options :: [decode_option()],
     Config :: sp_config()
 ) -> {ok, dynamic()} | {error, [error()]}.
-maybe_codec_decode(Format, TypeInfo, SpType, Data, Options, Config) ->
+maybe_codec_decode(Format, TypeInfo, TypeRef, SpType, Data, Options, Config) ->
     case
         spectra_codec:try_codec_decode(
             TypeInfo,
             Format,
+            TypeRef,
             SpType,
             Data,
             SpType,
@@ -538,16 +539,18 @@ maybe_codec_decode(Format, TypeInfo, SpType, Data, Options, Config) ->
 -spec maybe_codec_encode(
     Format :: atom(),
     TypeInfo :: type_info(),
+    TypeRef :: sp_type_reference(),
     SpType :: sp_type(),
     Data :: dynamic(),
     Options :: [encode_option()],
     Config :: sp_config()
 ) -> {ok, dynamic()} | {error, [error()]}.
-maybe_codec_encode(Format, TypeInfo, SpType, Data, Options, Config) ->
+maybe_codec_encode(Format, TypeInfo, TypeRef, SpType, Data, Options, Config) ->
     case
         spectra_codec:try_codec_encode(
             TypeInfo,
             Format,
+            TypeRef,
             SpType,
             Data,
             SpType,
@@ -570,14 +573,14 @@ do_schema(Format, TypeInfo, {record, _} = TypeRef, Options, Config) ->
 do_schema(json_schema, TypeInfo, SpType, Options, Config) ->
     SchemaMap =
         case type_ref_from_meta(SpType) of
-            {ok, TypeRef} -> maybe_codec_schema(json_schema, TypeInfo, TypeRef, Config);
+            {ok, TypeRef} -> maybe_codec_schema(json_schema, TypeInfo, TypeRef, SpType, Config);
             error -> default_schema(json_schema, TypeInfo, SpType, Config)
         end,
     finalize_schema(json_schema, spectra_json_schema:add_schema_version(SchemaMap), Options);
 do_schema(Format, TypeInfo, SpType, Options, Config) ->
     SchemaMap =
         case type_ref_from_meta(SpType) of
-            {ok, TypeRef} -> maybe_codec_schema(Format, TypeInfo, TypeRef, Config);
+            {ok, TypeRef} -> maybe_codec_schema(Format, TypeInfo, TypeRef, SpType, Config);
             error -> default_schema(Format, TypeInfo, SpType, Config)
         end,
     finalize_schema(Format, SchemaMap, Options).
@@ -585,12 +588,14 @@ do_schema(Format, TypeInfo, SpType, Options, Config) ->
 -spec do_schema_ref(atom(), type_info(), sp_type_reference(), [schema_option()], sp_config()) ->
     iodata() | map().
 do_schema_ref(json_schema, TypeInfo, TypeRef, Options, Config) ->
+    SpType = resolve_type_ref(TypeInfo, TypeRef),
     SchemaMap = spectra_json_schema:add_schema_version(
-        maybe_codec_schema(json_schema, TypeInfo, TypeRef, Config)
+        maybe_codec_schema(json_schema, TypeInfo, TypeRef, SpType, Config)
     ),
     finalize_schema(json_schema, SchemaMap, Options);
 do_schema_ref(Format, TypeInfo, TypeRef, Options, Config) ->
-    SchemaMap = maybe_codec_schema(Format, TypeInfo, TypeRef, Config),
+    SpType = resolve_type_ref(TypeInfo, TypeRef),
+    SchemaMap = maybe_codec_schema(Format, TypeInfo, TypeRef, SpType, Config),
     finalize_schema(Format, SchemaMap, Options).
 
 -spec type_ref_from_meta(sp_type()) -> {ok, sp_type_reference()} | error.

--- a/src/spectra_binary_string.erl
+++ b/src/spectra_binary_string.erl
@@ -50,10 +50,12 @@ from_binary_string(
     Config
 ) ->
     Type = spectra_type_info:get_type(TypeInfo, N, Arity),
+    TypeRef = {type, N, Arity},
     case
         spectra_codec:try_codec_decode(
             TypeInfo,
             binary_string,
+            TypeRef,
             Type,
             BinaryString,
             UserTypeRef,
@@ -75,10 +77,12 @@ from_binary_string(
 ) ->
     RemoteTypeInfo = spectra_module_types:get(Module, Config),
     RemoteType = spectra_type_info:get_type(RemoteTypeInfo, TypeName, TypeArity),
+    TypeRef = {type, TypeName, TypeArity},
     case
         spectra_codec:try_codec_decode(
             RemoteTypeInfo,
             binary_string,
+            TypeRef,
             RemoteType,
             BinaryString,
             RemoteRef,
@@ -97,10 +101,12 @@ from_binary_string(
     TypeInfo, #sp_rec_ref{record_name = RecordName} = RecordRef, BinaryString, _Opts, Config
 ) ->
     RecordType = spectra_type_info:get_record(TypeInfo, RecordName),
+    TypeRef = {record, RecordName},
     case
         spectra_codec:try_codec_decode(
             TypeInfo,
             binary_string,
+            TypeRef,
             RecordType,
             BinaryString,
             RecordRef,
@@ -188,10 +194,12 @@ to_binary_string(
     Config
 ) ->
     Type = spectra_type_info:get_type(TypeInfo, TypeName, Arity),
+    TypeRef = {type, TypeName, Arity},
     case
         spectra_codec:try_codec_encode(
             TypeInfo,
             binary_string,
+            TypeRef,
             Type,
             Data,
             UserTypeRef,
@@ -213,10 +221,12 @@ to_binary_string(
 ) ->
     RemoteTypeInfo = spectra_module_types:get(Module, Config),
     RemoteType = spectra_type_info:get_type(RemoteTypeInfo, TypeName, TypeArity),
+    TypeRef = {type, TypeName, TypeArity},
     case
         spectra_codec:try_codec_encode(
             RemoteTypeInfo,
             binary_string,
+            TypeRef,
             RemoteType,
             Data,
             RemoteRef,
@@ -231,10 +241,12 @@ to_binary_string(
     end;
 to_binary_string(TypeInfo, #sp_rec_ref{record_name = RecordName} = RecordRef, Data, _Opts, Config) ->
     RecordType = spectra_type_info:get_record(TypeInfo, RecordName),
+    TypeRef = {record, RecordName},
     case
         spectra_codec:try_codec_encode(
             TypeInfo,
             binary_string,
+            TypeRef,
             RecordType,
             Data,
             RecordRef,

--- a/src/spectra_codec.erl
+++ b/src/spectra_codec.erl
@@ -98,22 +98,22 @@ where the reference node is available.
 -optional_callbacks([schema/6]).
 
 -export([
-    try_codec_encode/6,
-    try_codec_decode/6,
-    try_codec_schema/5
+    try_codec_encode/7,
+    try_codec_decode/7,
+    try_codec_schema/6
 ]).
 
 -doc "Encodes `Data` via a registered codec for the module owning `TypeInfo`, or returns `continue`.".
 -spec try_codec_encode(
     TypeInfo :: spectra:type_info(),
     Format :: atom(),
+    TypeRef :: spectra:sp_type_reference(),
     Type :: spectra:sp_type(),
     Data :: dynamic(),
     SpType :: spectra:sp_type(),
     Config :: spectra:sp_config()
 ) -> spectra:codec_encode_result().
-try_codec_encode(TypeInfo, Format, Type, Data, SpType, Config) ->
-    #{name := TypeReference} = spectra_type:get_meta(Type),
+try_codec_encode(TypeInfo, Format, TypeReference, Type, Data, SpType, Config) ->
     Mod = spectra_type_info:get_module(TypeInfo),
     case spectra_type_info:find_codec(TypeInfo, TypeReference, Config) of
         {ok, M} ->
@@ -128,13 +128,13 @@ try_codec_encode(TypeInfo, Format, Type, Data, SpType, Config) ->
 -spec try_codec_decode(
     TypeInfo :: spectra:type_info(),
     Format :: atom(),
+    TypeRef :: spectra:sp_type_reference(),
     Type :: spectra:sp_type(),
     Data :: dynamic(),
     SpType :: spectra:sp_type(),
     Config :: spectra:sp_config()
 ) -> spectra:codec_decode_result().
-try_codec_decode(TypeInfo, Format, Type, Data, SpType, Config) ->
-    #{name := TypeReference} = spectra_type:get_meta(Type),
+try_codec_decode(TypeInfo, Format, TypeReference, Type, Data, SpType, Config) ->
     Mod = spectra_type_info:get_module(TypeInfo),
     case spectra_type_info:find_codec(TypeInfo, TypeReference, Config) of
         {ok, M} ->
@@ -149,12 +149,12 @@ try_codec_decode(TypeInfo, Format, Type, Data, SpType, Config) ->
 -spec try_codec_schema(
     TypeInfo :: spectra:type_info(),
     Format :: atom(),
+    TypeRef :: spectra:sp_type_reference(),
     Type :: spectra:sp_type(),
     SpType :: spectra:sp_type(),
     Config :: spectra:sp_config()
 ) -> dynamic() | continue.
-try_codec_schema(TypeInfo, Format, Type, SpType, Config) ->
-    #{name := TypeReference} = spectra_type:get_meta(Type),
+try_codec_schema(TypeInfo, Format, TypeReference, Type, SpType, Config) ->
     Mod = spectra_type_info:get_module(TypeInfo),
     case spectra_type_info:find_codec(TypeInfo, TypeReference, Config) of
         {ok, M} ->

--- a/src/spectra_json.erl
+++ b/src/spectra_json.erl
@@ -49,10 +49,12 @@ to_json(
     is_atom(TypeName)
 ->
     Type = spectra_type_info:get_type(TypeInfo, TypeName, Arity),
+    TypeRef = {type, TypeName, Arity},
     case
         spectra_codec:try_codec_encode(
             TypeInfo,
             json,
+            TypeRef,
             Type,
             Data,
             UserTypeRef,
@@ -73,10 +75,12 @@ to_json(
 ) ->
     RemoteTypeInfo = spectra_module_types:get(Module, Config),
     RemoteType = spectra_type_info:get_type(RemoteTypeInfo, TypeName, TypeArity),
+    TypeRef = {type, TypeName, TypeArity},
     case
         spectra_codec:try_codec_encode(
             RemoteTypeInfo,
             json,
+            TypeRef,
             RemoteType,
             Data,
             RemoteRef,
@@ -102,10 +106,12 @@ to_json(
     is_atom(RecordName)
 ->
     RecordType = spectra_type_info:get_record(TypeInfo, RecordName),
+    TypeRef = {record, RecordName},
     case
         spectra_codec:try_codec_encode(
             TypeInfo,
             json,
+            TypeRef,
             RecordType,
             Record,
             RecordRef,
@@ -514,10 +520,12 @@ do_from_json(
     is_atom(TypeName)
 ->
     Type = spectra_type_info:get_type(TypeInfo, TypeName, Arity),
+    TypeRef = {type, TypeName, Arity},
     case
         spectra_codec:try_codec_decode(
             TypeInfo,
             json,
+            TypeRef,
             Type,
             Json,
             UserTypeRef,
@@ -538,10 +546,12 @@ do_from_json(
 ) ->
     RemoteTypeInfo = spectra_module_types:get(Module, Config),
     RemoteType = spectra_type_info:get_type(RemoteTypeInfo, TypeName, TypeArity),
+    TypeRef = {type, TypeName, TypeArity},
     case
         spectra_codec:try_codec_decode(
             RemoteTypeInfo,
             json,
+            TypeRef,
             RemoteType,
             Json,
             RemoteRef,
@@ -567,10 +577,12 @@ do_from_json(
     is_atom(RecordName)
 ->
     RecordType = spectra_type_info:get_record(TypeInfo, RecordName),
+    TypeRef = {record, RecordName},
     case
         spectra_codec:try_codec_decode(
             TypeInfo,
             json,
+            TypeRef,
             RecordType,
             Json,
             RecordRef,

--- a/src/spectra_json_schema.erl
+++ b/src/spectra_json_schema.erl
@@ -77,7 +77,10 @@ do_to_schema(
     Config
 ) ->
     Type = spectra_type_info:get_type(TypeInfo, N, Arity),
-    case spectra_codec:try_codec_schema(TypeInfo, json_schema, Type, UserTypeRef, Config) of
+    TypeRef = {type, N, Arity},
+    case
+        spectra_codec:try_codec_schema(TypeInfo, json_schema, TypeRef, Type, UserTypeRef, Config)
+    of
         continue ->
             TypeWithoutVars = spectra_util:apply_args(TypeInfo, Type, Args),
             do_to_schema(TypeInfo, TypeWithoutVars, Config);
@@ -91,8 +94,11 @@ do_to_schema(
 ) ->
     RemoteTypeInfo = spectra_module_types:get(Mod, Config),
     RemoteType = spectra_type_info:get_type(RemoteTypeInfo, TypeName, Arity),
+    TypeRef = {type, TypeName, Arity},
     case
-        spectra_codec:try_codec_schema(RemoteTypeInfo, json_schema, RemoteType, RemoteRef, Config)
+        spectra_codec:try_codec_schema(
+            RemoteTypeInfo, json_schema, TypeRef, RemoteType, RemoteRef, Config
+        )
     of
         continue ->
             TypeResolved = spectra_type:propagate_params(
@@ -104,7 +110,12 @@ do_to_schema(
     end;
 do_to_schema(TypeInfo, #sp_rec_ref{record_name = N} = RecordRef, Config) ->
     RecordType = spectra_type_info:get_record(TypeInfo, N),
-    case spectra_codec:try_codec_schema(TypeInfo, json_schema, RecordType, RecordRef, Config) of
+    TypeRef = {record, N},
+    case
+        spectra_codec:try_codec_schema(
+            TypeInfo, json_schema, TypeRef, RecordType, RecordRef, Config
+        )
+    of
         continue ->
             Schema = record_to_schema_internal(TypeInfo, RecordType, Config),
             merge_type_doc_into_schema(TypeInfo, RecordType, Schema, Config);

--- a/src/spectra_openapi.erl
+++ b/src/spectra_openapi.erl
@@ -1020,13 +1020,15 @@ capitalize_word([First | Rest]) ->
     spectra_json_schema:json_schema().
 to_inline_schema(TypeInfo, {type, Name, Arity}, Config) ->
     Type = spectra_type_info:get_type(TypeInfo, Name, Arity),
-    case spectra_codec:try_codec_schema(TypeInfo, json_schema, Type, Type, Config) of
+    TypeRef = {type, Name, Arity},
+    case spectra_codec:try_codec_schema(TypeInfo, json_schema, TypeRef, Type, Type, Config) of
         continue -> spectra_json_schema:to_schema(TypeInfo, Type, Config);
         Schema -> Schema
     end;
 to_inline_schema(TypeInfo, {record, RecordName}, Config) ->
     Record = spectra_type_info:get_record(TypeInfo, RecordName),
-    case spectra_codec:try_codec_schema(TypeInfo, json_schema, Record, Record, Config) of
+    TypeRef = {record, RecordName},
+    case spectra_codec:try_codec_schema(TypeInfo, json_schema, TypeRef, Record, Record, Config) of
         continue -> spectra_json_schema:to_schema(TypeInfo, Record, Config);
         Schema -> Schema
     end;

--- a/src/spectra_string.erl
+++ b/src/spectra_string.erl
@@ -44,10 +44,12 @@ from_string(
     Config
 ) ->
     Type = spectra_type_info:get_type(TypeInfo, TypeName, Arity),
+    TypeRef = {type, TypeName, Arity},
     case
         spectra_codec:try_codec_decode(
             TypeInfo,
             string,
+            TypeRef,
             Type,
             String,
             UserTypeRef,
@@ -62,10 +64,12 @@ from_string(
     end;
 from_string(TypeInfo, #sp_rec_ref{record_name = RecordName} = RecordRef, String, Config) ->
     RecordType = spectra_type_info:get_record(TypeInfo, RecordName),
+    TypeRef = {record, RecordName},
     case
         spectra_codec:try_codec_decode(
             TypeInfo,
             string,
+            TypeRef,
             RecordType,
             String,
             RecordRef,
@@ -83,10 +87,12 @@ from_string(
 ) ->
     RemoteTypeInfo = spectra_module_types:get(Module, Config),
     RemoteType = spectra_type_info:get_type(RemoteTypeInfo, TypeName, TypeArity),
+    TypeRef = {type, TypeName, TypeArity},
     case
         spectra_codec:try_codec_decode(
             RemoteTypeInfo,
             string,
+            TypeRef,
             RemoteType,
             String,
             RemoteRef,
@@ -171,10 +177,12 @@ to_string(
     Config
 ) ->
     Type = spectra_type_info:get_type(TypeInfo, TypeName, Arity),
+    TypeRef = {type, TypeName, Arity},
     case
         spectra_codec:try_codec_encode(
             TypeInfo,
             string,
+            TypeRef,
             Type,
             Data,
             UserTypeRef,
@@ -189,10 +197,12 @@ to_string(
     end;
 to_string(TypeInfo, #sp_rec_ref{record_name = RecordName} = RecordRef, Data, Config) ->
     RecordType = spectra_type_info:get_record(TypeInfo, RecordName),
+    TypeRef = {record, RecordName},
     case
         spectra_codec:try_codec_encode(
             TypeInfo,
             string,
+            TypeRef,
             RecordType,
             Data,
             RecordRef,
@@ -210,10 +220,12 @@ to_string(
 ) ->
     RemoteTypeInfo = spectra_module_types:get(Module, Config),
     RemoteType = spectra_type_info:get_type(RemoteTypeInfo, TypeName, TypeArity),
+    TypeRef = {type, TypeName, TypeArity},
     case
         spectra_codec:try_codec_encode(
             RemoteTypeInfo,
             string,
+            TypeRef,
             RemoteType,
             Data,
             RemoteRef,


### PR DESCRIPTION
## Summary
- pass `sp_type_reference()` explicitly from the encode/decode/schema call sites that already know it
- remove codec dispatch's dependency on reading `name` from type metadata in the hot path
- keep metadata fallback only for top-level raw `sp_type()` entry points in `spectra.erl`

## Verification
- `make format`
- `make build-test`
- `make proper`