### PR TITLE
Add running-without-debug_info docs section and simplify map key filtering

### DIFF
--- a/README.md
+++ b/README.md
@@ -21,7 +21,17 @@ Add spectra to your rebar.config dependencies:
 ]}.
 ```
 
-Your modules must be compiled with `debug_info` for spectra to extract type information. If your release strips debug info, opt individual modules into the [`spectra_transform` parse transform](#parse-transform-no-debug_info-required) instead.
+By default, spectra reads type information from `debug_info` in compiled BEAM files. Rebar3 enables `debug_info` by default in development profiles. See [Running without `debug_info`](#running-without-debug_info) if you need to strip it in production.
+
+### Running without `debug_info`
+
+Some release tools strip `debug_info` from BEAM files to reduce binary size. If you cannot keep `debug_info`, you must compensate for every module whose types you encode or decode:
+
+1. **Your own modules** — add `-compile({parse_transform, spectra_transform}).` to each module. This injects `__spectra_type_info__/0` at compile time, embedding the type information directly into the module so it survives stripping. See the [Parse Transform](#parse-transform-no-debug_info-required) section for details.
+
+2. **Dependency and OTP modules** — write a [custom codec](#custom-codecs) for every type from those modules that you encode or decode, and register it via `{spectra, [{codecs, ...}]}` in your sys.config.
+
+If any type is encountered that has neither `debug_info` nor a registered codec, spectra will raise a configuration error at runtime.
 
 ## Data (de)serialization and schemas
 

--- a/src/spectra_json.erl
+++ b/src/spectra_json.erl
@@ -284,11 +284,7 @@ map_fields_to_json(TypeInfo, MapFieldTypes, Data, Config) ->
                     {ok, LiteralMapFields};
                 _ ->
                     %% Phase 2: Process typed fields with remaining data entries
-                    ConsumedKeysSet = sets:from_list(ConsumedKeys, [{version, 2}]),
-                    RemainingDataList = lists:filter(
-                        fun({K, _}) -> not sets:is_element(K, ConsumedKeysSet) end,
-                        maps:to_list(Data)
-                    ),
+                    RemainingDataList = maps:to_list(maps:without(ConsumedKeys, Data)),
                     case
                         spectra_util:fold_until_error(
                             fun map_typed_field_to_json/3,
@@ -943,11 +939,7 @@ map_from_json(TypeInfo, #sp_map{fields = MapFieldType, struct_name = StructName}
                     BuildResult(LiteralMapFields);
                 _ ->
                     %% Phase 2: Process typed fields with remaining JSON entries
-                    ConsumedKeysSet = sets:from_list(ConsumedKeys, [{version, 2}]),
-                    RemainingJsonList = lists:filter(
-                        fun({K, _}) -> not sets:is_element(K, ConsumedKeysSet) end,
-                        maps:to_list(Json)
-                    ),
+                    RemainingJsonList = maps:to_list(maps:without(ConsumedKeys, Json)),
                     case
                         spectra_util:fold_until_error(
                             fun map_typed_field_from_json/3,


### PR DESCRIPTION
## Summary

- Adds a `### Running without \`debug_info\`` subsection under Installation in the README, mirroring the equivalent section in the [spectral docs](https://github.com/andreashasse/spectral#running-without-debug_info). Explains the two cases: own modules (parse transform) and dependency/OTP modules (custom codecs).
- Simplifies the remaining-key computation in `map_fields_to_json` and `map_from_json` from a manual `sets`-based filter to `maps:without/2`, which is cleaner and more idiomatic.

## Test plan

- [ ] `make format && make build-test` passes
- [ ] `make proper` passes
- [ ] README renders correctly on GitHub (check the anchor link `#running-without-debug_info` resolves)

🤖 Generated with [Claude Code](https://claude.com/claude-code)