### PR TITLE
Allow additional fields for #{} type in JSON encode/decode

### DIFF
--- a/src/spectra_json.erl
+++ b/src/spectra_json.erl
@@ -233,7 +233,7 @@ list_to_json(TypeInfo, #sp_list{type = Type} = ListType, Data, Config) when is_l
     Config :: spectra:sp_config()
 ) ->
     {ok, json:encode_value()} | {error, [spectra:error()]}.
-map_to_json(TypeInfo, #sp_map{fields = Fields} = Map, Data, Config) when
+map_to_json(TypeInfo, #sp_map{fields = Fields}, Data, Config) when
     is_map(Data)
 ->
     %% Check if this is an Elixir struct and remove __struct__ field for JSON serialization
@@ -244,16 +244,11 @@ map_to_json(TypeInfo, #sp_map{fields = Fields} = Map, Data, Config) when
             error ->
                 Data
         end,
-    case {Fields, map_size(DataWithoutStruct)} of
-        {[], Size} when Size > 0 ->
-            {error, [sp_error:type_mismatch(Map, Data)]};
-        _ ->
-            case map_fields_to_json(TypeInfo, Fields, DataWithoutStruct, Config) of
-                {ok, MapFields} ->
-                    {ok, maps:from_list(MapFields)};
-                {error, Errors} ->
-                    {error, Errors}
-            end
+    case map_fields_to_json(TypeInfo, Fields, DataWithoutStruct, Config) of
+        {ok, MapFields} ->
+            {ok, maps:from_list(MapFields)};
+        {error, Errors} ->
+            {error, Errors}
     end;
 map_to_json(_TypeInfo, MapType, Data, _Config) ->
     {error, [sp_error:type_mismatch(MapType, Data)]}.
@@ -910,10 +905,6 @@ do_first(Fun, TypeInfo, [Type | Rest], Json, Config, ErrorsAcc) ->
 ) ->
     {ok, #{json:encode_value() => json:encode_value()}}
     | {error, [spectra:error()]}.
-map_from_json(_TypeInfo, #sp_map{fields = []} = Map, Json, _Config) when
-    is_map(Json), map_size(Json) > 0
-->
-    {error, [sp_error:type_mismatch(Map, Json)]};
 map_from_json(TypeInfo, #sp_map{fields = MapFieldType, struct_name = StructName}, Json, Config) when
     is_map(Json)
 ->

--- a/test/map_test.erl
+++ b/test/map_test.erl
@@ -312,31 +312,36 @@ from_json_empty_map_bad_test() ->
         from_json_empty_map([])
     ).
 
-strict_empty_map_ok_test() ->
+strict_empty_map_test() ->
     ?assertEqual({ok, #{}}, to_json_strict_empty_map(#{})),
-    ?assertEqual({ok, #{}}, from_json_strict_empty_map(#{})).
+    ?assertEqual({ok, #{}}, to_json_strict_empty_map(#{a => 1})),
+    ?assertEqual({ok, #{}}, to_json_strict_empty_map(#{a => 1, b => 2})),
+    ?assertEqual({ok, #{}}, from_json_strict_empty_map(#{})),
+    ?assertEqual({ok, #{}}, from_json_strict_empty_map(#{<<"a">> => 1})),
+    ?assertEqual({ok, #{}}, from_json_strict_empty_map(#{<<"a">> => 1, <<"b">> => 2})).
 
-strict_empty_map_rejects_non_empty_test() ->
+strict_empty_map_bad_test() ->
     TypeInfo = spectra_abstract_code:types_in_module(?MODULE),
     StrictType = spectra_type_info:get_type(TypeInfo, strict_empty_map, 0),
     ?assertEqual(
-        {error, [sp_error:type_mismatch(StrictType, #{a => 1})]},
-        to_json_strict_empty_map(#{a => 1})
+        {error, [sp_error:type_mismatch(StrictType, not_a_map)]},
+        to_json_strict_empty_map(not_a_map)
     ),
     ?assertEqual(
-        {error, [sp_error:type_mismatch(StrictType, #{<<"a">> => 1})]},
-        from_json_strict_empty_map(#{<<"a">> => 1})
+        {error, [sp_error:type_mismatch(StrictType, not_a_map)]},
+        from_json_strict_empty_map(not_a_map)
     ).
 
-strict_empty_or_rec_roundtrip_test() ->
-    %% Regression: union of #{} and a record decoded a record-shaped JSON
-    %% object as #{} because the empty-map branch silently accepted any
-    %% object and dropped its keys.
+strict_empty_map_in_union_test() ->
+    %% Encoding a record works because records are tuples, not maps, so the
+    %% #{} arm fails the is_map guard and the record arm is tried next.
     Rec = #only_atom5{f = atom5},
-    {ok, Json} = to_json_strict_empty_or_rec(Rec),
-    ?assertEqual({ok, Rec}, from_json_strict_empty_or_rec(Json)),
-    {ok, EmptyJson} = to_json_strict_empty_or_rec(#{}),
-    ?assertEqual({ok, #{}}, from_json_strict_empty_or_rec(EmptyJson)).
+    ?assertMatch({ok, #{<<"f">> := <<"atom5">>}}, to_json_strict_empty_or_rec(Rec)),
+    %% Decoding: #{} is tried first and accepts any JSON object, producing #{}
+    %% and discarding all fields. This is consistent with how other literal-field
+    %% maps work when placed first in a union.
+    ?assertEqual({ok, #{}}, from_json_strict_empty_or_rec(#{<<"f">> => <<"atom5">>})),
+    ?assertEqual({ok, #{}}, from_json_strict_empty_or_rec(#{})).
 
 map_with_tuple_value_test() ->
     ?assertError({type_not_supported, _}, to_json_map_with_tuple_value(#{a => {a}})),


### PR DESCRIPTION
## Summary

- Removes the special rejection of non-empty maps for the `#{}` type in `map_to_json` and `map_from_json`
- `#{}` now behaves like other literal-field maps: any map is accepted as input, and extra fields are silently dropped (encode always produces `{}`, decode always produces `#{}`)
- Updates tests: replaces the "rejects non-empty" test with positive and negative tests matching the new behaviour; updates the union test to document that `#{}` placed first in a union greedily matches any JSON object

## Test plan

- [ ] `make build-test` passes
- [ ] `strict_empty_map_test` confirms encode/decode of non-empty maps produce `#{}`
- [ ] `strict_empty_map_bad_test` confirms non-maps are still rejected
- [ ] `strict_empty_map_in_union_test` documents the union greedy-match behaviour

🤖 Generated with [Claude Code](https://claude.com/claude-code)