### PR TITLE
Reject non-empty maps for #{} type in JSON encode/decode

### DIFF
--- a/src/spectra_json.erl
+++ b/src/spectra_json.erl
@@ -255,7 +255,7 @@ list_to_json(TypeInfo, #sp_list{type = Type} = ListType, Data, Config) when is_l
     Config :: spectra:sp_config()
 ) ->
     {ok, json:encode_value()} | {error, [spectra:error()]}.
-map_to_json(TypeInfo, #sp_map{fields = Fields}, Data, Config) when
+map_to_json(TypeInfo, #sp_map{fields = Fields} = Map, Data, Config) when
     is_map(Data)
 ->
     %% Check if this is an Elixir struct and remove __struct__ field for JSON serialization
@@ -266,11 +266,16 @@ map_to_json(TypeInfo, #sp_map{fields = Fields}, Data, Config) when
             error ->
                 Data
         end,
-    case map_fields_to_json(TypeInfo, Fields, DataWithoutStruct, Config) of
-        {ok, MapFields} ->
-            {ok, maps:from_list(MapFields)};
-        {error, Errors} ->
-            {error, Errors}
+    case {Fields, map_size(DataWithoutStruct)} of
+        {[], Size} when Size > 0 ->
+            {error, [sp_error:type_mismatch(Map, Data)]};
+        _ ->
+            case map_fields_to_json(TypeInfo, Fields, DataWithoutStruct, Config) of
+                {ok, MapFields} ->
+                    {ok, maps:from_list(MapFields)};
+                {error, Errors} ->
+                    {error, Errors}
+            end
     end;
 map_to_json(_TypeInfo, MapType, Data, _Config) ->
     {error, [sp_error:type_mismatch(MapType, Data)]}.
@@ -951,6 +956,10 @@ do_first(Fun, TypeInfo, [Type | Rest], Json, Config, ErrorsAcc) ->
 ) ->
     {ok, #{json:encode_value() => json:encode_value()}}
     | {error, [spectra:error()]}.
+map_from_json(_TypeInfo, #sp_map{fields = []} = Map, Json, _Config) when
+    is_map(Json), map_size(Json) > 0
+->
+    {error, [sp_error:type_mismatch(Map, Json)]};
 map_from_json(TypeInfo, #sp_map{fields = MapFieldType, struct_name = StructName}, Json, Config) when
     is_map(Json)
 ->

--- a/test/map_test.erl
+++ b/test/map_test.erl
@@ -21,6 +21,10 @@
 -type optional_nullable() :: #{a1 => integer() | undefined}.
 -type nullable() :: #{a1 := integer() | undefined}.
 
+-record(only_atom5, {f :: atom5}).
+-type strict_empty_map() :: #{}.
+-type strict_empty_or_rec() :: #{} | #only_atom5{}.
+
 map1_test() ->
     ?assertEqual({ok, #{<<"a1">> => 1}}, to_json_atom_map(#{a1 => 1})).
 
@@ -308,6 +312,32 @@ from_json_empty_map_bad_test() ->
         from_json_empty_map([])
     ).
 
+strict_empty_map_ok_test() ->
+    ?assertEqual({ok, #{}}, to_json_strict_empty_map(#{})),
+    ?assertEqual({ok, #{}}, from_json_strict_empty_map(#{})).
+
+strict_empty_map_rejects_non_empty_test() ->
+    TypeInfo = spectra_abstract_code:types_in_module(?MODULE),
+    StrictType = spectra_type_info:get_type(TypeInfo, strict_empty_map, 0),
+    ?assertEqual(
+        {error, [sp_error:type_mismatch(StrictType, #{a => 1})]},
+        to_json_strict_empty_map(#{a => 1})
+    ),
+    ?assertEqual(
+        {error, [sp_error:type_mismatch(StrictType, #{<<"a">> => 1})]},
+        from_json_strict_empty_map(#{<<"a">> => 1})
+    ).
+
+strict_empty_or_rec_roundtrip_test() ->
+    %% Regression: union of #{} and a record decoded a record-shaped JSON
+    %% object as #{} because the empty-map branch silently accepted any
+    %% object and dropped its keys.
+    Rec = #only_atom5{f = atom5},
+    {ok, Json} = to_json_strict_empty_or_rec(Rec),
+    ?assertEqual({ok, Rec}, from_json_strict_empty_or_rec(Json)),
+    {ok, EmptyJson} = to_json_strict_empty_or_rec(#{}),
+    ?assertEqual({ok, #{}}, from_json_strict_empty_or_rec(EmptyJson)).
+
 map_with_tuple_value_test() ->
     ?assertError({type_not_supported, _}, to_json_map_with_tuple_value(#{a => {a}})),
     ?assertError({type_not_supported, _}, to_json_map_with_tuple_value(#{b => {1, 2, 3}})).
@@ -478,6 +508,26 @@ to_json_empty_map(Data) ->
 -spec from_json_empty_map(term()) -> {ok, empty_map()} | {error, [spectra:error()]}.
 from_json_empty_map(Data) ->
     spectra:decode(json, ?MODULE, {type, empty_map, 0}, Data, [pre_decoded]).
+
+-spec to_json_strict_empty_map(term()) ->
+    {ok, strict_empty_map()} | {error, [spectra:error()]}.
+to_json_strict_empty_map(Data) ->
+    spectra:encode(json, ?MODULE, {type, strict_empty_map, 0}, Data, [pre_encoded]).
+
+-spec from_json_strict_empty_map(term()) ->
+    {ok, strict_empty_map()} | {error, [spectra:error()]}.
+from_json_strict_empty_map(Data) ->
+    spectra:decode(json, ?MODULE, {type, strict_empty_map, 0}, Data, [pre_decoded]).
+
+-spec to_json_strict_empty_or_rec(term()) ->
+    {ok, strict_empty_or_rec()} | {error, [spectra:error()]}.
+to_json_strict_empty_or_rec(Data) ->
+    spectra:encode(json, ?MODULE, {type, strict_empty_or_rec, 0}, Data, [pre_encoded]).
+
+-spec from_json_strict_empty_or_rec(term()) ->
+    {ok, strict_empty_or_rec()} | {error, [spectra:error()]}.
+from_json_strict_empty_or_rec(Data) ->
+    spectra:decode(json, ?MODULE, {type, strict_empty_or_rec, 0}, Data, [pre_decoded]).
 
 -spec to_json_map_with_tuple_value(term()) ->
     {ok, map_with_tuple_value()} | {error, [spectra:error()]}.


### PR DESCRIPTION
## Summary
- The empty-map type `#{}` (`#sp_map{fields = []}`) silently accepted and dropped keys on both encode and decode, so `prop_json_roundtrip_from_data` could generate a union of `#{}` and a record whose record-shaped JSON was then decoded as `#{}`, breaking the roundtrip.
- Fix: `map_from_json` and `map_to_json` now return a `type_mismatch` error when `fields = []` meets a non-empty map.
- Added unit tests covering the strict empty-map semantics and the union regression from the prop failure.

## Test plan
- [x] `make build-test` (694 tests pass)
- [x] `make proper` (9/9 properties pass, including `prop_json_roundtrip_from_data`)

🤖 Generated with [Claude Code](https://claude.com/claude-code)