### PR TITLE
Optimize JSON traversal hot paths

### DIFF
--- a/src/spectra_codec.erl
+++ b/src/spectra_codec.erl
@@ -115,7 +115,7 @@ where the reference node is available.
 ) -> spectra:codec_encode_result().
 try_codec_encode(TypeInfo, Format, TypeReference, Type, Data, SpType, Config) ->
     Mod = spectra_type_info:get_module(TypeInfo),
-    case spectra_type_info:find_codec(TypeInfo, TypeReference, Config) of
+    case spectra_type_info:find_codec(TypeInfo, TypeReference, Mod, Config) of
         {ok, M} ->
             M:encode(
                 Format, Mod, TypeReference, Data, SpType, spectra_type:parameters(Type), Config
@@ -136,7 +136,7 @@ try_codec_encode(TypeInfo, Format, TypeReference, Type, Data, SpType, Config) ->
 ) -> spectra:codec_decode_result().
 try_codec_decode(TypeInfo, Format, TypeReference, Type, Data, SpType, Config) ->
     Mod = spectra_type_info:get_module(TypeInfo),
-    case spectra_type_info:find_codec(TypeInfo, TypeReference, Config) of
+    case spectra_type_info:find_codec(TypeInfo, TypeReference, Mod, Config) of
         {ok, M} ->
             M:decode(
                 Format, Mod, TypeReference, Data, SpType, spectra_type:parameters(Type), Config
@@ -156,7 +156,7 @@ try_codec_decode(TypeInfo, Format, TypeReference, Type, Data, SpType, Config) ->
 ) -> dynamic() | continue.
 try_codec_schema(TypeInfo, Format, TypeReference, Type, SpType, Config) ->
     Mod = spectra_type_info:get_module(TypeInfo),
-    case spectra_type_info:find_codec(TypeInfo, TypeReference, Config) of
+    case spectra_type_info:find_codec(TypeInfo, TypeReference, Mod, Config) of
         {ok, M} ->
             try
                 M:schema(

--- a/src/spectra_json.erl
+++ b/src/spectra_json.erl
@@ -738,20 +738,33 @@ nonempty_list_from_json(_TypeInfo, Type, Data, _Config) ->
     {error, [sp_error:type_mismatch(Type, Data)]}.
 
 list_from_json(TypeInfo, Type, Data, ListType, Config) when is_list(Data) ->
-    case safe_enumerate(Data) of
-        {ok, EnumeratedData} ->
-            Fun = fun({Nr, Item}) ->
-                case do_from_json(TypeInfo, Type, Item, Config) of
-                    {ok, Json} ->
-                        {ok, Json};
-                    {error, Errs} ->
-                        Errs2 = lists:map(fun(Err) -> sp_error:append_location(Err, Nr) end, Errs),
-
-                        {error, Errs2}
-                end
-            end,
-            spectra_util:map_until_error(Fun, EnumeratedData);
-        {error, improper_list} ->
+    try
+        case
+            spectra_util:fold_until_error(
+                fun(Item, {Nr, Acc}) ->
+                    case do_from_json(TypeInfo, Type, Item, Config) of
+                        {ok, Json} ->
+                            {ok, {Nr + 1, [Json | Acc]}};
+                        {error, Errs} ->
+                            Errs2 =
+                                lists:map(
+                                    fun(Err) -> sp_error:append_location(Err, Nr) end,
+                                    Errs
+                                ),
+                            {error, Errs2}
+                    end
+                end,
+                {1, []},
+                Data
+            )
+        of
+            {ok, {_Nr, Json}} ->
+                {ok, lists:reverse(Json)};
+            {error, _} = Err ->
+                Err
+        end
+    catch
+        error:{improper_list, _ImproperTail} ->
             %% Improper lists cannot be decoded from JSON
             {error, [sp_error:type_mismatch(ListType, Data)]}
     end;
@@ -898,13 +911,6 @@ to_binary_for_pattern(Type, Pat, V) when is_list(V) ->
     case unicode:characters_to_binary(V) of
         Bin when is_binary(Bin) -> {ok, Bin};
         _ -> {error, [sp_error:type_mismatch(Type, V, #{pattern => Pat})]}
-    end.
-
-safe_enumerate(List) ->
-    try lists:enumerate(List) of
-        EnumeratedList -> {ok, EnumeratedList}
-    catch
-        error:function_clause -> {error, improper_list}
     end.
 
 union(Fun, TypeInfo, #sp_union{types = Types} = T, Json, Config) ->

--- a/src/spectra_type_info.erl
+++ b/src/spectra_type_info.erl
@@ -92,10 +92,12 @@ find_local_codec(#type_info{implements_codec = true, module = M}) -> {ok, M};
 find_local_codec(#type_info{implements_codec = false}) -> error.
 
 -doc """
-Resolves the codec module for `{Mod, TypeRef}` using a pre-extracted `Mod`.
+Resolves the codec module for `{Mod, TypeRef}` using a pre-loaded `TypeInfo`.
 
 Checks the global codecs map first, then falls back to the module's own
-`spectra_codec` behaviour if it implements one.
+`spectra_codec` behaviour if it implements one. Uses the already-loaded
+`TypeInfo` to avoid a cache lookup. The caller must ensure that `TypeInfo`
+is the type info for the module that owns `TypeRef`.
 """.
 -spec find_codec(type_info(), spectra:sp_type_reference(), module(), spectra:sp_config()) ->
     {ok, module()} | error.

--- a/src/spectra_type_info.erl
+++ b/src/spectra_type_info.erl
@@ -12,13 +12,13 @@ tracks whether the owning module implements the `spectra_codec` behaviour.
 
 -include("../include/spectra_internal.hrl").
 
--ignore_xref([find_function/3, new/2]).
+-ignore_xref([find_codec/3, find_function/3, new/2]).
 
 -export([new/2, get_module/1]).
 -export([add_type/4, find_type/3, get_type/3]).
 -export([add_record/3, find_record/2, get_record/2]).
 -export([add_function/4, find_function/3]).
--export([find_codec/3]).
+-export([find_codec/3, find_codec/4]).
 
 -export_type([type_info/0, type_key/0, function_key/0]).
 
@@ -101,8 +101,18 @@ is the type info for the module that owns `TypeRef`.
 """.
 -spec find_codec(type_info(), spectra:sp_type_reference(), spectra:sp_config()) ->
     {ok, module()} | error.
-find_codec(TypeInfo, TypeRef, #sp_config{codecs = Codecs}) ->
-    Mod = get_module(TypeInfo),
+find_codec(TypeInfo, TypeRef, Config) ->
+    find_codec(TypeInfo, TypeRef, get_module(TypeInfo), Config).
+
+-doc """
+Resolves the codec module for `{Mod, TypeRef}` using a pre-extracted `Mod`.
+
+Checks the global codecs map first, then falls back to the module's own
+`spectra_codec` behaviour if it implements one.
+""".
+-spec find_codec(type_info(), spectra:sp_type_reference(), module(), spectra:sp_config()) ->
+    {ok, module()} | error.
+find_codec(TypeInfo, TypeRef, Mod, #sp_config{codecs = Codecs}) ->
     case Codecs of
         #{{Mod, TypeRef} := CodecMod} ->
             {ok, CodecMod};

--- a/src/spectra_type_info.erl
+++ b/src/spectra_type_info.erl
@@ -18,7 +18,7 @@ tracks whether the owning module implements the `spectra_codec` behaviour.
 -export([add_type/4, find_type/3, get_type/3]).
 -export([add_record/3, find_record/2, get_record/2]).
 -export([add_function/4, find_function/3]).
--export([find_codec/3, find_codec/4]).
+-export([find_codec/4]).
 
 -export_type([type_info/0, type_key/0, function_key/0]).
 
@@ -90,19 +90,6 @@ find_function(#type_info{functions = Functions}, Name, Arity) ->
 -spec find_local_codec(type_info()) -> {ok, module()} | error.
 find_local_codec(#type_info{implements_codec = true, module = M}) -> {ok, M};
 find_local_codec(#type_info{implements_codec = false}) -> error.
-
--doc """
-Resolves the codec module for `{Mod, TypeRef}` using a pre-loaded `TypeInfo`.
-
-Checks the global codecs map first, then falls back to the module's own
-`spectra_codec` behaviour if it implements one. Uses the already-loaded
-`TypeInfo` to avoid a cache lookup. The caller must ensure that `TypeInfo`
-is the type info for the module that owns `TypeRef`.
-""".
--spec find_codec(type_info(), spectra:sp_type_reference(), spectra:sp_config()) ->
-    {ok, module()} | error.
-find_codec(TypeInfo, TypeRef, Config) ->
-    find_codec(TypeInfo, TypeRef, get_module(TypeInfo), Config).
 
 -doc """
 Resolves the codec module for `{Mod, TypeRef}` using a pre-extracted `Mod`.


### PR DESCRIPTION
## Summary
- Replace `safe_enumerate/1` in `list_from_json/5` with the same indexed fold used by `list_to_json/4`
- Avoid duplicate `get_module/1` calls in codec dispatch by adding `find_codec/4` that accepts the pre-extracted module
- Remove the public `find_codec/3` API (internal change; we don't offer hot code reloading support)

## Verification
- `make format`
- `rebar3 eunit --module=custom_codec_test`
- `make build-test`
- `make proper`