### PR TITLE
Use map matching and list-based consumed keys

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -18,6 +18,9 @@ Once that is done, run `make proper`.
   - Add test: Create new test file in test/ directory
   - Run specific test: rebar3 eunit --module=test_module_name
 
+## Lint Rules
+  - When a lint diagnostic includes a code (e.g. W0032) and a link, follow the link to understand the rule before attempting a fix. Do not guess at the meaning of the code.
+
 ## Development Guidelines
   - All changes should come with unit tests (positive and negative if applicable) that cover the change.
   - Don't define types in .hrl files. Types that the user of this library should use should be defined in spectra.erl

--- a/include/spectra.hrl
+++ b/include/spectra.hrl
@@ -1,5 +1,5 @@
 -record(sp_error, {
-    location :: [string() | atom()],
+    location :: [string() | atom() | integer()],
     type :: decode_error | type_mismatch | no_match | missing_data | not_matched_fields,
     ctx :: #{
         type => spectra:sp_type_or_ref() | spectra:map_field() | spectra:record_field(),

--- a/src/sp_error.erl
+++ b/src/sp_error.erl
@@ -45,7 +45,7 @@ type_mismatch(Type, Value, Ctx) ->
 -spec missing_data(
     spectra:sp_type_or_ref() | spectra:map_field() | spectra:record_field(),
     dynamic(),
-    [string() | atom()]
+    [string() | atom() | integer()]
 ) -> #sp_error{}.
 missing_data(Type, Value, Location) ->
     #sp_error{
@@ -85,6 +85,6 @@ Prepends `FieldName` to the error's location path.
 Called as the traversal unwinds so the final location reads
 outermost-to-innermost (e.g. `[user, address, street]`).
 """.
--spec append_location(#sp_error{}, string() | atom()) -> #sp_error{}.
+-spec append_location(#sp_error{}, string() | atom() | integer()) -> #sp_error{}.
 append_location(Err, FieldName) ->
     Err#sp_error{location = [FieldName | Err#sp_error.location]}.

--- a/src/spectra_json.erl
+++ b/src/spectra_json.erl
@@ -1049,69 +1049,74 @@ map_from_json(TypeInfo, #sp_map{fields = MapFieldType, struct_name = StructName}
 
     case spectra_util:fold_until_error(LiteralFun, {[], []}, LiteralFields) of
         {ok, {LiteralMapFields, ConsumedKeys}} ->
-            %% Phase 2: Process typed fields with remaining JSON entries
-            RemainingJsonList = lists:filter(
-                fun({K, _}) -> not lists:member(K, ConsumedKeys) end,
-                maps:to_list(Json)
-            ),
+            BuildResult = fun(AllFields) ->
+                Decoded = maps:from_list(AllFields),
+                case Defaults of
+                    undefined -> {ok, Decoded};
+                    _ -> {ok, maps:merge(Defaults, Decoded)}
+                end
+            end,
 
-            TypedFun = fun
-                (
-                    #typed_map_field{kind = assoc, key_type = KeyType, val_type = ValueType},
-                    {FieldsAcc, CurrentRemainingJsonList}
-                ) ->
-                    case
-                        map_field_type_from_json_list(
-                            TypeInfo, KeyType, ValueType, CurrentRemainingJsonList, Config
-                        )
-                    of
-                        {ok, {NewFields, NewConsumed}} ->
-                            NextRemainingJsonList = lists:filter(
-                                fun({K, _}) -> not lists:member(K, NewConsumed) end,
-                                CurrentRemainingJsonList
-                            ),
-                            {ok, {NewFields ++ FieldsAcc, NextRemainingJsonList}};
-                        {error, Reason} ->
-                            {error, Reason}
-                    end;
-                (
-                    #typed_map_field{kind = exact, key_type = KeyType, val_type = ValueType} = Type,
-                    {FieldsAcc, CurrentRemainingJsonList}
-                ) ->
-                    case
-                        map_field_type_from_json_list(
-                            TypeInfo, KeyType, ValueType, CurrentRemainingJsonList, Config
-                        )
-                    of
-                        {ok, {NewFields, NewConsumed}} ->
-                            NextRemainingJsonList = lists:filter(
-                                fun({K, _}) -> not lists:member(K, NewConsumed) end,
-                                CurrentRemainingJsonList
-                            ),
-                            case NewFields of
-                                [] ->
-                                    Remainder = maps:from_list(CurrentRemainingJsonList),
-                                    {error, [sp_error:not_matched_fields(Type, Remainder)]};
-                                _ ->
-                                    {ok, {NewFields ++ FieldsAcc, NextRemainingJsonList}}
+            case TypedFields of
+                [] ->
+                    BuildResult(LiteralMapFields);
+                _ ->
+                    %% Phase 2: Process typed fields with remaining JSON entries
+                    RemainingJsonList = lists:filter(
+                        fun({K, _}) -> not lists:member(K, ConsumedKeys) end,
+                        maps:to_list(Json)
+                    ),
+
+                    TypedFun = fun
+                        (
+                            #typed_map_field{
+                                kind = assoc, key_type = KeyType, val_type = ValueType
+                            },
+                            {FieldsAcc, CurrentRemainingJsonList}
+                        ) ->
+                            case
+                                map_field_type_from_json_list(
+                                    TypeInfo, KeyType, ValueType, CurrentRemainingJsonList, Config
+                                )
+                            of
+                                {ok, {NewFields, NextRemainingJsonList}} ->
+                                    {ok, {NewFields ++ FieldsAcc, NextRemainingJsonList}};
+                                {error, Reason} ->
+                                    {error, Reason}
                             end;
+                        (
+                            #typed_map_field{kind = exact, key_type = KeyType, val_type = ValueType} =
+                                Type,
+                            {FieldsAcc, CurrentRemainingJsonList}
+                        ) ->
+                            case
+                                map_field_type_from_json_list(
+                                    TypeInfo, KeyType, ValueType, CurrentRemainingJsonList, Config
+                                )
+                            of
+                                {ok, {NewFields, NextRemainingJsonList}} ->
+                                    case NewFields of
+                                        [] ->
+                                            Remainder = maps:from_list(CurrentRemainingJsonList),
+                                            {error, [sp_error:not_matched_fields(Type, Remainder)]};
+                                        _ ->
+                                            {ok, {NewFields ++ FieldsAcc, NextRemainingJsonList}}
+                                    end;
+                                {error, _} = Err ->
+                                    Err
+                            end
+                    end,
+
+                    case
+                        spectra_util:fold_until_error(
+                            TypedFun, {[], RemainingJsonList}, TypedFields
+                        )
+                    of
+                        {ok, {TypedMapFields, _FinalRemainingJsonList}} ->
+                            BuildResult(TypedMapFields ++ LiteralMapFields);
                         {error, _} = Err ->
                             Err
                     end
-            end,
-
-            case spectra_util:fold_until_error(TypedFun, {[], RemainingJsonList}, TypedFields) of
-                {ok, {TypedMapFields, _FinalRemainingJsonList}} ->
-                    AllFields = TypedMapFields ++ LiteralMapFields,
-                    Decoded = maps:from_list(AllFields),
-                    Result =
-                        case Defaults of
-                            undefined -> Decoded;
-                            _ -> maps:merge(Defaults, Decoded)
-                        end,
-                    {ok, Result};
-                {error, _} = Err ->
-                    Err
             end;
         {error, _} = Err ->
             Err
@@ -1131,16 +1136,15 @@ struct_default_value(Defaults, FieldName) ->
 
 map_field_type_from_json_list(TypeInfo, KeyType, ValueType, JsonList, Config) ->
     spectra_util:fold_until_error(
-        fun({Key, Value}, {FieldsAcc, ConsumedAcc}) ->
+        fun({Key, Value}, {FieldsAcc, RemainingAcc}) ->
             case do_from_json(TypeInfo, KeyType, Key, Config) of
                 {ok, KeyJson} ->
                     case do_from_json(TypeInfo, ValueType, Value, Config) of
                         {ok, ValueJson} ->
-                            {ok,
-                                {
-                                    [{KeyJson, ValueJson} | FieldsAcc],
-                                    [Key | ConsumedAcc]
-                                }};
+                            {ok, {
+                                [{KeyJson, ValueJson} | FieldsAcc],
+                                RemainingAcc
+                            }};
                         {error, Errs} ->
                             Errs2 =
                                 lists:map(
@@ -1152,7 +1156,7 @@ map_field_type_from_json_list(TypeInfo, KeyType, ValueType, JsonList, Config) ->
                             {error, Errs2}
                     end;
                 {error, _Errs} ->
-                    {ok, {FieldsAcc, ConsumedAcc}}
+                    {ok, {FieldsAcc, [{Key, Value} | RemainingAcc]}}
             end
         end,
         {[], []},

--- a/src/spectra_json.erl
+++ b/src/spectra_json.erl
@@ -292,84 +292,14 @@ map_fields_to_json(TypeInfo, MapFieldTypes, Data, Config) ->
         MapFieldTypes
     ),
 
-    LiteralFun = fun
-        (
-            #literal_map_field{
-                kind = assoc, name = FieldName, binary_name = BinaryFieldName, val_type = FieldType
-            },
-            {FieldsAcc, ConsumedKeys}
-        ) ->
-            case Data of
-                #{FieldName := FieldData} ->
-                    Missing = spectra_type:can_be_missing(TypeInfo, FieldType),
-                    case {FieldData, Missing} of
-                        {MissingValue, {true, MissingValue}} ->
-                            {ok, {FieldsAcc, [FieldName | ConsumedKeys]}};
-                        _ ->
-                            case to_json(TypeInfo, FieldType, FieldData, Config) of
-                                {ok, FieldJson} ->
-                                    {ok,
-                                        {
-                                            [{BinaryFieldName, FieldJson} | FieldsAcc],
-                                            [FieldName | ConsumedKeys]
-                                        }};
-                                {error, Errs} ->
-                                    Errs2 =
-                                        lists:map(
-                                            fun(Err) ->
-                                                sp_error:append_location(Err, FieldName)
-                                            end,
-                                            Errs
-                                        ),
-                                    {error, Errs2}
-                            end
-                    end;
-                #{} ->
-                    {ok, {FieldsAcc, ConsumedKeys}}
-            end;
-        (
-            #literal_map_field{
-                kind = exact, name = FieldName, binary_name = BinaryFieldName, val_type = FieldType
-            } = Type,
-            {FieldsAcc, ConsumedKeys}
-        ) ->
-            Missing = spectra_type:can_be_missing(TypeInfo, FieldType),
-            case Data of
-                #{FieldName := FieldData} ->
-                    case {FieldData, Missing} of
-                        {MissingValue, {true, MissingValue}} ->
-                            {ok, {FieldsAcc, [FieldName | ConsumedKeys]}};
-                        _ ->
-                            case to_json(TypeInfo, FieldType, FieldData, Config) of
-                                {ok, FieldJson} ->
-                                    {ok,
-                                        {
-                                            [{BinaryFieldName, FieldJson} | FieldsAcc],
-                                            [FieldName | ConsumedKeys]
-                                        }};
-                                {error, Errs} ->
-                                    Errs2 =
-                                        lists:map(
-                                            fun(Err) ->
-                                                sp_error:append_location(Err, FieldName)
-                                            end,
-                                            Errs
-                                        ),
-                                    {error, Errs2}
-                            end
-                    end;
-                #{} ->
-                    case Missing of
-                        {true, _} ->
-                            {ok, {FieldsAcc, ConsumedKeys}};
-                        false ->
-                            Remainder = maps:without(ConsumedKeys, Data),
-                            {error, [sp_error:missing_data(Type, Remainder, [FieldName])]}
-                    end
-            end
-    end,
-
-    case spectra_util:fold_until_error(LiteralFun, {[], []}, LiteralFields) of
+    case
+        spectra_util:fold_until_error(
+            fun map_literal_field_to_json/3,
+            {TypeInfo, Data, Config},
+            {[], []},
+            LiteralFields
+        )
+    of
         {ok, {LiteralMapFields, ConsumedKeys}} ->
             case TypedFields of
                 [] ->
@@ -381,56 +311,12 @@ map_fields_to_json(TypeInfo, MapFieldTypes, Data, Config) ->
                         fun({K, _}) -> not sets:is_element(K, ConsumedKeysSet) end,
                         maps:to_list(Data)
                     ),
-
-                    TypedFun = fun
-                        (
-                            #typed_map_field{
-                                kind = assoc, key_type = KeyType, val_type = ValueType
-                            },
-                            {FieldsAcc, CurrentRemainingDataList}
-                        ) ->
-                            case
-                                map_typed_field_to_json_list(
-                                    TypeInfo, KeyType, ValueType, CurrentRemainingDataList, Config
-                                )
-                            of
-                                {ok, {NewFields, NextRemainingDataList}} ->
-                                    {ok, {
-                                        lists:reverse(NewFields, FieldsAcc),
-                                        NextRemainingDataList
-                                    }};
-                                {error, _} = Err ->
-                                    Err
-                            end;
-                        (
-                            #typed_map_field{kind = exact, key_type = KeyType, val_type = ValueType} =
-                                Type,
-                            {FieldsAcc, CurrentRemainingDataList}
-                        ) ->
-                            case
-                                map_typed_field_to_json_list(
-                                    TypeInfo, KeyType, ValueType, CurrentRemainingDataList, Config
-                                )
-                            of
-                                {ok, {NewFields, NextRemainingDataList}} ->
-                                    case NewFields of
-                                        [] ->
-                                            Remainder = maps:from_list(CurrentRemainingDataList),
-                                            {error, [sp_error:not_matched_fields(Type, Remainder)]};
-                                        _ ->
-                                            {ok, {
-                                                lists:reverse(NewFields, FieldsAcc),
-                                                NextRemainingDataList
-                                            }}
-                                    end;
-                                {error, _} = Err ->
-                                    Err
-                            end
-                    end,
-
                     case
                         spectra_util:fold_until_error(
-                            TypedFun, {[], RemainingDataList}, TypedFields
+                            fun map_typed_field_to_json/3,
+                            {TypeInfo, Config},
+                            {[], RemainingDataList},
+                            TypedFields
                         )
                     of
                         {ok, {TypedMapFields, _}} ->
@@ -438,6 +324,93 @@ map_fields_to_json(TypeInfo, MapFieldTypes, Data, Config) ->
                         {error, _} = Err ->
                             Err
                     end
+            end;
+        {error, _} = Err ->
+            Err
+    end.
+
+-spec map_literal_field_to_json(
+    {spectra:type_info(), map(), spectra:sp_config()},
+    #literal_map_field{},
+    {[{binary(), json:encode_value()}], [atom() | integer()]}
+) ->
+    {ok, {[{binary(), json:encode_value()}], [atom() | integer()]}} | {error, [spectra:error()]}.
+map_literal_field_to_json(
+    {TypeInfo, Data, Config},
+    #literal_map_field{
+        kind = Kind,
+        name = FieldName,
+        binary_name = BinaryFieldName,
+        val_type = FieldType
+    } =
+        Type,
+    {FieldsAcc, ConsumedKeys}
+) ->
+    Missing = spectra_type:can_be_missing(TypeInfo, FieldType),
+    case Data of
+        #{FieldName := FieldData} ->
+            case {FieldData, Missing} of
+                {MissingValue, {true, MissingValue}} ->
+                    {ok, {FieldsAcc, [FieldName | ConsumedKeys]}};
+                _ ->
+                    case to_json(TypeInfo, FieldType, FieldData, Config) of
+                        {ok, FieldJson} ->
+                            {ok,
+                                {
+                                    [{BinaryFieldName, FieldJson} | FieldsAcc],
+                                    [FieldName | ConsumedKeys]
+                                }};
+                        {error, Errs} ->
+                            {error, append_error_location(Errs, FieldName)}
+                    end
+            end;
+        #{} ->
+            case {Kind, Missing} of
+                {assoc, _} ->
+                    {ok, {FieldsAcc, ConsumedKeys}};
+                {exact, {true, _}} ->
+                    {ok, {FieldsAcc, ConsumedKeys}};
+                {exact, false} ->
+                    Remainder = maps:without(ConsumedKeys, Data),
+                    {error, [sp_error:missing_data(Type, Remainder, [FieldName])]}
+            end
+    end.
+
+-spec map_typed_field_to_json(
+    {spectra:type_info(), spectra:sp_config()},
+    #typed_map_field{},
+    {[{json:encode_value(), json:encode_value()}], [{dynamic(), dynamic()}]}
+) ->
+    {ok, {[{json:encode_value(), json:encode_value()}], [{dynamic(), dynamic()}]}}
+    | {error, [spectra:error()]}.
+map_typed_field_to_json(
+    {TypeInfo, Config},
+    #typed_map_field{kind = assoc, key_type = KeyType, val_type = ValueType},
+    {FieldsAcc, CurrentRemainingDataList}
+) ->
+    case
+        map_typed_field_to_json_list(TypeInfo, KeyType, ValueType, CurrentRemainingDataList, Config)
+    of
+        {ok, {NewFields, NextRemainingDataList}} ->
+            {ok, {lists:reverse(NewFields, FieldsAcc), NextRemainingDataList}};
+        {error, _} = Err ->
+            Err
+    end;
+map_typed_field_to_json(
+    {TypeInfo, Config},
+    #typed_map_field{kind = exact, key_type = KeyType, val_type = ValueType} = Type,
+    {FieldsAcc, CurrentRemainingDataList}
+) ->
+    case
+        map_typed_field_to_json_list(TypeInfo, KeyType, ValueType, CurrentRemainingDataList, Config)
+    of
+        {ok, {NewFields, NextRemainingDataList}} ->
+            case NewFields of
+                [] ->
+                    Remainder = maps:from_list(CurrentRemainingDataList),
+                    {error, [sp_error:not_matched_fields(Type, Remainder)]};
+                _ ->
+                    {ok, {lists:reverse(NewFields, FieldsAcc), NextRemainingDataList}}
             end;
         {error, _} = Err ->
             Err
@@ -981,90 +954,22 @@ map_from_json(TypeInfo, #sp_map{fields = MapFieldType, struct_name = StructName}
         MapFieldType
     ),
 
-    LiteralFun = fun
-        (
-            #literal_map_field{
-                kind = assoc, name = FieldName, binary_name = BinaryName, val_type = FieldType
-            },
-            {FieldsAcc, ConsumedKeys}
-        ) ->
-            case Json of
-                #{BinaryName := FieldData} ->
-                    case do_from_json(TypeInfo, FieldType, FieldData, Config) of
-                        {ok, FieldJson} ->
-                            {ok,
-                                {
-                                    [{FieldName, FieldJson} | FieldsAcc],
-                                    [BinaryName | ConsumedKeys]
-                                }};
-                        {error, Errs} ->
-                            Errs2 =
-                                lists:map(
-                                    fun(Err) ->
-                                        sp_error:append_location(Err, FieldName)
-                                    end,
-                                    Errs
-                                ),
-                            {error, Errs2}
-                    end;
-                #{} ->
-                    {ok, {FieldsAcc, ConsumedKeys}}
-            end;
-        (
-            #literal_map_field{
-                kind = exact, name = FieldName, binary_name = BinaryName, val_type = FieldType
-            } = Type,
-            {FieldsAcc, ConsumedKeys}
-        ) ->
-            case Json of
-                #{BinaryName := FieldData} ->
-                    case do_from_json(TypeInfo, FieldType, FieldData, Config) of
-                        {ok, FieldJson} ->
-                            {ok,
-                                {
-                                    [{FieldName, FieldJson} | FieldsAcc],
-                                    [BinaryName | ConsumedKeys]
-                                }};
-                        {error, Errs} ->
-                            Errs2 =
-                                lists:map(
-                                    fun(Err) ->
-                                        sp_error:append_location(Err, FieldName)
-                                    end,
-                                    Errs
-                                ),
-                            {error, Errs2}
-                    end;
-                #{} ->
-                    case spectra_type:can_be_missing(TypeInfo, FieldType) of
-                        {true, MissingValue} when Defaults =:= undefined ->
-                            {ok, {[{FieldName, MissingValue} | FieldsAcc], ConsumedKeys}};
-                        {true, _} ->
-                            {ok, {FieldsAcc, ConsumedKeys}};
-                        false ->
-                            case struct_default_value(Defaults, FieldName) of
-                                {ok, _} ->
-                                    {ok, {FieldsAcc, ConsumedKeys}};
-                                error ->
-                                    Remainder = maps:without(ConsumedKeys, Json),
-                                    {error, [
-                                        sp_error:missing_data(Type, Remainder, [FieldName])
-                                    ]}
-                            end
-                    end
-            end
+    BuildResult = fun(AllFields) ->
+        Decoded = maps:from_list(AllFields),
+        case Defaults of
+            undefined -> {ok, Decoded};
+            _ -> {ok, maps:merge(Defaults, Decoded)}
+        end
     end,
-
-    case spectra_util:fold_until_error(LiteralFun, {[], []}, LiteralFields) of
+    case
+        spectra_util:fold_until_error(
+            fun map_literal_field_from_json/3,
+            {TypeInfo, Json, Defaults, Config},
+            {[], []},
+            LiteralFields
+        )
+    of
         {ok, {LiteralMapFields, ConsumedKeys}} ->
-            BuildResult = fun(AllFields) ->
-                Decoded = maps:from_list(AllFields),
-                case Defaults of
-                    undefined -> {ok, Decoded};
-                    _ -> {ok, maps:merge(Defaults, Decoded)}
-                end
-            end,
-
             case TypedFields of
                 [] ->
                     BuildResult(LiteralMapFields);
@@ -1075,50 +980,12 @@ map_from_json(TypeInfo, #sp_map{fields = MapFieldType, struct_name = StructName}
                         fun({K, _}) -> not sets:is_element(K, ConsumedKeysSet) end,
                         maps:to_list(Json)
                     ),
-
-                    TypedFun = fun
-                        (
-                            #typed_map_field{
-                                kind = assoc, key_type = KeyType, val_type = ValueType
-                            },
-                            {FieldsAcc, CurrentRemainingJsonList}
-                        ) ->
-                            case
-                                map_field_type_from_json_list(
-                                    TypeInfo, KeyType, ValueType, CurrentRemainingJsonList, Config
-                                )
-                            of
-                                {ok, {NewFields, NextRemainingJsonList}} ->
-                                    {ok, {NewFields ++ FieldsAcc, NextRemainingJsonList}};
-                                {error, Reason} ->
-                                    {error, Reason}
-                            end;
-                        (
-                            #typed_map_field{kind = exact, key_type = KeyType, val_type = ValueType} =
-                                Type,
-                            {FieldsAcc, CurrentRemainingJsonList}
-                        ) ->
-                            case
-                                map_field_type_from_json_list(
-                                    TypeInfo, KeyType, ValueType, CurrentRemainingJsonList, Config
-                                )
-                            of
-                                {ok, {NewFields, NextRemainingJsonList}} ->
-                                    case NewFields of
-                                        [] ->
-                                            Remainder = maps:from_list(CurrentRemainingJsonList),
-                                            {error, [sp_error:not_matched_fields(Type, Remainder)]};
-                                        _ ->
-                                            {ok, {NewFields ++ FieldsAcc, NextRemainingJsonList}}
-                                    end;
-                                {error, _} = Err ->
-                                    Err
-                            end
-                    end,
-
                     case
                         spectra_util:fold_until_error(
-                            TypedFun, {[], RemainingJsonList}, TypedFields
+                            fun map_typed_field_from_json/3,
+                            {TypeInfo, Config},
+                            {[], RemainingJsonList},
+                            TypedFields
                         )
                     of
                         {ok, {TypedMapFields, _FinalRemainingJsonList}} ->
@@ -1134,7 +1001,95 @@ map_from_json(_TypeInfo, MapType, Json, _Config) ->
     %% Return error when Json is not a map
     {error, [sp_error:type_mismatch(MapType, Json)]}.
 
--spec struct_default_value(undefined | map(), atom()) -> {ok, term()} | error.
+-spec map_literal_field_from_json(
+    {spectra:type_info(), map(), undefined | map(), spectra:sp_config()},
+    #literal_map_field{},
+    {[{atom() | integer(), dynamic()}], [binary()]}
+) ->
+    {ok, {[{atom() | integer(), dynamic()}], [binary()]}} | {error, [spectra:error()]}.
+map_literal_field_from_json(
+    {TypeInfo, Json, Defaults, Config},
+    #literal_map_field{
+        kind = Kind,
+        name = FieldName,
+        binary_name = BinaryName,
+        val_type = FieldType
+    } =
+        Type,
+    {FieldsAcc, ConsumedKeys}
+) ->
+    case Json of
+        #{BinaryName := FieldData} ->
+            case do_from_json(TypeInfo, FieldType, FieldData, Config) of
+                {ok, FieldJson} ->
+                    {ok, {[{FieldName, FieldJson} | FieldsAcc], [BinaryName | ConsumedKeys]}};
+                {error, Errs} ->
+                    {error, append_error_location(Errs, FieldName)}
+            end;
+        #{} ->
+            case {Kind, spectra_type:can_be_missing(TypeInfo, FieldType)} of
+                {assoc, _} ->
+                    {ok, {FieldsAcc, ConsumedKeys}};
+                {exact, {true, MissingValue}} when Defaults =:= undefined ->
+                    {ok, {[{FieldName, MissingValue} | FieldsAcc], ConsumedKeys}};
+                {exact, {true, _}} ->
+                    {ok, {FieldsAcc, ConsumedKeys}};
+                {exact, false} ->
+                    case struct_default_value(Defaults, FieldName) of
+                        {ok, _} ->
+                            {ok, {FieldsAcc, ConsumedKeys}};
+                        error ->
+                            Remainder = maps:without(ConsumedKeys, Json),
+                            {error, [sp_error:missing_data(Type, Remainder, [FieldName])]}
+                    end
+            end
+    end.
+
+-spec map_typed_field_from_json(
+    {spectra:type_info(), spectra:sp_config()},
+    #typed_map_field{},
+    {[{dynamic(), dynamic()}], [{json:encode_value(), json:decode_value()}]}
+) ->
+    {ok, {[{dynamic(), dynamic()}], [{json:encode_value(), json:decode_value()}]}}
+    | {error, [spectra:error()]}.
+map_typed_field_from_json(
+    {TypeInfo, Config},
+    #typed_map_field{kind = assoc, key_type = KeyType, val_type = ValueType},
+    {FieldsAcc, CurrentRemainingJsonList}
+) ->
+    case
+        map_field_type_from_json_list(
+            TypeInfo, KeyType, ValueType, CurrentRemainingJsonList, Config
+        )
+    of
+        {ok, {NewFields, NextRemainingJsonList}} ->
+            {ok, {NewFields ++ FieldsAcc, NextRemainingJsonList}};
+        {error, Reason} ->
+            {error, Reason}
+    end;
+map_typed_field_from_json(
+    {TypeInfo, Config},
+    #typed_map_field{kind = exact, key_type = KeyType, val_type = ValueType} = Type,
+    {FieldsAcc, CurrentRemainingJsonList}
+) ->
+    case
+        map_field_type_from_json_list(
+            TypeInfo, KeyType, ValueType, CurrentRemainingJsonList, Config
+        )
+    of
+        {ok, {NewFields, NextRemainingJsonList}} ->
+            case NewFields of
+                [] ->
+                    Remainder = maps:from_list(CurrentRemainingJsonList),
+                    {error, [sp_error:not_matched_fields(Type, Remainder)]};
+                _ ->
+                    {ok, {NewFields ++ FieldsAcc, NextRemainingJsonList}}
+            end;
+        {error, _} = Err ->
+            Err
+    end.
+
+-spec struct_default_value(undefined | map(), atom() | integer()) -> {ok, term()} | error.
 struct_default_value(undefined, _FieldName) ->
     error;
 struct_default_value(Defaults, FieldName) ->
@@ -1142,6 +1097,10 @@ struct_default_value(Defaults, FieldName) ->
         {ok, V} when V =/= nil, V =/= undefined -> {ok, V};
         _ -> error
     end.
+
+-spec append_error_location([spectra:error()], atom() | integer()) -> [spectra:error()].
+append_error_location(Errors, FieldName) ->
+    lists:map(fun(Err) -> sp_error:append_location(Err, FieldName) end, Errors).
 
 map_field_type_from_json_list(TypeInfo, KeyType, ValueType, JsonList, Config) ->
     spectra_util:fold_until_error(

--- a/src/spectra_json.erl
+++ b/src/spectra_json.erl
@@ -335,17 +335,13 @@ map_fields_to_json(TypeInfo, MapFieldTypes, Data, Config) ->
     {[{binary(), json:encode_value()}], [atom() | integer()]}
 ) ->
     {ok, {[{binary(), json:encode_value()}], [atom() | integer()]}} | {error, [spectra:error()]}.
-map_literal_field_to_json(
-    {TypeInfo, Data, Config},
+map_literal_field_to_json({TypeInfo, Data, Config}, Type, {FieldsAcc, ConsumedKeys}) ->
     #literal_map_field{
         kind = Kind,
         name = FieldName,
         binary_name = BinaryFieldName,
         val_type = FieldType
-    } =
-        Type,
-    {FieldsAcc, ConsumedKeys}
-) ->
+    } = Type,
     Missing = spectra_type:can_be_missing(TypeInfo, FieldType),
     case Data of
         #{FieldName := FieldData} ->
@@ -1158,13 +1154,13 @@ do_record_from_json(TypeInfo, #sp_rec{name = RecordName, fields = RecordInfo}, J
 ->
     Fun = fun(
         #sp_rec_field{name = FieldName, binary_name = BinaryName, type = FieldType} = Type,
-        FieldsAcc
+        {FieldsAcc, ConsumedFields}
     ) ->
         case Json of
             #{BinaryName := RecordFieldData} ->
                 case do_from_json(TypeInfo, FieldType, RecordFieldData, Config) of
                     {ok, FieldJson} ->
-                        {ok, [FieldJson | FieldsAcc]};
+                        {ok, {[FieldJson | FieldsAcc], [BinaryName | ConsumedFields]}};
                     {error, Errs} ->
                         Errs2 =
                             lists:map(
@@ -1176,14 +1172,15 @@ do_record_from_json(TypeInfo, #sp_rec{name = RecordName, fields = RecordInfo}, J
             #{} ->
                 case spectra_type:can_be_missing(TypeInfo, FieldType) of
                     {true, MissingValue} ->
-                        {ok, [MissingValue | FieldsAcc]};
+                        {ok, {[MissingValue | FieldsAcc], ConsumedFields}};
                     false ->
-                        {error, [sp_error:missing_data(Type, Json, [FieldName])]}
+                        RemainingJson = maps:without(ConsumedFields, Json),
+                        {error, [sp_error:missing_data(Type, RemainingJson, [FieldName])]}
                 end
         end
     end,
-    case spectra_util:fold_until_error(Fun, [], RecordInfo) of
-        {ok, Fields} ->
+    case spectra_util:fold_until_error(Fun, {[], []}, RecordInfo) of
+        {ok, {Fields, _}} ->
             {ok, list_to_tuple([RecordName | lists:reverse(Fields)])};
         % TODO: Add config option to optionally error on extra fields
         {error, Errs} ->

--- a/src/spectra_json.erl
+++ b/src/spectra_json.erl
@@ -288,50 +288,61 @@ map_fields_to_json(TypeInfo, MapFieldTypes, Data, Config) ->
             #literal_map_field{
                 kind = assoc, name = FieldName, binary_name = BinaryFieldName, val_type = FieldType
             },
-            {FieldsAcc, DataAcc}
+            {FieldsAcc, Consumed}
         ) ->
-            case
-                {maps:take(FieldName, DataAcc), spectra_type:can_be_missing(TypeInfo, FieldType)}
-            of
-                {{MissingValue, NewDataAcc}, {true, MissingValue}} ->
-                    {ok, {FieldsAcc, NewDataAcc}};
-                {{FieldData, NewDataAcc}, _} ->
-                    case to_json(TypeInfo, FieldType, FieldData, Config) of
-                        {ok, FieldJson} ->
-                            {ok, {
-                                [{BinaryFieldName, FieldJson} | FieldsAcc],
-                                NewDataAcc
-                            }};
-                        {error, Errs} ->
-                            Errs2 =
-                                lists:map(
-                                    fun(Err) -> sp_error:append_location(Err, FieldName) end,
-                                    Errs
-                                ),
-                            {error, Errs2}
-                    end;
-                {error, _} ->
-                    {ok, {FieldsAcc, DataAcc}}
+            case is_consumed(FieldName, Consumed) of
+                true ->
+                    {ok, {FieldsAcc, Consumed}};
+                false ->
+                    Missing = spectra_type:can_be_missing(TypeInfo, FieldType),
+                    case Data of
+                        #{FieldName := FieldData} ->
+                            case {FieldData, Missing} of
+                                {MissingValue, {true, MissingValue}} ->
+                                    {ok, {FieldsAcc, add_consumed(FieldName, Consumed)}};
+                                _ ->
+                                    case to_json(TypeInfo, FieldType, FieldData, Config) of
+                                        {ok, FieldJson} ->
+                                            {ok, {
+                                                [{BinaryFieldName, FieldJson} | FieldsAcc],
+                                                add_consumed(FieldName, Consumed)
+                                            }};
+                                        {error, Errs} ->
+                                            Errs2 =
+                                                lists:map(
+                                                    fun(Err) ->
+                                                        sp_error:append_location(Err, FieldName)
+                                                    end,
+                                                    Errs
+                                                ),
+                                            {error, Errs2}
+                                    end
+                            end;
+                        #{} ->
+                            {ok, {FieldsAcc, Consumed}}
+                    end
             end;
         (
             #typed_map_field{kind = assoc, key_type = KeyType, val_type = ValueType},
-            {FieldsAcc, DataAcc}
+            {FieldsAcc, Consumed}
         ) ->
-            case map_typed_field_to_json(TypeInfo, KeyType, ValueType, DataAcc, Config) of
-                {ok, {NewFields, NewDataAcc}} ->
-                    {ok, {lists:reverse(NewFields, FieldsAcc), NewDataAcc}};
+            Remainder = maps:without(Consumed, Data),
+            case map_typed_field_to_json(TypeInfo, KeyType, ValueType, Remainder, Config) of
+                {ok, {NewFields, NewConsumed}} ->
+                    {ok, {lists:reverse(NewFields, FieldsAcc), NewConsumed ++ Consumed}};
                 {error, _} = Err ->
                     Err
             end;
         (
             #typed_map_field{kind = exact, key_type = KeyType, val_type = ValueType} = Type,
-            {FieldsAcc, DataAcc}
+            {FieldsAcc, Consumed}
         ) ->
-            case map_typed_field_to_json(TypeInfo, KeyType, ValueType, DataAcc, Config) of
+            Remainder = maps:without(Consumed, Data),
+            case map_typed_field_to_json(TypeInfo, KeyType, ValueType, Remainder, Config) of
                 {ok, {[], _}} ->
-                    {error, [sp_error:not_matched_fields(Type, DataAcc)]};
-                {ok, {NewFields, NewDataAcc}} ->
-                    {ok, {lists:reverse(NewFields, FieldsAcc), NewDataAcc}};
+                    {error, [sp_error:not_matched_fields(Type, Remainder)]};
+                {ok, {NewFields, NewConsumed}} ->
+                    {ok, {lists:reverse(NewFields, FieldsAcc), NewConsumed ++ Consumed}};
                 {error, _} = Err ->
                     Err
             end;
@@ -339,54 +350,59 @@ map_fields_to_json(TypeInfo, MapFieldTypes, Data, Config) ->
             #literal_map_field{
                 kind = exact, name = FieldName, binary_name = BinaryFieldName, val_type = FieldType
             } = Type,
-            {FieldsAcc, DataAcc}
+            {FieldsAcc, Consumed}
         ) ->
-            case
-                {maps:take(FieldName, DataAcc), spectra_type:can_be_missing(TypeInfo, FieldType)}
-            of
-                {{MissingValue, NewDataAcc}, {true, MissingValue}} ->
-                    {ok, {FieldsAcc, NewDataAcc}};
-                {{FieldData, NewDataAcc}, _} ->
-                    case to_json(TypeInfo, FieldType, FieldData, Config) of
-                        {ok, FieldJson} ->
-                            {ok, {[{BinaryFieldName, FieldJson} | FieldsAcc], NewDataAcc}};
-                        {error, Errs} ->
-                            Errs2 =
-                                lists:map(
-                                    fun(Err) -> sp_error:append_location(Err, FieldName) end,
-                                    Errs
-                                ),
-                            {error, Errs2}
-                    end;
-                {error, _} ->
+            case is_consumed(FieldName, Consumed) of
+                true ->
                     case spectra_type:can_be_missing(TypeInfo, FieldType) of
                         {true, _} ->
-                            {ok, {FieldsAcc, DataAcc}};
+                            {ok, {FieldsAcc, Consumed}};
                         false ->
-                            {error, [sp_error:missing_data(Type, DataAcc, [FieldName])]}
+                            Remainder = maps:without(Consumed, Data),
+                            {error, [sp_error:missing_data(Type, Remainder, [FieldName])]}
+                    end;
+                false ->
+                    Missing = spectra_type:can_be_missing(TypeInfo, FieldType),
+                    case Data of
+                        #{FieldName := FieldData} ->
+                            case {FieldData, Missing} of
+                                {MissingValue, {true, MissingValue}} ->
+                                    {ok, {FieldsAcc, add_consumed(FieldName, Consumed)}};
+                                _ ->
+                                    case to_json(TypeInfo, FieldType, FieldData, Config) of
+                                        {ok, FieldJson} ->
+                                            {ok, {
+                                                [{BinaryFieldName, FieldJson} | FieldsAcc],
+                                                add_consumed(FieldName, Consumed)
+                                            }};
+                                        {error, Errs} ->
+                                            Errs2 =
+                                                lists:map(
+                                                    fun(Err) ->
+                                                        sp_error:append_location(Err, FieldName)
+                                                    end,
+                                                    Errs
+                                                ),
+                                            {error, Errs2}
+                                    end
+                            end;
+                        #{} ->
+                            case Missing of
+                                {true, _} ->
+                                    {ok, {FieldsAcc, Consumed}};
+                                false ->
+                                    Remainder = maps:without(Consumed, Data),
+                                    {error, [sp_error:missing_data(Type, Remainder, [FieldName])]}
+                            end
                     end
             end
     end,
-    case spectra_util:fold_until_error(Fun, {[], Data}, MapFieldTypes) of
-        {ok, {MapFields, _FinalData}} ->
+    case spectra_util:fold_until_error(Fun, {[], []}, MapFieldTypes) of
+        {ok, {MapFields, _FinalConsumed}} ->
             {ok, MapFields};
         % TODO: Add config option to optionally error on extra fields
-        % case maps:to_list(FinalData) of
-        %     [] ->
-        %         {ok, MapFields};
-        %     L ->
-        %         {error,
-        %             lists:map(
-        %                 fun({Key, Value}) ->
-        %                     #sp_error{
-        %                         type = not_matched_fields,
-        %                         location = [],
-        %                         ctx = #{key => Key, value => Value}
-        %                     }
-        %                 end,
-        %                 L
-        %             )}
-        % end;
+        % Remainder = maps:without(FinalConsumed, Data),
+        % case maps:to_list(Remainder) of ...
         {error, _} = Err ->
             Err
     end.
@@ -398,33 +414,36 @@ map_fields_to_json(TypeInfo, MapFieldTypes, Data, Config) ->
     Data :: map(),
     Config :: spectra:sp_config()
 ) ->
-    {ok, {[{json:encode_value(), json:encode_value()}], map()}}
+    {ok, {[{json:encode_value(), json:encode_value()}], [dynamic()]}}
     | {error, [spectra:error()]}.
 map_typed_field_to_json(TypeInfo, KeyType, ValueType, Data, Config) ->
-    Fun = fun({Key, Value}, {FieldsAcc, DataAcc}) ->
+    Fun = fun({Key, Value}, {FieldsAcc, ConsumedAcc}) ->
         case to_json(TypeInfo, KeyType, Key, Config) of
             {ok, KeyJson} ->
                 case {Value, spectra_type:can_be_missing(TypeInfo, ValueType)} of
                     {MissingValue, {true, MissingValue}} ->
-                        {ok, {FieldsAcc, maps:remove(Key, DataAcc)}};
+                        {ok, {FieldsAcc, [Key | ConsumedAcc]}};
                     _ ->
                         case to_json(TypeInfo, ValueType, Value, Config) of
                             {ok, ValueJson} ->
-                                {ok, {
-                                    [{KeyJson, ValueJson} | FieldsAcc], maps:remove(Key, DataAcc)
-                                }};
+                                {ok,
+                                    {
+                                        [{KeyJson, ValueJson} | FieldsAcc],
+                                        [Key | ConsumedAcc]
+                                    }};
                             {error, Errs} ->
                                 Errs2 = lists:map(
-                                    fun(Err) -> sp_error:append_location(Err, Key) end, Errs
+                                    fun(Err) -> sp_error:append_location(Err, Key) end,
+                                    Errs
                                 ),
                                 {error, Errs2}
                         end
                 end;
             {error, _Errs} ->
-                {ok, {FieldsAcc, DataAcc}}
+                {ok, {FieldsAcc, ConsumedAcc}}
         end
     end,
-    spectra_util:fold_until_error(Fun, {[], Data}, maps:to_list(Data)).
+    spectra_util:fold_until_error(Fun, {[], []}, maps:to_list(Data)).
 
 -spec record_to_json(
     TypeInfo :: spectra:type_info(),
@@ -934,87 +953,125 @@ map_from_json(TypeInfo, #sp_map{fields = MapFieldType, struct_name = StructName}
             #literal_map_field{
                 kind = assoc, name = FieldName, binary_name = BinaryName, val_type = FieldType
             },
-            {FieldsAcc, JsonAcc}
+            {FieldsAcc, Consumed}
         ) ->
-            case maps:take(BinaryName, JsonAcc) of
-                {FieldData, NewJsonAcc} ->
-                    case do_from_json(TypeInfo, FieldType, FieldData, Config) of
-                        {ok, FieldJson} ->
-                            {ok, {[{FieldName, FieldJson} | FieldsAcc], NewJsonAcc}};
-                        {error, Errs} ->
-                            Errs2 =
-                                lists:map(
-                                    fun(Err) -> sp_error:append_location(Err, FieldName) end,
-                                    Errs
-                                ),
-                            {error, Errs2}
-                    end;
-                error ->
-                    {ok, {FieldsAcc, JsonAcc}}
+            case is_consumed(BinaryName, Consumed) of
+                true ->
+                    {ok, {FieldsAcc, Consumed}};
+                false ->
+                    case Json of
+                        #{BinaryName := FieldData} ->
+                            case do_from_json(TypeInfo, FieldType, FieldData, Config) of
+                                {ok, FieldJson} ->
+                                    {ok, {
+                                        [{FieldName, FieldJson} | FieldsAcc],
+                                        add_consumed(BinaryName, Consumed)
+                                    }};
+                                {error, Errs} ->
+                                    Errs2 =
+                                        lists:map(
+                                            fun(Err) ->
+                                                sp_error:append_location(Err, FieldName)
+                                            end,
+                                            Errs
+                                        ),
+                                    {error, Errs2}
+                            end;
+                        #{} ->
+                            {ok, {FieldsAcc, Consumed}}
+                    end
             end;
         (
             #literal_map_field{
                 kind = exact, name = FieldName, binary_name = BinaryName, val_type = FieldType
             } = Type,
-            {FieldsAcc, JsonAcc}
+            {FieldsAcc, Consumed}
         ) ->
-            case maps:take(BinaryName, JsonAcc) of
-                {FieldData, NewJsonAcc} ->
-                    case do_from_json(TypeInfo, FieldType, FieldData, Config) of
-                        {ok, FieldJson} ->
-                            {ok, {[{FieldName, FieldJson} | FieldsAcc], NewJsonAcc}};
-                        {error, Errs} ->
-                            Errs2 =
-                                lists:map(
-                                    fun(Err) -> sp_error:append_location(Err, FieldName) end,
-                                    Errs
-                                ),
-                            {error, Errs2}
-                    end;
-                error ->
+            case is_consumed(BinaryName, Consumed) of
+                true ->
                     case spectra_type:can_be_missing(TypeInfo, FieldType) of
                         {true, MissingValue} when Defaults =:= undefined ->
-                            {ok, {[{FieldName, MissingValue} | FieldsAcc], JsonAcc}};
+                            {ok, {[{FieldName, MissingValue} | FieldsAcc], Consumed}};
                         {true, _} ->
-                            {ok, {FieldsAcc, JsonAcc}};
+                            {ok, {FieldsAcc, Consumed}};
                         false ->
                             case struct_default_value(Defaults, FieldName) of
                                 {ok, _} ->
-                                    {ok, {FieldsAcc, JsonAcc}};
+                                    {ok, {FieldsAcc, Consumed}};
                                 error ->
-                                    {error, [sp_error:missing_data(Type, JsonAcc, [FieldName])]}
+                                    Remainder = maps:without(Consumed, Json),
+                                    {error, [sp_error:missing_data(Type, Remainder, [FieldName])]}
+                            end
+                    end;
+                false ->
+                    case Json of
+                        #{BinaryName := FieldData} ->
+                            case do_from_json(TypeInfo, FieldType, FieldData, Config) of
+                                {ok, FieldJson} ->
+                                    {ok, {
+                                        [{FieldName, FieldJson} | FieldsAcc],
+                                        add_consumed(BinaryName, Consumed)
+                                    }};
+                                {error, Errs} ->
+                                    Errs2 =
+                                        lists:map(
+                                            fun(Err) ->
+                                                sp_error:append_location(Err, FieldName)
+                                            end,
+                                            Errs
+                                        ),
+                                    {error, Errs2}
+                            end;
+                        #{} ->
+                            case spectra_type:can_be_missing(TypeInfo, FieldType) of
+                                {true, MissingValue} when Defaults =:= undefined ->
+                                    {ok, {[{FieldName, MissingValue} | FieldsAcc], Consumed}};
+                                {true, _} ->
+                                    {ok, {FieldsAcc, Consumed}};
+                                false ->
+                                    case struct_default_value(Defaults, FieldName) of
+                                        {ok, _} ->
+                                            {ok, {FieldsAcc, Consumed}};
+                                        error ->
+                                            Remainder = maps:without(Consumed, Json),
+                                            {error, [
+                                                sp_error:missing_data(Type, Remainder, [FieldName])
+                                            ]}
+                                    end
                             end
                     end
             end;
         (
             #typed_map_field{kind = assoc, key_type = KeyType, val_type = ValueType},
-            {FieldsAcc, JsonAcc}
+            {FieldsAcc, Consumed}
         ) ->
-            case map_field_type_from_json(TypeInfo, KeyType, ValueType, JsonAcc, Config) of
-                {ok, {NewFields, NewJsonAcc}} ->
-                    {ok, {NewFields ++ FieldsAcc, NewJsonAcc}};
+            Remainder = maps:without(Consumed, Json),
+            case map_field_type_from_json(TypeInfo, KeyType, ValueType, Remainder, Config) of
+                {ok, {NewFields, NewConsumed}} ->
+                    {ok, {NewFields ++ FieldsAcc, NewConsumed ++ Consumed}};
                 {error, Reason} ->
                     {error, Reason}
             end;
         (
             #typed_map_field{kind = exact, key_type = KeyType, val_type = ValueType} = Type,
-            {FieldsAcc, JsonAcc}
+            {FieldsAcc, Consumed}
         ) ->
-            case map_field_type_from_json(TypeInfo, KeyType, ValueType, JsonAcc, Config) of
-                {ok, {NewFields, NewJsonAcc}} ->
+            Remainder = maps:without(Consumed, Json),
+            case map_field_type_from_json(TypeInfo, KeyType, ValueType, Remainder, Config) of
+                {ok, {NewFields, NewConsumed}} ->
                     case NewFields of
                         [] ->
-                            {error, [sp_error:not_matched_fields(Type, JsonAcc)]};
+                            {error, [sp_error:not_matched_fields(Type, Remainder)]};
                         _ ->
-                            {ok, {NewFields ++ FieldsAcc, NewJsonAcc}}
+                            {ok, {NewFields ++ FieldsAcc, NewConsumed ++ Consumed}}
                     end;
                 {error, _} = Err ->
                     Err
             end
     end,
 
-    case spectra_util:fold_until_error(Fun, {[], Json}, SortedFields) of
-        {ok, {Fields, _NotMapped}} ->
+    case spectra_util:fold_until_error(Fun, {[], []}, SortedFields) of
+        {ok, {Fields, _FinalConsumed}} ->
             Decoded = maps:from_list(Fields),
             Result =
                 case Defaults of
@@ -1023,22 +1080,8 @@ map_from_json(TypeInfo, #sp_map{fields = MapFieldType, struct_name = StructName}
                 end,
             {ok, Result};
         % TODO: Add config option to optionally error on extra fields
-        % case maps:size(NotMapped) of
-        %     0 ->
-        %         {ok, maps:from_list(Fields)};
-        %     _ ->
-        %         {error,
-        %             lists:map(
-        %                 fun({Key, Value}) ->
-        %                     #sp_error{
-        %                         type = not_matched_fields,
-        %                         location = [],
-        %                         ctx = #{key => Key, value => Value}
-        %                     }
-        %                 end,
-        %                 maps:to_list(NotMapped)
-        %             )}
-        % end;
+        % Remainder = maps:without(FinalConsumed, Json),
+        % case maps:size(Remainder) of ...
         {error, _} = Err ->
             Err
     end;
@@ -1057,30 +1100,31 @@ struct_default_value(Defaults, FieldName) ->
 
 map_field_type_from_json(TypeInfo, KeyType, ValueType, Json, Config) ->
     spectra_util:fold_until_error(
-        fun({Key, Value}, {FieldsAcc, JsonAcc}) ->
+        fun({Key, Value}, {FieldsAcc, ConsumedAcc}) ->
             case do_from_json(TypeInfo, KeyType, Key, Config) of
                 {ok, KeyJson} ->
                     case do_from_json(TypeInfo, ValueType, Value, Config) of
                         {ok, ValueJson} ->
-                            {ok, {[{KeyJson, ValueJson} | FieldsAcc], maps:remove(Key, JsonAcc)}};
+                            {ok,
+                                {
+                                    [{KeyJson, ValueJson} | FieldsAcc],
+                                    [Key | ConsumedAcc]
+                                }};
                         {error, Errs} ->
                             Errs2 =
                                 lists:map(
                                     fun(Err) ->
-                                        sp_error:append_location(
-                                            Err,
-                                            Key
-                                        )
+                                        sp_error:append_location(Err, Key)
                                     end,
                                     Errs
                                 ),
                             {error, Errs2}
                     end;
                 {error, _Errs} ->
-                    {ok, {FieldsAcc, JsonAcc}}
+                    {ok, {FieldsAcc, ConsumedAcc}}
             end
         end,
-        {[], Json},
+        {[], []},
         maps:to_list(Json)
     ).
 
@@ -1111,13 +1155,13 @@ do_record_from_json(TypeInfo, #sp_rec{name = RecordName, fields = RecordInfo}, J
 ->
     Fun = fun(
         #sp_rec_field{name = FieldName, binary_name = BinaryName, type = FieldType} = Type,
-        {FieldsAcc, JsonAcc}
+        FieldsAcc
     ) ->
-        case maps:take(BinaryName, JsonAcc) of
-            {RecordFieldData, NewJsonAcc} ->
+        case Json of
+            #{BinaryName := RecordFieldData} ->
                 case do_from_json(TypeInfo, FieldType, RecordFieldData, Config) of
                     {ok, FieldJson} ->
-                        {ok, {[FieldJson | FieldsAcc], NewJsonAcc}};
+                        {ok, [FieldJson | FieldsAcc]};
                     {error, Errs} ->
                         Errs2 =
                             lists:map(
@@ -1126,37 +1170,32 @@ do_record_from_json(TypeInfo, #sp_rec{name = RecordName, fields = RecordInfo}, J
                             ),
                         {error, Errs2}
                 end;
-            error ->
+            #{} ->
                 case spectra_type:can_be_missing(TypeInfo, FieldType) of
                     {true, MissingValue} ->
-                        {ok, {[MissingValue | FieldsAcc], JsonAcc}};
+                        {ok, [MissingValue | FieldsAcc]};
                     false ->
-                        {error, [sp_error:missing_data(Type, JsonAcc, [FieldName])]}
+                        {error, [sp_error:missing_data(Type, Json, [FieldName])]}
                 end
         end
     end,
-    case spectra_util:fold_until_error(Fun, {[], Json}, RecordInfo) of
-        {ok, {Fields, _NotMapped}} ->
+    case spectra_util:fold_until_error(Fun, [], RecordInfo) of
+        {ok, Fields} ->
             {ok, list_to_tuple([RecordName | lists:reverse(Fields)])};
         % TODO: Add config option to optionally error on extra fields
-        % case maps:size(NotMapped) of
-        %     0 ->
-        %         {ok, list_to_tuple([RecordName | lists:reverse(Fields)])};
-        %     _ ->
-        %         {error,
-        %             lists:map(
-        %                 fun({Key, Value}) ->
-        %                     #sp_error{
-        %                         type = not_matched_fields,
-        %                         location = [],
-        %                         ctx = #{key => Key, value => Value}
-        %                     }
-        %                 end,
-        %                 maps:to_list(NotMapped)
-        %             )}
-        % end;
         {error, Errs} ->
             {error, Errs}
     end;
 do_record_from_json(_TypeInfo, Type, Json, _Config) ->
     {error, [sp_error:type_mismatch(Type, Json)]}.
+
+%% --- Consumed-key helpers for map fold optimisation ---
+%%
+%% Consumed keys are tracked as a simple list and used directly with
+%% maps:without/2 when typed fields need the current remainder.
+
+-spec is_consumed(dynamic(), [dynamic()]) -> boolean().
+is_consumed(Key, Consumed) -> lists:member(Key, Consumed).
+
+-spec add_consumed(dynamic(), [dynamic()]) -> [dynamic()].
+add_consumed(Key, Consumed) -> [Key | Consumed].

--- a/src/spectra_json.erl
+++ b/src/spectra_json.erl
@@ -371,64 +371,72 @@ map_fields_to_json(TypeInfo, MapFieldTypes, Data, Config) ->
 
     case spectra_util:fold_until_error(LiteralFun, {[], []}, LiteralFields) of
         {ok, {LiteralMapFields, ConsumedKeys}} ->
-            %% Phase 2: Process typed fields with remaining data entries
-            RemainingDataList = lists:filter(
-                fun({K, _}) -> not lists:member(K, ConsumedKeys) end,
-                maps:to_list(Data)
-            ),
+            case TypedFields of
+                [] ->
+                    {ok, LiteralMapFields};
+                _ ->
+                    %% Phase 2: Process typed fields with remaining data entries
+                    RemainingDataList = lists:filter(
+                        fun({K, _}) -> not lists:member(K, ConsumedKeys) end,
+                        maps:to_list(Data)
+                    ),
 
-            TypedFun = fun
-                (
-                    #typed_map_field{kind = assoc, key_type = KeyType, val_type = ValueType},
-                    {FieldsAcc, CurrentRemainingDataList}
-                ) ->
-                    case
-                        map_typed_field_to_json_list(
-                            TypeInfo, KeyType, ValueType, CurrentRemainingDataList, Config
-                        )
-                    of
-                        {ok, {NewFields, NewConsumed}} ->
-                            NextRemainingDataList = lists:filter(
-                                fun({K, _}) -> not lists:member(K, NewConsumed) end,
-                                CurrentRemainingDataList
-                            ),
-                            {ok, {lists:reverse(NewFields, FieldsAcc), NextRemainingDataList}};
-                        {error, _} = Err ->
-                            Err
-                    end;
-                (
-                    #typed_map_field{kind = exact, key_type = KeyType, val_type = ValueType} = Type,
-                    {FieldsAcc, CurrentRemainingDataList}
-                ) ->
-                    case
-                        map_typed_field_to_json_list(
-                            TypeInfo, KeyType, ValueType, CurrentRemainingDataList, Config
-                        )
-                    of
-                        {ok, {NewFields, NewConsumed}} ->
-                            NextRemainingDataList = lists:filter(
-                                fun({K, _}) -> not lists:member(K, NewConsumed) end,
-                                CurrentRemainingDataList
-                            ),
-                            case NewFields of
-                                [] ->
-                                    Remainder = maps:from_list(CurrentRemainingDataList),
-                                    {error, [sp_error:not_matched_fields(Type, Remainder)]};
-                                _ ->
+                    TypedFun = fun
+                        (
+                            #typed_map_field{
+                                kind = assoc, key_type = KeyType, val_type = ValueType
+                            },
+                            {FieldsAcc, CurrentRemainingDataList}
+                        ) ->
+                            case
+                                map_typed_field_to_json_list(
+                                    TypeInfo, KeyType, ValueType, CurrentRemainingDataList, Config
+                                )
+                            of
+                                {ok, {NewFields, NextRemainingDataList}} ->
                                     {ok, {
-                                        lists:reverse(NewFields, FieldsAcc), NextRemainingDataList
-                                    }}
+                                        lists:reverse(NewFields, FieldsAcc),
+                                        NextRemainingDataList
+                                    }};
+                                {error, _} = Err ->
+                                    Err
                             end;
+                        (
+                            #typed_map_field{kind = exact, key_type = KeyType, val_type = ValueType} =
+                                Type,
+                            {FieldsAcc, CurrentRemainingDataList}
+                        ) ->
+                            case
+                                map_typed_field_to_json_list(
+                                    TypeInfo, KeyType, ValueType, CurrentRemainingDataList, Config
+                                )
+                            of
+                                {ok, {NewFields, NextRemainingDataList}} ->
+                                    case NewFields of
+                                        [] ->
+                                            Remainder = maps:from_list(CurrentRemainingDataList),
+                                            {error, [sp_error:not_matched_fields(Type, Remainder)]};
+                                        _ ->
+                                            {ok, {
+                                                lists:reverse(NewFields, FieldsAcc),
+                                                NextRemainingDataList
+                                            }}
+                                    end;
+                                {error, _} = Err ->
+                                    Err
+                            end
+                    end,
+
+                    case
+                        spectra_util:fold_until_error(
+                            TypedFun, {[], RemainingDataList}, TypedFields
+                        )
+                    of
+                        {ok, {TypedMapFields, _}} ->
+                            {ok, TypedMapFields ++ LiteralMapFields};
                         {error, _} = Err ->
                             Err
                     end
-            end,
-
-            case spectra_util:fold_until_error(TypedFun, {[], RemainingDataList}, TypedFields) of
-                {ok, {TypedMapFields, _}} ->
-                    {ok, TypedMapFields ++ LiteralMapFields};
-                {error, _} = Err ->
-                    Err
             end;
         {error, _} = Err ->
             Err
@@ -441,23 +449,22 @@ map_fields_to_json(TypeInfo, MapFieldTypes, Data, Config) ->
     DataList :: [{dynamic(), dynamic()}],
     Config :: spectra:sp_config()
 ) ->
-    {ok, {[{json:encode_value(), json:encode_value()}], [dynamic()]}}
+    {ok, {[{json:encode_value(), json:encode_value()}], [{dynamic(), dynamic()}]}}
     | {error, [spectra:error()]}.
 map_typed_field_to_json_list(TypeInfo, KeyType, ValueType, DataList, Config) ->
-    Fun = fun({Key, Value}, {FieldsAcc, ConsumedAcc}) ->
+    Fun = fun({Key, Value}, {FieldsAcc, RemainingAcc}) ->
         case to_json(TypeInfo, KeyType, Key, Config) of
             {ok, KeyJson} ->
                 case {Value, spectra_type:can_be_missing(TypeInfo, ValueType)} of
                     {MissingValue, {true, MissingValue}} ->
-                        {ok, {FieldsAcc, [Key | ConsumedAcc]}};
+                        {ok, {FieldsAcc, RemainingAcc}};
                     _ ->
                         case to_json(TypeInfo, ValueType, Value, Config) of
                             {ok, ValueJson} ->
-                                {ok,
-                                    {
-                                        [{KeyJson, ValueJson} | FieldsAcc],
-                                        [Key | ConsumedAcc]
-                                    }};
+                                {ok, {
+                                    [{KeyJson, ValueJson} | FieldsAcc],
+                                    RemainingAcc
+                                }};
                             {error, Errs} ->
                                 Errs2 = lists:map(
                                     fun(Err) -> sp_error:append_location(Err, Key) end,
@@ -467,7 +474,7 @@ map_typed_field_to_json_list(TypeInfo, KeyType, ValueType, DataList, Config) ->
                         end
                 end;
             {error, _Errs} ->
-                {ok, {FieldsAcc, ConsumedAcc}}
+                {ok, {FieldsAcc, [{Key, Value} | RemainingAcc]}}
         end
     end,
     spectra_util:fold_until_error(Fun, {[], []}, DataList).

--- a/src/spectra_json.erl
+++ b/src/spectra_json.erl
@@ -1058,42 +1058,50 @@ map_from_json(TypeInfo, #sp_map{fields = MapFieldType, struct_name = StructName}
             TypedFun = fun
                 (
                     #typed_map_field{kind = assoc, key_type = KeyType, val_type = ValueType},
-                    {FieldsAcc, _}
+                    {FieldsAcc, CurrentRemainingJsonList}
                 ) ->
                     case
                         map_field_type_from_json_list(
-                            TypeInfo, KeyType, ValueType, RemainingJsonList, Config
+                            TypeInfo, KeyType, ValueType, CurrentRemainingJsonList, Config
                         )
                     of
-                        {ok, {NewFields, _}} ->
-                            {ok, {NewFields ++ FieldsAcc, []}};
+                        {ok, {NewFields, NewConsumed}} ->
+                            NextRemainingJsonList = lists:filter(
+                                fun({K, _}) -> not lists:member(K, NewConsumed) end,
+                                CurrentRemainingJsonList
+                            ),
+                            {ok, {NewFields ++ FieldsAcc, NextRemainingJsonList}};
                         {error, Reason} ->
                             {error, Reason}
                     end;
                 (
                     #typed_map_field{kind = exact, key_type = KeyType, val_type = ValueType} = Type,
-                    {FieldsAcc, _}
+                    {FieldsAcc, CurrentRemainingJsonList}
                 ) ->
                     case
                         map_field_type_from_json_list(
-                            TypeInfo, KeyType, ValueType, RemainingJsonList, Config
+                            TypeInfo, KeyType, ValueType, CurrentRemainingJsonList, Config
                         )
                     of
-                        {ok, {NewFields, _}} ->
+                        {ok, {NewFields, NewConsumed}} ->
+                            NextRemainingJsonList = lists:filter(
+                                fun({K, _}) -> not lists:member(K, NewConsumed) end,
+                                CurrentRemainingJsonList
+                            ),
                             case NewFields of
                                 [] ->
-                                    Remainder = maps:from_list(RemainingJsonList),
+                                    Remainder = maps:from_list(CurrentRemainingJsonList),
                                     {error, [sp_error:not_matched_fields(Type, Remainder)]};
                                 _ ->
-                                    {ok, {NewFields ++ FieldsAcc, []}}
+                                    {ok, {NewFields ++ FieldsAcc, NextRemainingJsonList}}
                             end;
                         {error, _} = Err ->
                             Err
                     end
             end,
 
-            case spectra_util:fold_until_error(TypedFun, {[], []}, TypedFields) of
-                {ok, {TypedMapFields, _}} ->
+            case spectra_util:fold_until_error(TypedFun, {[], RemainingJsonList}, TypedFields) of
+                {ok, {TypedMapFields, _FinalRemainingJsonList}} ->
                     AllFields = TypedMapFields ++ LiteralMapFields,
                     Decoded = maps:from_list(AllFields),
                     Result =

--- a/src/spectra_json.erl
+++ b/src/spectra_json.erl
@@ -376,8 +376,9 @@ map_fields_to_json(TypeInfo, MapFieldTypes, Data, Config) ->
                     {ok, LiteralMapFields};
                 _ ->
                     %% Phase 2: Process typed fields with remaining data entries
+                    ConsumedKeysSet = sets:from_list(ConsumedKeys),
                     RemainingDataList = lists:filter(
-                        fun({K, _}) -> not lists:member(K, ConsumedKeys) end,
+                        fun({K, _}) -> not sets:is_element(K, ConsumedKeysSet) end,
                         maps:to_list(Data)
                     ),
 
@@ -1069,8 +1070,9 @@ map_from_json(TypeInfo, #sp_map{fields = MapFieldType, struct_name = StructName}
                     BuildResult(LiteralMapFields);
                 _ ->
                     %% Phase 2: Process typed fields with remaining JSON entries
+                    ConsumedKeysSet = sets:from_list(ConsumedKeys),
                     RemainingJsonList = lists:filter(
-                        fun({K, _}) -> not lists:member(K, ConsumedKeys) end,
+                        fun({K, _}) -> not sets:is_element(K, ConsumedKeysSet) end,
                         maps:to_list(Json)
                     ),
 

--- a/src/spectra_json.erl
+++ b/src/spectra_json.erl
@@ -299,9 +299,9 @@ map_fields_to_json(TypeInfo, MapFieldTypes, Data, Config) ->
             },
             {FieldsAcc, ConsumedKeys}
         ) ->
-            Missing = spectra_type:can_be_missing(TypeInfo, FieldType),
             case Data of
                 #{FieldName := FieldData} ->
+                    Missing = spectra_type:can_be_missing(TypeInfo, FieldType),
                     case {FieldData, Missing} of
                         {MissingValue, {true, MissingValue}} ->
                             {ok, {FieldsAcc, [FieldName | ConsumedKeys]}};
@@ -380,41 +380,51 @@ map_fields_to_json(TypeInfo, MapFieldTypes, Data, Config) ->
             TypedFun = fun
                 (
                     #typed_map_field{kind = assoc, key_type = KeyType, val_type = ValueType},
-                    {FieldsAcc, _}
+                    {FieldsAcc, CurrentRemainingDataList}
                 ) ->
                     case
                         map_typed_field_to_json_list(
-                            TypeInfo, KeyType, ValueType, RemainingDataList, Config
+                            TypeInfo, KeyType, ValueType, CurrentRemainingDataList, Config
                         )
                     of
-                        {ok, {NewFields, _}} ->
-                            {ok, {lists:reverse(NewFields, FieldsAcc), []}};
+                        {ok, {NewFields, NewConsumed}} ->
+                            NextRemainingDataList = lists:filter(
+                                fun({K, _}) -> not lists:member(K, NewConsumed) end,
+                                CurrentRemainingDataList
+                            ),
+                            {ok, {lists:reverse(NewFields, FieldsAcc), NextRemainingDataList}};
                         {error, _} = Err ->
                             Err
                     end;
                 (
                     #typed_map_field{kind = exact, key_type = KeyType, val_type = ValueType} = Type,
-                    {FieldsAcc, _}
+                    {FieldsAcc, CurrentRemainingDataList}
                 ) ->
                     case
                         map_typed_field_to_json_list(
-                            TypeInfo, KeyType, ValueType, RemainingDataList, Config
+                            TypeInfo, KeyType, ValueType, CurrentRemainingDataList, Config
                         )
                     of
-                        {ok, {NewFields, _}} ->
+                        {ok, {NewFields, NewConsumed}} ->
+                            NextRemainingDataList = lists:filter(
+                                fun({K, _}) -> not lists:member(K, NewConsumed) end,
+                                CurrentRemainingDataList
+                            ),
                             case NewFields of
                                 [] ->
-                                    Remainder = maps:from_list(RemainingDataList),
+                                    Remainder = maps:from_list(CurrentRemainingDataList),
                                     {error, [sp_error:not_matched_fields(Type, Remainder)]};
                                 _ ->
-                                    {ok, {lists:reverse(NewFields, FieldsAcc), []}}
+                                    {ok, {
+                                        lists:reverse(NewFields, FieldsAcc), NextRemainingDataList
+                                    }}
                             end;
                         {error, _} = Err ->
                             Err
                     end
             end,
 
-            case spectra_util:fold_until_error(TypedFun, {[], []}, TypedFields) of
+            case spectra_util:fold_until_error(TypedFun, {[], RemainingDataList}, TypedFields) of
                 {ok, {TypedMapFields, _}} ->
                     {ok, TypedMapFields ++ LiteralMapFields};
                 {error, _} = Err ->

--- a/src/spectra_json.erl
+++ b/src/spectra_json.erl
@@ -306,7 +306,7 @@ map_fields_to_json(TypeInfo, MapFieldTypes, Data, Config) ->
                     {ok, LiteralMapFields};
                 _ ->
                     %% Phase 2: Process typed fields with remaining data entries
-                    ConsumedKeysSet = sets:from_list(ConsumedKeys),
+                    ConsumedKeysSet = sets:from_list(ConsumedKeys, [{version, 2}]),
                     RemainingDataList = lists:filter(
                         fun({K, _}) -> not sets:is_element(K, ConsumedKeysSet) end,
                         maps:to_list(Data)
@@ -971,7 +971,7 @@ map_from_json(TypeInfo, #sp_map{fields = MapFieldType, struct_name = StructName}
                     BuildResult(LiteralMapFields);
                 _ ->
                     %% Phase 2: Process typed fields with remaining JSON entries
-                    ConsumedKeysSet = sets:from_list(ConsumedKeys),
+                    ConsumedKeysSet = sets:from_list(ConsumedKeys, [{version, 2}]),
                     RemainingJsonList = lists:filter(
                         fun({K, _}) -> not sets:is_element(K, ConsumedKeysSet) end,
                         maps:to_list(Json)

--- a/src/spectra_json.erl
+++ b/src/spectra_json.erl
@@ -283,140 +283,157 @@ map_to_json(_TypeInfo, MapType, Data, _Config) ->
 ) ->
     {ok, [{binary(), json:encode_value()}]} | {error, [spectra:error()]}.
 map_fields_to_json(TypeInfo, MapFieldTypes, Data, Config) ->
-    Fun = fun
+    %% Two-phase processing: all literal fields (assoc and exact) first, then typed fields
+    {LiteralFields, TypedFields} = lists:partition(
+        fun
+            (#literal_map_field{}) -> true;
+            (_) -> false
+        end,
+        MapFieldTypes
+    ),
+
+    LiteralFun = fun
         (
             #literal_map_field{
                 kind = assoc, name = FieldName, binary_name = BinaryFieldName, val_type = FieldType
             },
-            {FieldsAcc, Consumed}
+            {FieldsAcc, ConsumedKeys}
         ) ->
-            case is_consumed(FieldName, Consumed) of
-                true ->
-                    {ok, {FieldsAcc, Consumed}};
-                false ->
-                    Missing = spectra_type:can_be_missing(TypeInfo, FieldType),
-                    case Data of
-                        #{FieldName := FieldData} ->
-                            case {FieldData, Missing} of
-                                {MissingValue, {true, MissingValue}} ->
-                                    {ok, {FieldsAcc, add_consumed(FieldName, Consumed)}};
-                                _ ->
-                                    case to_json(TypeInfo, FieldType, FieldData, Config) of
-                                        {ok, FieldJson} ->
-                                            {ok, {
-                                                [{BinaryFieldName, FieldJson} | FieldsAcc],
-                                                add_consumed(FieldName, Consumed)
-                                            }};
-                                        {error, Errs} ->
-                                            Errs2 =
-                                                lists:map(
-                                                    fun(Err) ->
-                                                        sp_error:append_location(Err, FieldName)
-                                                    end,
-                                                    Errs
-                                                ),
-                                            {error, Errs2}
-                                    end
-                            end;
-                        #{} ->
-                            {ok, {FieldsAcc, Consumed}}
-                    end
-            end;
-        (
-            #typed_map_field{kind = assoc, key_type = KeyType, val_type = ValueType},
-            {FieldsAcc, Consumed}
-        ) ->
-            Remainder = maps:without(Consumed, Data),
-            case map_typed_field_to_json(TypeInfo, KeyType, ValueType, Remainder, Config) of
-                {ok, {NewFields, NewConsumed}} ->
-                    {ok, {lists:reverse(NewFields, FieldsAcc), NewConsumed ++ Consumed}};
-                {error, _} = Err ->
-                    Err
-            end;
-        (
-            #typed_map_field{kind = exact, key_type = KeyType, val_type = ValueType} = Type,
-            {FieldsAcc, Consumed}
-        ) ->
-            Remainder = maps:without(Consumed, Data),
-            case map_typed_field_to_json(TypeInfo, KeyType, ValueType, Remainder, Config) of
-                {ok, {[], _}} ->
-                    {error, [sp_error:not_matched_fields(Type, Remainder)]};
-                {ok, {NewFields, NewConsumed}} ->
-                    {ok, {lists:reverse(NewFields, FieldsAcc), NewConsumed ++ Consumed}};
-                {error, _} = Err ->
-                    Err
+            Missing = spectra_type:can_be_missing(TypeInfo, FieldType),
+            case Data of
+                #{FieldName := FieldData} ->
+                    case {FieldData, Missing} of
+                        {MissingValue, {true, MissingValue}} ->
+                            {ok, {FieldsAcc, [FieldName | ConsumedKeys]}};
+                        _ ->
+                            case to_json(TypeInfo, FieldType, FieldData, Config) of
+                                {ok, FieldJson} ->
+                                    {ok,
+                                        {
+                                            [{BinaryFieldName, FieldJson} | FieldsAcc],
+                                            [FieldName | ConsumedKeys]
+                                        }};
+                                {error, Errs} ->
+                                    Errs2 =
+                                        lists:map(
+                                            fun(Err) ->
+                                                sp_error:append_location(Err, FieldName)
+                                            end,
+                                            Errs
+                                        ),
+                                    {error, Errs2}
+                            end
+                    end;
+                #{} ->
+                    {ok, {FieldsAcc, ConsumedKeys}}
             end;
         (
             #literal_map_field{
                 kind = exact, name = FieldName, binary_name = BinaryFieldName, val_type = FieldType
             } = Type,
-            {FieldsAcc, Consumed}
+            {FieldsAcc, ConsumedKeys}
         ) ->
-            case is_consumed(FieldName, Consumed) of
-                true ->
-                    case spectra_type:can_be_missing(TypeInfo, FieldType) of
-                        {true, _} ->
-                            {ok, {FieldsAcc, Consumed}};
-                        false ->
-                            Remainder = maps:without(Consumed, Data),
-                            {error, [sp_error:missing_data(Type, Remainder, [FieldName])]}
-                    end;
-                false ->
-                    Missing = spectra_type:can_be_missing(TypeInfo, FieldType),
-                    case Data of
-                        #{FieldName := FieldData} ->
-                            case {FieldData, Missing} of
-                                {MissingValue, {true, MissingValue}} ->
-                                    {ok, {FieldsAcc, add_consumed(FieldName, Consumed)}};
-                                _ ->
-                                    case to_json(TypeInfo, FieldType, FieldData, Config) of
-                                        {ok, FieldJson} ->
-                                            {ok, {
-                                                [{BinaryFieldName, FieldJson} | FieldsAcc],
-                                                add_consumed(FieldName, Consumed)
-                                            }};
-                                        {error, Errs} ->
-                                            Errs2 =
-                                                lists:map(
-                                                    fun(Err) ->
-                                                        sp_error:append_location(Err, FieldName)
-                                                    end,
-                                                    Errs
-                                                ),
-                                            {error, Errs2}
-                                    end
-                            end;
-                        #{} ->
-                            case Missing of
-                                {true, _} ->
-                                    {ok, {FieldsAcc, Consumed}};
-                                false ->
-                                    Remainder = maps:without(Consumed, Data),
-                                    {error, [sp_error:missing_data(Type, Remainder, [FieldName])]}
+            Missing = spectra_type:can_be_missing(TypeInfo, FieldType),
+            case Data of
+                #{FieldName := FieldData} ->
+                    case {FieldData, Missing} of
+                        {MissingValue, {true, MissingValue}} ->
+                            {ok, {FieldsAcc, [FieldName | ConsumedKeys]}};
+                        _ ->
+                            case to_json(TypeInfo, FieldType, FieldData, Config) of
+                                {ok, FieldJson} ->
+                                    {ok,
+                                        {
+                                            [{BinaryFieldName, FieldJson} | FieldsAcc],
+                                            [FieldName | ConsumedKeys]
+                                        }};
+                                {error, Errs} ->
+                                    Errs2 =
+                                        lists:map(
+                                            fun(Err) ->
+                                                sp_error:append_location(Err, FieldName)
+                                            end,
+                                            Errs
+                                        ),
+                                    {error, Errs2}
                             end
+                    end;
+                #{} ->
+                    case Missing of
+                        {true, _} ->
+                            {ok, {FieldsAcc, ConsumedKeys}};
+                        false ->
+                            Remainder = maps:without(ConsumedKeys, Data),
+                            {error, [sp_error:missing_data(Type, Remainder, [FieldName])]}
                     end
             end
     end,
-    case spectra_util:fold_until_error(Fun, {[], []}, MapFieldTypes) of
-        {ok, {MapFields, _FinalConsumed}} ->
-            {ok, MapFields};
-        % TODO: Add config option to optionally error on extra fields
-        % Remainder = maps:without(FinalConsumed, Data),
-        % case maps:to_list(Remainder) of ...
+
+    case spectra_util:fold_until_error(LiteralFun, {[], []}, LiteralFields) of
+        {ok, {LiteralMapFields, ConsumedKeys}} ->
+            %% Phase 2: Process typed fields with remaining data entries
+            RemainingDataList = lists:filter(
+                fun({K, _}) -> not lists:member(K, ConsumedKeys) end,
+                maps:to_list(Data)
+            ),
+
+            TypedFun = fun
+                (
+                    #typed_map_field{kind = assoc, key_type = KeyType, val_type = ValueType},
+                    {FieldsAcc, _}
+                ) ->
+                    case
+                        map_typed_field_to_json_list(
+                            TypeInfo, KeyType, ValueType, RemainingDataList, Config
+                        )
+                    of
+                        {ok, {NewFields, _}} ->
+                            {ok, {lists:reverse(NewFields, FieldsAcc), []}};
+                        {error, _} = Err ->
+                            Err
+                    end;
+                (
+                    #typed_map_field{kind = exact, key_type = KeyType, val_type = ValueType} = Type,
+                    {FieldsAcc, _}
+                ) ->
+                    case
+                        map_typed_field_to_json_list(
+                            TypeInfo, KeyType, ValueType, RemainingDataList, Config
+                        )
+                    of
+                        {ok, {NewFields, _}} ->
+                            case NewFields of
+                                [] ->
+                                    Remainder = maps:from_list(RemainingDataList),
+                                    {error, [sp_error:not_matched_fields(Type, Remainder)]};
+                                _ ->
+                                    {ok, {lists:reverse(NewFields, FieldsAcc), []}}
+                            end;
+                        {error, _} = Err ->
+                            Err
+                    end
+            end,
+
+            case spectra_util:fold_until_error(TypedFun, {[], []}, TypedFields) of
+                {ok, {TypedMapFields, _}} ->
+                    {ok, TypedMapFields ++ LiteralMapFields};
+                {error, _} = Err ->
+                    Err
+            end;
         {error, _} = Err ->
             Err
     end.
 
--spec map_typed_field_to_json(
+-spec map_typed_field_to_json_list(
     TypeInfo :: spectra:type_info(),
     KeyType :: spectra:sp_type(),
     ValueType :: spectra:sp_type(),
-    Data :: map(),
+    DataList :: [{dynamic(), dynamic()}],
     Config :: spectra:sp_config()
 ) ->
     {ok, {[{json:encode_value(), json:encode_value()}], [dynamic()]}}
     | {error, [spectra:error()]}.
-map_typed_field_to_json(TypeInfo, KeyType, ValueType, Data, Config) ->
+map_typed_field_to_json_list(TypeInfo, KeyType, ValueType, DataList, Config) ->
     Fun = fun({Key, Value}, {FieldsAcc, ConsumedAcc}) ->
         case to_json(TypeInfo, KeyType, Key, Config) of
             {ok, KeyJson} ->
@@ -443,7 +460,7 @@ map_typed_field_to_json(TypeInfo, KeyType, ValueType, Data, Config) ->
                 {ok, {FieldsAcc, ConsumedAcc}}
         end
     end,
-    spectra_util:fold_until_error(Fun, {[], []}, maps:to_list(Data)).
+    spectra_util:fold_until_error(Fun, {[], []}, DataList).
 
 -spec record_to_json(
     TypeInfo :: spectra:type_info(),
@@ -937,151 +954,147 @@ map_from_json(TypeInfo, #sp_map{fields = MapFieldType, struct_name = StructName}
             undefined -> undefined;
             _ -> StructName:'__struct__'()
         end,
-    %% Partition fields: exact literal fields should be processed first to claim their keys
-    %% before typed fields try to match them
-    {ExactLiteralFields, OtherFields} = lists:partition(
+    %% Phase 1: Process all literal fields, tracking consumed keys
+    {LiteralFields, TypedFields} = lists:partition(
         fun
-            (#literal_map_field{kind = exact}) -> true;
+            (#literal_map_field{}) -> true;
             (_) -> false
         end,
         MapFieldType
     ),
-    SortedFields = ExactLiteralFields ++ OtherFields,
 
-    Fun = fun
+    LiteralFun = fun
         (
             #literal_map_field{
                 kind = assoc, name = FieldName, binary_name = BinaryName, val_type = FieldType
             },
-            {FieldsAcc, Consumed}
+            {FieldsAcc, ConsumedKeys}
         ) ->
-            case is_consumed(BinaryName, Consumed) of
-                true ->
-                    {ok, {FieldsAcc, Consumed}};
-                false ->
-                    case Json of
-                        #{BinaryName := FieldData} ->
-                            case do_from_json(TypeInfo, FieldType, FieldData, Config) of
-                                {ok, FieldJson} ->
-                                    {ok, {
-                                        [{FieldName, FieldJson} | FieldsAcc],
-                                        add_consumed(BinaryName, Consumed)
-                                    }};
-                                {error, Errs} ->
-                                    Errs2 =
-                                        lists:map(
-                                            fun(Err) ->
-                                                sp_error:append_location(Err, FieldName)
-                                            end,
-                                            Errs
-                                        ),
-                                    {error, Errs2}
-                            end;
-                        #{} ->
-                            {ok, {FieldsAcc, Consumed}}
-                    end
+            case Json of
+                #{BinaryName := FieldData} ->
+                    case do_from_json(TypeInfo, FieldType, FieldData, Config) of
+                        {ok, FieldJson} ->
+                            {ok,
+                                {
+                                    [{FieldName, FieldJson} | FieldsAcc],
+                                    [BinaryName | ConsumedKeys]
+                                }};
+                        {error, Errs} ->
+                            Errs2 =
+                                lists:map(
+                                    fun(Err) ->
+                                        sp_error:append_location(Err, FieldName)
+                                    end,
+                                    Errs
+                                ),
+                            {error, Errs2}
+                    end;
+                #{} ->
+                    {ok, {FieldsAcc, ConsumedKeys}}
             end;
         (
             #literal_map_field{
                 kind = exact, name = FieldName, binary_name = BinaryName, val_type = FieldType
             } = Type,
-            {FieldsAcc, Consumed}
+            {FieldsAcc, ConsumedKeys}
         ) ->
-            case is_consumed(BinaryName, Consumed) of
-                true ->
+            case Json of
+                #{BinaryName := FieldData} ->
+                    case do_from_json(TypeInfo, FieldType, FieldData, Config) of
+                        {ok, FieldJson} ->
+                            {ok,
+                                {
+                                    [{FieldName, FieldJson} | FieldsAcc],
+                                    [BinaryName | ConsumedKeys]
+                                }};
+                        {error, Errs} ->
+                            Errs2 =
+                                lists:map(
+                                    fun(Err) ->
+                                        sp_error:append_location(Err, FieldName)
+                                    end,
+                                    Errs
+                                ),
+                            {error, Errs2}
+                    end;
+                #{} ->
                     case spectra_type:can_be_missing(TypeInfo, FieldType) of
                         {true, MissingValue} when Defaults =:= undefined ->
-                            {ok, {[{FieldName, MissingValue} | FieldsAcc], Consumed}};
+                            {ok, {[{FieldName, MissingValue} | FieldsAcc], ConsumedKeys}};
                         {true, _} ->
-                            {ok, {FieldsAcc, Consumed}};
+                            {ok, {FieldsAcc, ConsumedKeys}};
                         false ->
                             case struct_default_value(Defaults, FieldName) of
                                 {ok, _} ->
-                                    {ok, {FieldsAcc, Consumed}};
+                                    {ok, {FieldsAcc, ConsumedKeys}};
                                 error ->
-                                    Remainder = maps:without(Consumed, Json),
-                                    {error, [sp_error:missing_data(Type, Remainder, [FieldName])]}
-                            end
-                    end;
-                false ->
-                    case Json of
-                        #{BinaryName := FieldData} ->
-                            case do_from_json(TypeInfo, FieldType, FieldData, Config) of
-                                {ok, FieldJson} ->
-                                    {ok, {
-                                        [{FieldName, FieldJson} | FieldsAcc],
-                                        add_consumed(BinaryName, Consumed)
-                                    }};
-                                {error, Errs} ->
-                                    Errs2 =
-                                        lists:map(
-                                            fun(Err) ->
-                                                sp_error:append_location(Err, FieldName)
-                                            end,
-                                            Errs
-                                        ),
-                                    {error, Errs2}
-                            end;
-                        #{} ->
-                            case spectra_type:can_be_missing(TypeInfo, FieldType) of
-                                {true, MissingValue} when Defaults =:= undefined ->
-                                    {ok, {[{FieldName, MissingValue} | FieldsAcc], Consumed}};
-                                {true, _} ->
-                                    {ok, {FieldsAcc, Consumed}};
-                                false ->
-                                    case struct_default_value(Defaults, FieldName) of
-                                        {ok, _} ->
-                                            {ok, {FieldsAcc, Consumed}};
-                                        error ->
-                                            Remainder = maps:without(Consumed, Json),
-                                            {error, [
-                                                sp_error:missing_data(Type, Remainder, [FieldName])
-                                            ]}
-                                    end
+                                    Remainder = maps:without(ConsumedKeys, Json),
+                                    {error, [
+                                        sp_error:missing_data(Type, Remainder, [FieldName])
+                                    ]}
                             end
                     end
-            end;
-        (
-            #typed_map_field{kind = assoc, key_type = KeyType, val_type = ValueType},
-            {FieldsAcc, Consumed}
-        ) ->
-            Remainder = maps:without(Consumed, Json),
-            case map_field_type_from_json(TypeInfo, KeyType, ValueType, Remainder, Config) of
-                {ok, {NewFields, NewConsumed}} ->
-                    {ok, {NewFields ++ FieldsAcc, NewConsumed ++ Consumed}};
-                {error, Reason} ->
-                    {error, Reason}
-            end;
-        (
-            #typed_map_field{kind = exact, key_type = KeyType, val_type = ValueType} = Type,
-            {FieldsAcc, Consumed}
-        ) ->
-            Remainder = maps:without(Consumed, Json),
-            case map_field_type_from_json(TypeInfo, KeyType, ValueType, Remainder, Config) of
-                {ok, {NewFields, NewConsumed}} ->
-                    case NewFields of
-                        [] ->
-                            {error, [sp_error:not_matched_fields(Type, Remainder)]};
-                        _ ->
-                            {ok, {NewFields ++ FieldsAcc, NewConsumed ++ Consumed}}
-                    end;
-                {error, _} = Err ->
-                    Err
             end
     end,
 
-    case spectra_util:fold_until_error(Fun, {[], []}, SortedFields) of
-        {ok, {Fields, _FinalConsumed}} ->
-            Decoded = maps:from_list(Fields),
-            Result =
-                case Defaults of
-                    undefined -> Decoded;
-                    _ -> maps:merge(Defaults, Decoded)
-                end,
-            {ok, Result};
-        % TODO: Add config option to optionally error on extra fields
-        % Remainder = maps:without(FinalConsumed, Json),
-        % case maps:size(Remainder) of ...
+    case spectra_util:fold_until_error(LiteralFun, {[], []}, LiteralFields) of
+        {ok, {LiteralMapFields, ConsumedKeys}} ->
+            %% Phase 2: Process typed fields with remaining JSON entries
+            RemainingJsonList = lists:filter(
+                fun({K, _}) -> not lists:member(K, ConsumedKeys) end,
+                maps:to_list(Json)
+            ),
+
+            TypedFun = fun
+                (
+                    #typed_map_field{kind = assoc, key_type = KeyType, val_type = ValueType},
+                    {FieldsAcc, _}
+                ) ->
+                    case
+                        map_field_type_from_json_list(
+                            TypeInfo, KeyType, ValueType, RemainingJsonList, Config
+                        )
+                    of
+                        {ok, {NewFields, _}} ->
+                            {ok, {NewFields ++ FieldsAcc, []}};
+                        {error, Reason} ->
+                            {error, Reason}
+                    end;
+                (
+                    #typed_map_field{kind = exact, key_type = KeyType, val_type = ValueType} = Type,
+                    {FieldsAcc, _}
+                ) ->
+                    case
+                        map_field_type_from_json_list(
+                            TypeInfo, KeyType, ValueType, RemainingJsonList, Config
+                        )
+                    of
+                        {ok, {NewFields, _}} ->
+                            case NewFields of
+                                [] ->
+                                    Remainder = maps:from_list(RemainingJsonList),
+                                    {error, [sp_error:not_matched_fields(Type, Remainder)]};
+                                _ ->
+                                    {ok, {NewFields ++ FieldsAcc, []}}
+                            end;
+                        {error, _} = Err ->
+                            Err
+                    end
+            end,
+
+            case spectra_util:fold_until_error(TypedFun, {[], []}, TypedFields) of
+                {ok, {TypedMapFields, _}} ->
+                    AllFields = TypedMapFields ++ LiteralMapFields,
+                    Decoded = maps:from_list(AllFields),
+                    Result =
+                        case Defaults of
+                            undefined -> Decoded;
+                            _ -> maps:merge(Defaults, Decoded)
+                        end,
+                    {ok, Result};
+                {error, _} = Err ->
+                    Err
+            end;
         {error, _} = Err ->
             Err
     end;
@@ -1098,7 +1111,7 @@ struct_default_value(Defaults, FieldName) ->
         _ -> error
     end.
 
-map_field_type_from_json(TypeInfo, KeyType, ValueType, Json, Config) ->
+map_field_type_from_json_list(TypeInfo, KeyType, ValueType, JsonList, Config) ->
     spectra_util:fold_until_error(
         fun({Key, Value}, {FieldsAcc, ConsumedAcc}) ->
             case do_from_json(TypeInfo, KeyType, Key, Config) of
@@ -1125,7 +1138,7 @@ map_field_type_from_json(TypeInfo, KeyType, ValueType, Json, Config) ->
             end
         end,
         {[], []},
-        maps:to_list(Json)
+        JsonList
     ).
 
 -spec record_from_json(
@@ -1188,14 +1201,3 @@ do_record_from_json(TypeInfo, #sp_rec{name = RecordName, fields = RecordInfo}, J
     end;
 do_record_from_json(_TypeInfo, Type, Json, _Config) ->
     {error, [sp_error:type_mismatch(Type, Json)]}.
-
-%% --- Consumed-key helpers for map fold optimisation ---
-%%
-%% Consumed keys are tracked as a simple list and used directly with
-%% maps:without/2 when typed fields need the current remainder.
-
--spec is_consumed(dynamic(), [dynamic()]) -> boolean().
-is_consumed(Key, Consumed) -> lists:member(Key, Consumed).
-
--spec add_consumed(dynamic(), [dynamic()]) -> [dynamic()].
-add_consumed(Key, Consumed) -> [Key | Consumed].

--- a/src/spectra_util.erl
+++ b/src/spectra_util.erl
@@ -4,6 +4,7 @@
     test_abs_code/1,
     apply_args/3,
     fold_until_error/3,
+    fold_until_error/4,
     map_until_error/2,
     normalize_type_ref/2,
     type_replace_vars/3,
@@ -94,6 +95,29 @@ fold_until_error(Fun, Acc, [H | T]) ->
 fold_until_error(Fun, Acc, []) when is_function(Fun, 2) ->
     {ok, Acc};
 fold_until_error(Fun, _Acc, ImproperList) when is_function(Fun, 2) ->
+    erlang:error({improper_list, ImproperList}).
+
+-spec fold_until_error(
+    Fun ::
+        fun(
+            (Context :: dynamic(), Elem :: dynamic(), Acc :: dynamic()) ->
+                {error, Err :: dynamic()} | {ok, Acc :: dynamic()}
+        ),
+    Context :: dynamic(),
+    Acc :: dynamic(),
+    List :: [Elem :: dynamic()]
+) ->
+    {ok, Acc :: dynamic()} | {error, Err :: dynamic()}.
+fold_until_error(Fun, Context, Acc, [H | T]) ->
+    case Fun(Context, H, Acc) of
+        {error, _} = Error ->
+            Error;
+        {ok, NewAcc} ->
+            fold_until_error(Fun, Context, NewAcc, T)
+    end;
+fold_until_error(Fun, _Context, Acc, []) when is_function(Fun, 3) ->
+    {ok, Acc};
+fold_until_error(Fun, _Context, _Acc, ImproperList) when is_function(Fun, 3) ->
     erlang:error({improper_list, ImproperList}).
 
 -spec map_until_error(

--- a/test/map_test.erl
+++ b/test/map_test.erl
@@ -126,7 +126,7 @@ type_shaddow_literal_map_test() ->
 
 type_shaddow_literal_map_bad_test() ->
     ?assertEqual(
-        {ok, #{<<"a1">> => 1, some_atom => some_value}},
+        {ok, #{some_atom => some_value, <<"a1">> => 1}},
         to_json_type_shaddow_literal_map(#{a1 => 1, some_atom => some_value})
     ).
 

--- a/test/map_test.erl
+++ b/test/map_test.erl
@@ -113,18 +113,21 @@ to_json_optional_nullable(Binary) ->
 to_json_nullable(Binary) ->
     spectra:decode(json, ?MODULE, nullable, Binary).
 
-type_shaddow_literal_map_test() ->
+type_shaddow_literal_map_bad_test() ->
     ?assertEqual(
         {error, [
             sp_error:append_location(
-                sp_error:type_mismatch({sp_literal, 1, <<"1">>, #{}}, pelle),
+                sp_error:type_mismatch(
+                    #sp_literal{value = 1, binary_value = <<"1">>},
+                    pelle
+                ),
                 a1
             )
         ]},
         to_json_type_shaddow_literal_map(#{a1 => pelle, some_atom => some_value})
     ).
 
-type_shaddow_literal_map_bad_test() ->
+type_shaddow_literal_map_ok_test() ->
     ?assertEqual(
         {ok, #{some_atom => some_value, <<"a1">> => 1}},
         to_json_type_shaddow_literal_map(#{a1 => 1, some_atom => some_value})
@@ -210,7 +213,10 @@ from_json_type_shaddow_literal_map_test() ->
     ?assertEqual(
         {error, [
             sp_error:append_location(
-                sp_error:type_mismatch({sp_literal, 1, <<"1">>, #{}}, <<"pelle">>),
+                sp_error:type_mismatch(
+                    #sp_literal{value = 1, binary_value = <<"1">>},
+                    <<"pelle">>
+                ),
                 a1
             )
         ]},

--- a/test/map_test.erl
+++ b/test/map_test.erl
@@ -115,18 +115,18 @@ to_json_nullable(Binary) ->
 
 type_shaddow_literal_map_test() ->
     ?assertEqual(
-        {ok, #{a1 => pelle, some_atom => some_value}},
+        {error, [
+            sp_error:append_location(
+                sp_error:type_mismatch({sp_literal, 1, <<"1">>, #{}}, pelle),
+                a1
+            )
+        ]},
         to_json_type_shaddow_literal_map(#{a1 => pelle, some_atom => some_value})
     ).
 
 type_shaddow_literal_map_bad_test() ->
     ?assertEqual(
-        {error, [
-            sp_error:append_location(
-                sp_error:type_mismatch(#sp_simple_type{type = atom}, 1),
-                a1
-            )
-        ]},
+        {ok, #{<<"a1">> => 1, some_atom => some_value}},
         to_json_type_shaddow_literal_map(#{a1 => 1, some_atom => some_value})
     ).
 
@@ -208,7 +208,12 @@ from_json_map3_bad_test() ->
 
 from_json_type_shaddow_literal_map_test() ->
     ?assertEqual(
-        {ok, #{a1 => pelle, some_atom => some_value}},
+        {error, [
+            sp_error:append_location(
+                sp_error:type_mismatch({sp_literal, 1, <<"1">>, #{}}, <<"pelle">>),
+                a1
+            )
+        ]},
         from_json_type_shaddow_literal_map(#{
             <<"a1">> => <<"pelle">>,
             <<"some_atom">> => <<"some_value">>


### PR DESCRIPTION
## Summary
- keep consumed keys as a simple list and derive typed-field remainders with `maps:without/2` instead of promoting consumed state to a map
- preserve existing JSON encode/decode behaviour while simplifying the traversal state used during map folding