### PR TITLE
Release 0.11.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,19 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.11.0] - 2026-04-12
+
+### Added
+- `module_types_cache` configuration with `local`, `persistent`, and `none` modes for controlling how module type information is cached.
+- A shared internal config path so encoding, decoding, schema generation, and OpenAPI generation use the same resolved runtime configuration throughout a call.
+
+### Changed
+- **Breaking**: Custom codec callbacks now receive an extra config argument. `encode` and `decode` move from arity 6 to 7, and `schema` moves from arity 5 to 6.
+- **Breaking**: The old `use_module_types_cache` boolean option is replaced by `module_types_cache`.
+
+### Fixed
+- Codec dispatch now passes type references explicitly, improving codec-backed type handling across encoding, decoding, schema generation, and OpenAPI generation.
+
 ## [0.10.0] - 2026-04-08
 
 ### Added

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -17,9 +17,6 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - **Breaking**: Custom codec callbacks now receive an extra config argument. `encode` and `decode` move from arity 6 to 7, and `schema` moves from arity 5 to 6.
 - **Breaking**: The old `use_module_types_cache` boolean option is replaced by `module_types_cache`.
 
-### Fixed
-- Codec dispatch now passes type references explicitly, improving codec-backed type handling across encoding, decoding, schema generation, and OpenAPI generation.
-
 ## [0.10.0] - 2026-04-08
 
 ### Added

--- a/README.md
+++ b/README.md
@@ -17,7 +17,7 @@ Add spectra to your rebar.config dependencies:
 
 ```erlang
 {deps, [
-    {spectra, "~> 0.10.0"}
+    {spectra, "~> 0.11.0"}
 ]}.
 ```
 


### PR DESCRIPTION
## Release 0.11.0

### Added
- `module_types_cache` configuration with `local`, `persistent`, and `none` modes for controlling how module type information is cached.
- A shared internal config path so encoding, decoding, schema generation, and OpenAPI generation use the same resolved runtime configuration throughout a call.

### Changed
- **Breaking**: Custom codec callbacks now receive an extra config argument. `encode` and `decode` move from arity 6 to 7, and `schema` moves from arity 5 to 6.
- **Breaking**: The old `use_module_types_cache` boolean option is replaced by `module_types_cache`.