### PR TITLE
fix: configure regex module to support Unicode and UCP

### DIFF
--- a/README.md
+++ b/README.md
@@ -269,7 +269,7 @@ For `binary()`, `nonempty_binary()`, `string()`, and `nonempty_string()` types y
 |---|---|---|---|
 | `min_length` | `minLength` | yes | Codepoint count (Unicode), not byte count |
 | `max_length` | `maxLength` | yes | Codepoint count (Unicode), not byte count |
-| `pattern` | `pattern` | yes | Erlang `re` regular expression (PCRE-style syntax) |
+| `pattern` | `pattern` | yes | Erlang `re` regular expression (PCRE-style, fully compatible with OpenAPI ECMA-262 via `unicode` & `ucp`) |
 | `format` | `format` | no | Schema annotation only |
 
 ```erlang

--- a/README.md
+++ b/README.md
@@ -269,7 +269,7 @@ For `binary()`, `nonempty_binary()`, `string()`, and `nonempty_string()` types y
 |---|---|---|---|
 | `min_length` | `minLength` | yes | Codepoint count (Unicode), not byte count |
 | `max_length` | `maxLength` | yes | Codepoint count (Unicode), not byte count |
-| `pattern` | `pattern` | yes | Erlang `re` regular expression (PCRE-style, fully compatible with OpenAPI ECMA-262 via `unicode` & `ucp`) |
+| `pattern` | `pattern` | yes | Erlang `re` regular expression (PCRE-style, fully compatible with OpenAPI ECMA-262) |
 | `format` | `format` | no | Schema annotation only |
 
 ```erlang

--- a/README.md
+++ b/README.md
@@ -272,6 +272,8 @@ For `binary()`, `nonempty_binary()`, `string()`, and `nonempty_string()` types y
 | `pattern` | `pattern` | yes | Erlang `re` regular expression (PCRE-style syntax; `unicode`/`ucp` enabled for Unicode character properties) |
 | `format` | `format` | no | Schema annotation only |
 
+The `pattern` constraint uses PCRE-style syntax and enables `unicode` and `ucp` options for Unicode character properties (e.g., `\w` matches letters beyond ASCII). An invalid or unbalanced regex pattern is a **developer error** and raises `{invalid_string_pattern, Pattern, Reason}` at runtime — this is not a validation error but a bug in the type definition.
+
 ```erlang
 -spectra(#{type_parameters => #{min_length => 2, max_length => 64}}).
 -type username() :: binary().

--- a/README.md
+++ b/README.md
@@ -269,7 +269,7 @@ For `binary()`, `nonempty_binary()`, `string()`, and `nonempty_string()` types y
 |---|---|---|---|
 | `min_length` | `minLength` | yes | Codepoint count (Unicode), not byte count |
 | `max_length` | `maxLength` | yes | Codepoint count (Unicode), not byte count |
-| `pattern` | `pattern` | yes | Erlang `re` regular expression (PCRE-style, fully compatible with OpenAPI ECMA-262) |
+| `pattern` | `pattern` | yes | Erlang `re` regular expression (PCRE-style syntax; `unicode`/`ucp` enabled for Unicode character properties) |
 | `format` | `format` | no | Schema annotation only |
 
 ```erlang

--- a/src/spectra_json.erl
+++ b/src/spectra_json.erl
@@ -881,11 +881,18 @@ check_string_params(Type, Params, Value) when is_map(Params) ->
             ({pattern, Pat}, V) when is_binary(Pat) ->
                 case to_binary_for_pattern(Type, Pat, V) of
                     {ok, Bin} ->
-                        case re:run(Bin, Pat, [{capture, none}, unicode, ucp]) of
-                            match ->
-                                {ok, V};
-                            nomatch ->
-                                {error, [sp_error:type_mismatch(Type, V, #{pattern => Pat})]}
+                        try
+                            case re:run(Bin, Pat, [{capture, none}, unicode, ucp]) of
+                                match ->
+                                    {ok, V};
+                                nomatch ->
+                                    {error, [sp_error:type_mismatch(Type, V, #{pattern => Pat})]};
+                                {error, Reason} ->
+                                    erlang:error({invalid_string_pattern, Pat, Reason})
+                            end
+                        catch
+                            error:badarg ->
+                                erlang:error({invalid_string_pattern, Pat, badarg})
                         end;
                     {error, _} = Err ->
                         Err

--- a/src/spectra_json.erl
+++ b/src/spectra_json.erl
@@ -881,7 +881,7 @@ check_string_params(Type, Params, Value) when is_map(Params) ->
             ({pattern, Pat}, V) when is_binary(Pat) ->
                 case to_binary_for_pattern(Type, Pat, V) of
                     {ok, Bin} ->
-                        case re:run(Bin, Pat, [{capture, none}]) of
+                        case re:run(Bin, Pat, [{capture, none}, unicode, ucp]) of
                             match -> {ok, V};
                             nomatch -> {error, [sp_error:type_mismatch(Type, V, #{pattern => Pat})]}
                         end;

--- a/src/spectra_json.erl
+++ b/src/spectra_json.erl
@@ -881,9 +881,16 @@ check_string_params(Type, Params, Value) when is_map(Params) ->
             ({pattern, Pat}, V) when is_binary(Pat) ->
                 case to_binary_for_pattern(Type, Pat, V) of
                     {ok, Bin} ->
-                        case re:run(Bin, Pat, [{capture, none}, unicode, ucp]) of
-                            match -> {ok, V};
-                            nomatch -> {error, [sp_error:type_mismatch(Type, V, #{pattern => Pat})]}
+                        try
+                            case re:run(Bin, Pat, [{capture, none}, unicode, ucp]) of
+                                match ->
+                                    {ok, V};
+                                nomatch ->
+                                    {error, [sp_error:type_mismatch(Type, V, #{pattern => Pat})]}
+                            end
+                        catch
+                            error:badarg ->
+                                {error, [sp_error:type_mismatch(Type, V, #{pattern => Pat})]}
                         end;
                     {error, _} = Err ->
                         Err

--- a/src/spectra_json.erl
+++ b/src/spectra_json.erl
@@ -881,15 +881,10 @@ check_string_params(Type, Params, Value) when is_map(Params) ->
             ({pattern, Pat}, V) when is_binary(Pat) ->
                 case to_binary_for_pattern(Type, Pat, V) of
                     {ok, Bin} ->
-                        try
-                            case re:run(Bin, Pat, [{capture, none}, unicode, ucp]) of
-                                match ->
-                                    {ok, V};
-                                nomatch ->
-                                    {error, [sp_error:type_mismatch(Type, V, #{pattern => Pat})]}
-                            end
-                        catch
-                            error:badarg ->
+                        case re:run(Bin, Pat, [{capture, none}, unicode, ucp]) of
+                            match ->
+                                {ok, V};
+                            nomatch ->
                                 {error, [sp_error:type_mismatch(Type, V, #{pattern => Pat})]}
                         end;
                     {error, _} = Err ->
@@ -912,8 +907,11 @@ check_string_params(_Type, Params, _Value) when not is_map(Params) ->
     Pat :: binary(),
     Value :: dynamic()
 ) -> {ok, binary()} | {error, [spectra:error()]}.
-to_binary_for_pattern(_Type, _Pat, V) when is_binary(V) ->
-    {ok, V};
+to_binary_for_pattern(Type, Pat, V) when is_binary(V) ->
+    case unicode:characters_to_binary(V) of
+        Bin when is_binary(Bin) -> {ok, Bin};
+        _ -> {error, [sp_error:type_mismatch(Type, V, #{pattern => Pat})]}
+    end;
 to_binary_for_pattern(Type, Pat, V) when is_list(V) ->
     case unicode:characters_to_binary(V) of
         Bin when is_binary(Bin) -> {ok, Bin};

--- a/test/sp_data_generators.erl
+++ b/test/sp_data_generators.erl
@@ -102,7 +102,8 @@ gen_data(TypeInfo, #sp_rec{name = Name, fields = Fields, arity = _Arity}) ->
 
 iolist_gen(N) ->
     case N of
-        0 -> binary();
+        0 ->
+            binary();
         _ ->
             oneof([
                 binary(),
@@ -120,7 +121,8 @@ iolist_gen(N) ->
 
 iodata_gen(N) ->
     case N of
-        0 -> binary();
+        0 ->
+            binary();
         _ ->
             oneof([
                 binary(),

--- a/test/sp_data_generators.erl
+++ b/test/sp_data_generators.erl
@@ -107,14 +107,12 @@ iolist_gen(N) ->
         _ ->
             oneof([
                 binary(),
-                non_empty(
-                    list(
-                        oneof([
-                            byte(),
-                            binary(),
-                            iolist_gen(N - 1)
-                        ])
-                    )
+                list(
+                    oneof([
+                        byte(),
+                        binary(),
+                        iolist_gen(N - 1)
+                    ])
                 )
             ])
     end.
@@ -126,13 +124,11 @@ iodata_gen(N) ->
         _ ->
             oneof([
                 binary(),
-                non_empty(
-                    list(
-                        oneof([
-                            byte(),
-                            binary()
-                        ])
-                    )
+                list(
+                    oneof([
+                        byte(),
+                        binary()
+                    ])
                 )
             ])
     end.

--- a/test/sp_data_generators.erl
+++ b/test/sp_data_generators.erl
@@ -43,9 +43,9 @@ gen_data(_TypeInfo, #sp_simple_type{type = pid}) ->
 gen_data(_TypeInfo, #sp_simple_type{type = port}) ->
     ?LET(_, integer(), hd(erlang:ports()));
 gen_data(_TypeInfo, #sp_simple_type{type = iolist}) ->
-    oneof([list(oneof([byte(), binary(), list(byte())])), binary()]);
+    iolist_gen(3);
 gen_data(_TypeInfo, #sp_simple_type{type = iodata}) ->
-    oneof([list(oneof([byte(), binary()])), binary()]);
+    iodata_gen(3);
 gen_data(_TypeInfo, #sp_simple_type{type = none}) ->
     ?LET(_, integer(), throw(none_type_cannot_generate_data));
 gen_data(_TypeInfo, #sp_simple_type{type = map}) ->
@@ -99,6 +99,41 @@ gen_data(_TypeInfo, #sp_remote_type{mfargs = {_Module, _Function, _Args}}) ->
 gen_data(TypeInfo, #sp_rec{name = Name, fields = Fields, arity = _Arity}) ->
     FieldValues = [gen_data(TypeInfo, FieldType) || {_FieldName, FieldType} <- Fields],
     list_to_tuple([Name | FieldValues]).
+
+iolist_gen(N) ->
+    case N of
+        0 -> binary();
+        _ ->
+            oneof([
+                binary(),
+                non_empty(
+                    list(
+                        oneof([
+                            byte(),
+                            binary(),
+                            iolist_gen(N - 1)
+                        ])
+                    )
+                )
+            ])
+    end.
+
+iodata_gen(N) ->
+    case N of
+        0 -> binary();
+        _ ->
+            oneof([
+                binary(),
+                non_empty(
+                    list(
+                        oneof([
+                            byte(),
+                            binary()
+                        ])
+                    )
+                )
+            ])
+    end.
 
 %% Helper function to generate map data from map fields
 gen_map_data(TypeInfo, Fields) ->

--- a/test/string_constraints_module.erl
+++ b/test/string_constraints_module.erl
@@ -48,6 +48,6 @@
 -spectra(#{type_parameters => #{pattern => <<"^\\w+$">>}}).
 -type ucp_word_binary() :: binary().
 
-%% binary() with an invalid/unbalanced regex pattern (tests error handling)
+%% binary() with an invalid/unbalanced regex pattern (developer error; raises {invalid_string_pattern, _, _})
 -spectra(#{type_parameters => #{pattern => <<"[invalid">>}}).
 -type invalid_pattern_binary() :: binary().

--- a/test/string_constraints_module.erl
+++ b/test/string_constraints_module.erl
@@ -48,6 +48,6 @@
 -spectra(#{type_parameters => #{pattern => <<"^\\w+$">>}}).
 -type ucp_word_binary() :: binary().
 
-%% binary() with an invalid/unbalanced regex pattern (developer error; raises {invalid_string_pattern, _, _})
+%% binary() with an invalid/unbalanced regex pattern (developer error; raises {invalid_string_pattern, ..., _})
 -spectra(#{type_parameters => #{pattern => <<"[invalid">>}}).
 -type invalid_pattern_binary() :: binary().

--- a/test/string_constraints_module.erl
+++ b/test/string_constraints_module.erl
@@ -39,3 +39,11 @@
 
 -spectra(#{type_parameters => #{pattern => <<"^[a-z]+$">>}}).
 -type pattern_remote() :: string_alias_module:t().
+
+%% binary() testing unicode behavior in regex
+-spectra(#{type_parameters => #{pattern => <<"^.$">>}}).
+-type single_char_binary() :: binary().
+
+%% binary() testing unicode character properties behavior in regex (\w matches unicode letters)
+-spectra(#{type_parameters => #{pattern => <<"^\\w+$">>}}).
+-type ucp_word_binary() :: binary().

--- a/test/string_constraints_module.erl
+++ b/test/string_constraints_module.erl
@@ -47,3 +47,7 @@
 %% binary() testing unicode character properties behavior in regex (\w matches unicode letters)
 -spectra(#{type_parameters => #{pattern => <<"^\\w+$">>}}).
 -type ucp_word_binary() :: binary().
+
+%% binary() with an invalid/unbalanced regex pattern (tests error handling)
+-spectra(#{type_parameters => #{pattern => <<"[invalid">>}}).
+-type invalid_pattern_binary() :: binary().

--- a/test/string_constraints_test.erl
+++ b/test/string_constraints_test.erl
@@ -313,3 +313,23 @@ encode_pattern_invalid_utf8_returns_error_test() ->
             json, string_constraints_module, {type, lowercase_binary, 0}, InvalidUtf8, [pre_encoded]
         )
     ).
+
+decode_pattern_invalid_regex_crashes_test() ->
+    ?assertError(
+        _,
+        spectra:decode(
+            json, string_constraints_module, {type, invalid_pattern_binary, 0}, <<"anything">>, [
+                pre_decoded
+            ]
+        )
+    ).
+
+encode_pattern_invalid_regex_crashes_test() ->
+    ?assertError(
+        _,
+        spectra:encode(
+            json, string_constraints_module, {type, invalid_pattern_binary, 0}, <<"anything">>, [
+                pre_encoded
+            ]
+        )
+    ).

--- a/test/string_constraints_test.erl
+++ b/test/string_constraints_test.erl
@@ -90,6 +90,26 @@ decode_ucp_pattern_match_test() ->
         )
     ).
 
+encode_unicode_pattern_match_test() ->
+    ?assertEqual(
+        {ok, <<"ä"/utf8>>},
+        spectra:encode(
+            json, string_constraints_module, {type, single_char_binary, 0}, <<"ä"/utf8>>, [
+                pre_encoded
+            ]
+        )
+    ).
+
+encode_ucp_pattern_match_test() ->
+    ?assertEqual(
+        {ok, <<"münchen"/utf8>>},
+        spectra:encode(
+            json, string_constraints_module, {type, ucp_word_binary, 0}, <<"münchen"/utf8>>, [
+                pre_encoded
+            ]
+        )
+    ).
+
 %% -----------------------------------------------------------------------
 %% Decode — min/max length validation
 %% -----------------------------------------------------------------------

--- a/test/string_constraints_test.erl
+++ b/test/string_constraints_test.erl
@@ -314,9 +314,9 @@ encode_pattern_invalid_utf8_returns_error_test() ->
         )
     ).
 
-decode_pattern_invalid_regex_crashes_test() ->
+decode_pattern_invalid_regex_returns_specific_error_test() ->
     ?assertError(
-        _,
+        {invalid_string_pattern, <<"[invalid">>, _},
         spectra:decode(
             json, string_constraints_module, {type, invalid_pattern_binary, 0}, <<"anything">>, [
                 pre_decoded
@@ -324,9 +324,9 @@ decode_pattern_invalid_regex_crashes_test() ->
         )
     ).
 
-encode_pattern_invalid_regex_crashes_test() ->
+encode_pattern_invalid_regex_returns_specific_error_test() ->
     ?assertError(
-        _,
+        {invalid_string_pattern, <<"[invalid">>, _},
         spectra:encode(
             json, string_constraints_module, {type, invalid_pattern_binary, 0}, <<"anything">>, [
                 pre_encoded

--- a/test/string_constraints_test.erl
+++ b/test/string_constraints_test.erl
@@ -70,6 +70,26 @@ decode_pattern_no_match_test() ->
         ])
     ).
 
+decode_unicode_pattern_match_test() ->
+    ?assertEqual(
+        {ok, <<"ä"/utf8>>},
+        spectra:decode(
+            json, string_constraints_module, {type, single_char_binary, 0}, <<"ä"/utf8>>, [
+                pre_decoded
+            ]
+        )
+    ).
+
+decode_ucp_pattern_match_test() ->
+    ?assertEqual(
+        {ok, <<"münchen"/utf8>>},
+        spectra:decode(
+            json, string_constraints_module, {type, ucp_word_binary, 0}, <<"münchen"/utf8>>, [
+                pre_decoded
+            ]
+        )
+    ).
+
 %% -----------------------------------------------------------------------
 %% Decode — min/max length validation
 %% -----------------------------------------------------------------------

--- a/test/string_constraints_test.erl
+++ b/test/string_constraints_test.erl
@@ -289,3 +289,27 @@ encode_remote_too_short_test() ->
             pre_encoded
         ])
     ).
+
+%% -----------------------------------------------------------------------
+%% Error handling — invalid UTF-8 and invalid regex patterns
+%% -----------------------------------------------------------------------
+
+decode_pattern_invalid_utf8_returns_error_test() ->
+    %% Bare 0xFF is not valid UTF-8; should return {error, [...]}, not crash
+    InvalidUtf8 = <<255>>,
+    ?assertMatch(
+        {error, [_]},
+        spectra:decode(
+            json, string_constraints_module, {type, lowercase_binary, 0}, InvalidUtf8, [pre_decoded]
+        )
+    ).
+
+encode_pattern_invalid_utf8_returns_error_test() ->
+    %% Bare 0xFF is not valid UTF-8; should return {error, [...]}, not crash
+    InvalidUtf8 = <<255>>,
+    ?assertMatch(
+        {error, [_]},
+        spectra:encode(
+            json, string_constraints_module, {type, lowercase_binary, 0}, InvalidUtf8, [pre_encoded]
+        )
+    ).


### PR DESCRIPTION
When validating strings using OpenAPI pattern (regex), ensure
re:run uses `unicode` and `ucp` parameters. This prevents issues with
unicode character validation and correctly implements \w, \s, etc.
Added tests to enforce unicode matching behavior.
