### PR TITLE
Add field_aliases support to -spectra() attribute

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,10 +11,6 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Added
 - `field_aliases` support in the `-spectra()` attribute for records and map types. Use `field_aliases => #{internal_name => <<"external_name">>}` to rename fields in JSON, OpenAPI, and other encoded formats without changing the Erlang record or map key names.
-- `apply_field_aliases/2` is now exported as part of the public API, enabling Elixir wrappers and other callers to apply alias mappings directly.
-
-### Fixed
-- `apply_only` field filtering is now applied before `field_aliases` renaming, so `only` lists refer to internal Erlang field names as expected rather than external alias names.
 
 ## [0.12.1] - 2026-04-24
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,15 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.13.0] - 2026-05-07
+
+### Added
+- `field_aliases` support in the `-spectra()` attribute for records and map types. Use `field_aliases => #{internal_name => <<"external_name">>}` to rename fields in JSON, OpenAPI, and other encoded formats without changing the Erlang record or map key names.
+- `apply_field_aliases/2` is now exported as part of the public API, enabling Elixir wrappers and other callers to apply alias mappings directly.
+
+### Fixed
+- `apply_only` field filtering is now applied before `field_aliases` renaming, so `only` lists refer to internal Erlang field names as expected rather than external alias names.
+
 ## [0.12.1] - 2026-04-24
 
 ### Fixed

--- a/README.md
+++ b/README.md
@@ -17,7 +17,7 @@ Add spectra to your rebar.config dependencies:
 
 ```erlang
 {deps, [
-    {spectra, "~> 0.12.1"}
+    {spectra, "~> 0.13.0"}
 ]}.
 ```
 

--- a/src/spectra_abstract_code.erl
+++ b/src/spectra_abstract_code.erl
@@ -115,9 +115,9 @@ process_type_form(TypeWithKey, PendingDoc, Rest, NamedTypes) ->
 attach_doc({{type, _Name, _Arity} = Key, Type}, DocMap) ->
     Aliases = maps:get(field_aliases, DocMap, #{}),
     OnlyFiltered =
-        case maps:get(only, DocMap, undefined) of
-            undefined -> Type;
-            Only -> apply_only(Type, validate_only(Only))
+        case DocMap of
+            #{only := Only} -> apply_only(Type, validate_only(Only));
+            #{} -> Type
         end,
     FinalType = apply_field_aliases(OnlyFiltered, validate_field_aliases(Aliases)),
     CleanDocMap = maps:without([field_aliases, only, type_parameters], DocMap),

--- a/src/spectra_abstract_code.erl
+++ b/src/spectra_abstract_code.erl
@@ -112,23 +112,16 @@ process_type_form(TypeWithKey, PendingDoc, Rest, NamedTypes) ->
     end.
 
 -spec attach_doc(type_form_result(), map()) -> type_form_result().
-attach_doc({{type, _Name, _Arity} = Key, Type}, #{only := Only} = DocMap) ->
-    Aliases = maps:get(field_aliases, DocMap, #{}),
-    FilteredType = apply_only(
-        apply_field_aliases(Type, validate_field_aliases(Aliases)), validate_only(Only)
-    ),
-    CleanDocMap = maps:remove(
-        field_aliases, maps:remove(only, maps:remove(type_parameters, DocMap))
-    ),
-    {Key, apply_type_parameters(spectra_type:add_doc_to_type(FilteredType, CleanDocMap), DocMap)};
 attach_doc({{type, _Name, _Arity} = Key, Type}, DocMap) ->
     Aliases = maps:get(field_aliases, DocMap, #{}),
     AliasedType = apply_field_aliases(Type, validate_field_aliases(Aliases)),
-    CleanDocMap = maps:remove(field_aliases, maps:remove(type_parameters, DocMap)),
-    {Key,
-        apply_type_parameters(
-            spectra_type:add_doc_to_type(AliasedType, CleanDocMap), DocMap
-        )};
+    FilteredType =
+        case maps:find(only, DocMap) of
+            {ok, Only} -> apply_only(AliasedType, validate_only(Only));
+            error -> AliasedType
+        end,
+    CleanDocMap = maps:without([field_aliases, only, type_parameters], DocMap),
+    {Key, apply_type_parameters(spectra_type:add_doc_to_type(FilteredType, CleanDocMap), DocMap)};
 attach_doc({{record, _Name} = Key, Record}, DocMap) ->
     Aliases = maps:get(field_aliases, DocMap, #{}),
     AliasedRecord = apply_field_aliases(Record, validate_field_aliases(Aliases)),
@@ -154,11 +147,11 @@ validate_only(Only) when is_list(Only) ->
 validate_only(Only) ->
     erlang:error({invalid_spectra_field, only, Only}).
 
--spec validate_field_aliases(term()) -> #{atom() => binary()}.
+-spec validate_field_aliases(term()) -> #{atom() | integer() => binary()}.
 validate_field_aliases(Aliases) when is_map(Aliases) ->
     maps:fold(
         fun
-            (K, V, Acc) when is_atom(K), is_binary(V) -> Acc#{K => V};
+            (K, V, Acc) when (is_atom(K) orelse is_integer(K)), is_binary(V) -> Acc#{K => V};
             (K, V, _Acc) -> erlang:error({invalid_spectra_field, field_aliases, {K, V}})
         end,
         #{},
@@ -167,7 +160,8 @@ validate_field_aliases(Aliases) when is_map(Aliases) ->
 validate_field_aliases(Aliases) ->
     erlang:error({invalid_spectra_field, field_aliases, Aliases}).
 
--spec apply_field_aliases(spectra:sp_type(), #{atom() => binary()}) -> spectra:sp_type().
+-spec apply_field_aliases(spectra:sp_type(), #{atom() | integer() => binary()}) ->
+    spectra:sp_type().
 apply_field_aliases(#sp_map{fields = Fields} = Map, Aliases) ->
     Updated = [alias_map_field(F, Aliases) || F <- Fields],
     check_unique_binary_names([BN || #literal_map_field{binary_name = BN} <- Updated]),

--- a/src/spectra_abstract_code.erl
+++ b/src/spectra_abstract_code.erl
@@ -177,7 +177,8 @@ apply_field_aliases(#sp_type_with_variables{type = Inner} = TWV, Aliases) ->
 apply_field_aliases(Other, _Aliases) ->
     Other.
 
--spec alias_map_field(spectra:map_field(), #{atom() => binary()}) -> spectra:map_field().
+-spec alias_map_field(spectra:map_field(), #{atom() | integer() => binary()}) ->
+    spectra:map_field().
 alias_map_field(#literal_map_field{name = Name} = F, Aliases) ->
     case Aliases of
         #{Name := Alias} -> F#literal_map_field{binary_name = Alias};
@@ -186,7 +187,7 @@ alias_map_field(#literal_map_field{name = Name} = F, Aliases) ->
 alias_map_field(F, _Aliases) ->
     F.
 
--spec alias_rec_field(#sp_rec_field{}, #{atom() => binary()}) -> #sp_rec_field{}.
+-spec alias_rec_field(#sp_rec_field{}, #{atom() | integer() => binary()}) -> #sp_rec_field{}.
 alias_rec_field(#sp_rec_field{name = Name} = F, Aliases) ->
     case Aliases of
         #{Name := Alias} -> F#sp_rec_field{binary_name = Alias};

--- a/src/spectra_abstract_code.erl
+++ b/src/spectra_abstract_code.erl
@@ -115,9 +115,9 @@ process_type_form(TypeWithKey, PendingDoc, Rest, NamedTypes) ->
 attach_doc({{type, _Name, _Arity} = Key, Type}, DocMap) ->
     Aliases = maps:get(field_aliases, DocMap, #{}),
     OnlyFiltered =
-        case maps:find(only, DocMap) of
-            {ok, Only} -> apply_only(Type, validate_only(Only));
-            error -> Type
+        case maps:get(only, DocMap, undefined) of
+            undefined -> Type;
+            Only -> apply_only(Type, validate_only(Only))
         end,
     FinalType = apply_field_aliases(OnlyFiltered, validate_field_aliases(Aliases)),
     CleanDocMap = maps:without([field_aliases, only, type_parameters], DocMap),

--- a/src/spectra_abstract_code.erl
+++ b/src/spectra_abstract_code.erl
@@ -114,14 +114,14 @@ process_type_form(TypeWithKey, PendingDoc, Rest, NamedTypes) ->
 -spec attach_doc(type_form_result(), map()) -> type_form_result().
 attach_doc({{type, _Name, _Arity} = Key, Type}, DocMap) ->
     Aliases = maps:get(field_aliases, DocMap, #{}),
-    AliasedType = apply_field_aliases(Type, validate_field_aliases(Aliases)),
-    FilteredType =
+    OnlyFiltered =
         case maps:find(only, DocMap) of
-            {ok, Only} -> apply_only(AliasedType, validate_only(Only));
-            error -> AliasedType
+            {ok, Only} -> apply_only(Type, validate_only(Only));
+            error -> Type
         end,
+    FinalType = apply_field_aliases(OnlyFiltered, validate_field_aliases(Aliases)),
     CleanDocMap = maps:without([field_aliases, only, type_parameters], DocMap),
-    {Key, apply_type_parameters(spectra_type:add_doc_to_type(FilteredType, CleanDocMap), DocMap)};
+    {Key, apply_type_parameters(spectra_type:add_doc_to_type(FinalType, CleanDocMap), DocMap)};
 attach_doc({{record, _Name} = Key, Record}, DocMap) ->
     Aliases = maps:get(field_aliases, DocMap, #{}),
     AliasedRecord = apply_field_aliases(Record, validate_field_aliases(Aliases)),

--- a/src/spectra_abstract_code.erl
+++ b/src/spectra_abstract_code.erl
@@ -113,18 +113,29 @@ process_type_form(TypeWithKey, PendingDoc, Rest, NamedTypes) ->
 
 -spec attach_doc(type_form_result(), map()) -> type_form_result().
 attach_doc({{type, _Name, _Arity} = Key, Type}, #{only := Only} = DocMap) ->
-    FilteredType = apply_only(Type, validate_only(Only)),
-    CleanDocMap = maps:remove(only, maps:remove(type_parameters, DocMap)),
+    Aliases = maps:get(field_aliases, DocMap, #{}),
+    FilteredType = apply_only(
+        apply_field_aliases(Type, validate_field_aliases(Aliases)), validate_only(Only)
+    ),
+    CleanDocMap = maps:remove(
+        field_aliases, maps:remove(only, maps:remove(type_parameters, DocMap))
+    ),
     {Key, apply_type_parameters(spectra_type:add_doc_to_type(FilteredType, CleanDocMap), DocMap)};
 attach_doc({{type, _Name, _Arity} = Key, Type}, DocMap) ->
+    Aliases = maps:get(field_aliases, DocMap, #{}),
+    AliasedType = apply_field_aliases(Type, validate_field_aliases(Aliases)),
+    CleanDocMap = maps:remove(field_aliases, maps:remove(type_parameters, DocMap)),
     {Key,
         apply_type_parameters(
-            spectra_type:add_doc_to_type(Type, maps:remove(type_parameters, DocMap)), DocMap
+            spectra_type:add_doc_to_type(AliasedType, CleanDocMap), DocMap
         )};
 attach_doc({{record, _Name} = Key, Record}, DocMap) ->
+    Aliases = maps:get(field_aliases, DocMap, #{}),
+    AliasedRecord = apply_field_aliases(Record, validate_field_aliases(Aliases)),
+    CleanDocMap = maps:remove(field_aliases, maps:remove(type_parameters, DocMap)),
     {Key,
         apply_type_parameters(
-            spectra_type:add_doc_to_type(Record, maps:remove(type_parameters, DocMap)), DocMap
+            spectra_type:add_doc_to_type(AliasedRecord, CleanDocMap), DocMap
         )};
 attach_doc({{function, _Name, _Arity} = Key, FuncSpecs}, DocMap) ->
     Doc = spectra_type:normalize_function_doc(DocMap),
@@ -142,6 +153,47 @@ validate_only(Only) when is_list(Only) ->
     end;
 validate_only(Only) ->
     erlang:error({invalid_spectra_field, only, Only}).
+
+-spec validate_field_aliases(term()) -> #{atom() => binary()}.
+validate_field_aliases(Aliases) when is_map(Aliases) ->
+    maps:foreach(
+        fun
+            (K, V) when is_atom(K), is_binary(V) -> ok;
+            (K, V) -> erlang:error({invalid_spectra_field, field_aliases, {K, V}})
+        end,
+        Aliases
+    ),
+    Aliases;
+validate_field_aliases(Aliases) ->
+    erlang:error({invalid_spectra_field, field_aliases, Aliases}).
+
+-spec apply_field_aliases(spectra:sp_type(), #{atom() => binary()}) -> spectra:sp_type().
+apply_field_aliases(#sp_map{fields = Fields} = Map, Aliases) ->
+    Map#sp_map{fields = [alias_map_field(F, Aliases) || F <- Fields]};
+apply_field_aliases(#sp_rec{fields = Fields} = Rec, Aliases) ->
+    Rec#sp_rec{fields = [alias_rec_field(F, Aliases) || F <- Fields]};
+apply_field_aliases(#sp_union{types = Types} = Union, Aliases) ->
+    Union#sp_union{types = [apply_field_aliases(T, Aliases) || T <- Types]};
+apply_field_aliases(#sp_type_with_variables{type = Inner} = TWV, Aliases) ->
+    TWV#sp_type_with_variables{type = apply_field_aliases(Inner, Aliases)};
+apply_field_aliases(Other, _Aliases) ->
+    Other.
+
+-spec alias_map_field(spectra:map_field(), #{atom() => binary()}) -> spectra:map_field().
+alias_map_field(#literal_map_field{name = Name} = F, Aliases) ->
+    case Aliases of
+        #{Name := Alias} -> F#literal_map_field{binary_name = Alias};
+        _ -> F
+    end;
+alias_map_field(F, _Aliases) ->
+    F.
+
+-spec alias_rec_field(#sp_rec_field{}, #{atom() => binary()}) -> #sp_rec_field{}.
+alias_rec_field(#sp_rec_field{name = Name} = F, Aliases) ->
+    case Aliases of
+        #{Name := Alias} -> F#sp_rec_field{binary_name = Alias};
+        _ -> F
+    end.
 
 -doc """
 Filters the fields of a map type to only those named in `Only`.

--- a/src/spectra_abstract_code.erl
+++ b/src/spectra_abstract_code.erl
@@ -169,9 +169,13 @@ validate_field_aliases(Aliases) ->
 
 -spec apply_field_aliases(spectra:sp_type(), #{atom() => binary()}) -> spectra:sp_type().
 apply_field_aliases(#sp_map{fields = Fields} = Map, Aliases) ->
-    Map#sp_map{fields = [alias_map_field(F, Aliases) || F <- Fields]};
+    Updated = [alias_map_field(F, Aliases) || F <- Fields],
+    check_unique_binary_names([BN || #literal_map_field{binary_name = BN} <- Updated]),
+    Map#sp_map{fields = Updated};
 apply_field_aliases(#sp_rec{fields = Fields} = Rec, Aliases) ->
-    Rec#sp_rec{fields = [alias_rec_field(F, Aliases) || F <- Fields]};
+    Updated = [alias_rec_field(F, Aliases) || F <- Fields],
+    check_unique_binary_names([BN || #sp_rec_field{binary_name = BN} <- Updated]),
+    Rec#sp_rec{fields = Updated};
 apply_field_aliases(#sp_union{types = Types} = Union, Aliases) ->
     Union#sp_union{types = [apply_field_aliases(T, Aliases) || T <- Types]};
 apply_field_aliases(#sp_type_with_variables{type = Inner} = TWV, Aliases) ->
@@ -193,6 +197,16 @@ alias_rec_field(#sp_rec_field{name = Name} = F, Aliases) ->
     case Aliases of
         #{Name := Alias} -> F#sp_rec_field{binary_name = Alias};
         _ -> F
+    end.
+
+-spec check_unique_binary_names([binary()]) -> ok.
+check_unique_binary_names(Names) ->
+    Sorted = lists:sort(Names),
+    case Sorted -- lists:usort(Sorted) of
+        [] ->
+            ok;
+        [Dup | _] ->
+            erlang:error({invalid_spectra_field, field_aliases, {duplicate_json_name, Dup}})
     end.
 
 -doc """

--- a/src/spectra_abstract_code.erl
+++ b/src/spectra_abstract_code.erl
@@ -156,14 +156,14 @@ validate_only(Only) ->
 
 -spec validate_field_aliases(term()) -> #{atom() => binary()}.
 validate_field_aliases(Aliases) when is_map(Aliases) ->
-    maps:foreach(
+    maps:fold(
         fun
-            (K, V) when is_atom(K), is_binary(V) -> ok;
-            (K, V) -> erlang:error({invalid_spectra_field, field_aliases, {K, V}})
+            (K, V, Acc) when is_atom(K), is_binary(V) -> Acc#{K => V};
+            (K, V, _Acc) -> erlang:error({invalid_spectra_field, field_aliases, {K, V}})
         end,
+        #{},
         Aliases
-    ),
-    Aliases;
+    );
 validate_field_aliases(Aliases) ->
     erlang:error({invalid_spectra_field, field_aliases, Aliases}).
 

--- a/src/spectra_abstract_code.erl
+++ b/src/spectra_abstract_code.erl
@@ -2,8 +2,10 @@
 
 -include("../include/spectra_internal.hrl").
 
--export([types_in_module/1, types_in_module_path/1, types_in_forms/2, apply_only/2]).
--ignore_xref([types_in_module_path/1, apply_only/2]).
+-export([
+    types_in_module/1, types_in_module_path/1, types_in_forms/2, apply_only/2, apply_field_aliases/2
+]).
+-ignore_xref([types_in_module_path/1, apply_only/2, apply_field_aliases/2]).
 
 -define(TYPE_INFO_FUNCTION, '__spectra_type_info__').
 

--- a/src/spectra_openapi.erl
+++ b/src/spectra_openapi.erl
@@ -630,7 +630,7 @@ endpoints_to_openapi(MetaData, Endpoints, Options) when is_list(Endpoints) ->
 group_endpoints_by_path(Endpoints) ->
     lists:foldl(
         fun(Endpoint, Acc) ->
-            Path = maps:get(path, Endpoint),
+            #{path := Path} = Endpoint,
             PathEndpoints = maps:get(Path, Acc, []),
             Acc#{Path => [Endpoint | PathEndpoints]}
         end,

--- a/test/elixir_struct_test.erl
+++ b/test/elixir_struct_test.erl
@@ -170,7 +170,7 @@ run_from_json_only() ->
 schema_only_includes_listed_fields_test() ->
     TypeInfo = spectra_abstract_code:types_in_module(elixir_test_user_struct_types),
     Schema = spectra:schema(json_schema, TypeInfo, {type, t_only, 0}, [pre_encoded]),
-    Properties = maps:get(properties, Schema),
+    #{properties := Properties} = Schema,
     ?assertEqual([<<"age">>, <<"name">>], lists:sort(maps:keys(Properties))).
 
 to_json_only_union_excludes_other_fields_test() ->
@@ -216,5 +216,5 @@ schema_only_parameterized_type_test() ->
     %% binary_item() = item(binary()) where item/1 has only => [name]
     %% Without the fix, 'age' also appears because apply_only bypasses #sp_type_with_variables{}
     Schema = spectra:schema(json_schema, TypeInfo, binary_item, [pre_encoded]),
-    Properties = maps:get(properties, Schema),
+    #{properties := Properties} = Schema,
     ?assertEqual([<<"name">>], lists:sort(maps:keys(Properties))).

--- a/test/field_alias_test.erl
+++ b/test/field_alias_test.erl
@@ -1,0 +1,133 @@
+-module(field_alias_test).
+
+-include_lib("eunit/include/eunit.hrl").
+
+-compile(nowarn_unused_type).
+-compile(nowarn_unused_record).
+
+-spectra(#{field_aliases => #{last_name => <<"lastName">>, first_name => <<"firstName">>}}).
+-record(person, {first_name :: binary(), last_name :: binary()}).
+
+-spectra(#{field_aliases => #{last_name => <<"lastName">>}}).
+-type person_map() :: #{last_name := binary()}.
+
+-spectra(#{description => <<"A person">>, field_aliases => #{last_name => <<"lastName">>}}).
+-type person_with_doc() :: #{last_name := binary()}.
+
+record_encode_test() ->
+    ?assertEqual(
+        {ok, #{<<"firstName">> => <<"John">>, <<"lastName">> => <<"Smith">>}},
+        spectra:encode(
+            json,
+            ?MODULE,
+            {record, person},
+            #person{first_name = <<"John">>, last_name = <<"Smith">>},
+            [pre_encoded]
+        )
+    ).
+
+record_decode_test() ->
+    ?assertEqual(
+        {ok, #person{first_name = <<"John">>, last_name = <<"Smith">>}},
+        spectra:decode(
+            json,
+            ?MODULE,
+            {record, person},
+            #{<<"firstName">> => <<"John">>, <<"lastName">> => <<"Smith">>},
+            [pre_decoded]
+        )
+    ).
+
+record_roundtrip_test() ->
+    Original = #person{first_name = <<"Jane">>, last_name = <<"Doe">>},
+    {ok, Json} = spectra:encode(json, ?MODULE, {record, person}, Original, [pre_encoded]),
+    ?assertEqual(
+        {ok, Original}, spectra:decode(json, ?MODULE, {record, person}, Json, [pre_decoded])
+    ).
+
+record_decode_rejects_unaliased_name_test() ->
+    ?assertMatch(
+        {error, _},
+        spectra:decode(
+            json,
+            ?MODULE,
+            {record, person},
+            #{<<"first_name">> => <<"John">>, <<"last_name">> => <<"Smith">>},
+            [pre_decoded]
+        )
+    ).
+
+map_encode_test() ->
+    ?assertEqual(
+        {ok, #{<<"lastName">> => <<"Smith">>}},
+        spectra:encode(json, ?MODULE, {type, person_map, 0}, #{last_name => <<"Smith">>}, [
+            pre_encoded
+        ])
+    ).
+
+map_decode_test() ->
+    ?assertEqual(
+        {ok, #{last_name => <<"Smith">>}},
+        spectra:decode(json, ?MODULE, {type, person_map, 0}, #{<<"lastName">> => <<"Smith">>}, [
+            pre_decoded
+        ])
+    ).
+
+map_roundtrip_test() ->
+    Original = #{last_name => <<"Doe">>},
+    {ok, Json} = spectra:encode(json, ?MODULE, {type, person_map, 0}, Original, [pre_encoded]),
+    ?assertEqual(
+        {ok, Original}, spectra:decode(json, ?MODULE, {type, person_map, 0}, Json, [pre_decoded])
+    ).
+
+combined_with_doc_test() ->
+    TypeInfo = spectra_abstract_code:types_in_module(?MODULE),
+    {ok, Type} = spectra_type_info:find_type(TypeInfo, person_with_doc, 0),
+    #{doc := Doc} = spectra_type:get_meta(Type),
+    ?assertEqual(#{description => <<"A person">>}, Doc),
+    ?assertEqual(
+        {ok, #{<<"lastName">> => <<"Smith">>}},
+        spectra:encode(json, ?MODULE, {type, person_with_doc, 0}, #{last_name => <<"Smith">>}, [
+            pre_encoded
+        ])
+    ).
+
+invalid_field_aliases_not_a_map_test() ->
+    Code =
+        "-module(bad_aliases_not_a_map).\n"
+        "-compile(nowarn_unused_type).\n"
+        "-spectra(#{field_aliases => not_a_map}).\n"
+        "-type t() :: #{name := binary()}.\n",
+    {ok, bad_aliases_not_a_map, BeamBinary} = spectra_test_compile:compile_module(Code),
+    TempFile = spectra_test_compile:temp_beam_path("bad_aliases_not_a_map"),
+    ok = file:write_file(TempFile, BeamBinary),
+    ?assertError(
+        {invalid_spectra_field, field_aliases, not_a_map},
+        spectra_abstract_code:types_in_module_path(TempFile)
+    ),
+    file:delete(TempFile).
+
+invalid_field_aliases_bad_value_test() ->
+    Code =
+        "-module(bad_aliases_bad_value).\n"
+        "-compile(nowarn_unused_type).\n"
+        "-spectra(#{field_aliases => #{name => not_a_binary}}).\n"
+        "-type t() :: #{name := binary()}.\n",
+    {ok, bad_aliases_bad_value, BeamBinary} = spectra_test_compile:compile_module(Code),
+    TempFile = spectra_test_compile:temp_beam_path("bad_aliases_bad_value"),
+    ok = file:write_file(TempFile, BeamBinary),
+    ?assertError(
+        {invalid_spectra_field, field_aliases, {name, not_a_binary}},
+        spectra_abstract_code:types_in_module_path(TempFile)
+    ),
+    file:delete(TempFile).
+
+schema_uses_aliased_names_test() ->
+    SchemaJson = spectra:schema(json_schema, ?MODULE, {type, person_map, 0}),
+    Schema = json:decode(iolist_to_binary(SchemaJson)),
+    ?assertMatch(#{<<"properties">> := #{<<"lastName">> := _}}, Schema).
+
+schema_record_uses_aliased_names_test() ->
+    SchemaJson = spectra:schema(json_schema, ?MODULE, {record, person}),
+    Schema = json:decode(iolist_to_binary(SchemaJson)),
+    ?assertMatch(#{<<"properties">> := #{<<"firstName">> := _, <<"lastName">> := _}}, Schema).

--- a/test/field_alias_test.erl
+++ b/test/field_alias_test.erl
@@ -126,11 +126,14 @@ invalid_field_aliases_not_a_map_test() ->
     {ok, bad_aliases_not_a_map, BeamBinary} = spectra_test_compile:compile_module(Code),
     TempFile = spectra_test_compile:temp_beam_path("bad_aliases_not_a_map"),
     ok = file:write_file(TempFile, BeamBinary),
-    ?assertError(
-        {invalid_spectra_field, field_aliases, not_a_map},
-        spectra_abstract_code:types_in_module_path(TempFile)
-    ),
-    file:delete(TempFile).
+    try
+        ?assertError(
+            {invalid_spectra_field, field_aliases, not_a_map},
+            spectra_abstract_code:types_in_module_path(TempFile)
+        )
+    after
+        file:delete(TempFile)
+    end.
 
 invalid_field_aliases_bad_value_test() ->
     Code =
@@ -141,11 +144,14 @@ invalid_field_aliases_bad_value_test() ->
     {ok, bad_aliases_bad_value, BeamBinary} = spectra_test_compile:compile_module(Code),
     TempFile = spectra_test_compile:temp_beam_path("bad_aliases_bad_value"),
     ok = file:write_file(TempFile, BeamBinary),
-    ?assertError(
-        {invalid_spectra_field, field_aliases, {name, not_a_binary}},
-        spectra_abstract_code:types_in_module_path(TempFile)
-    ),
-    file:delete(TempFile).
+    try
+        ?assertError(
+            {invalid_spectra_field, field_aliases, {name, not_a_binary}},
+            spectra_abstract_code:types_in_module_path(TempFile)
+        )
+    after
+        file:delete(TempFile)
+    end.
 
 duplicate_alias_in_map_type_test() ->
     Code =
@@ -156,11 +162,14 @@ duplicate_alias_in_map_type_test() ->
     {ok, bad_aliases_dup_map, BeamBinary} = spectra_test_compile:compile_module(Code),
     TempFile = spectra_test_compile:temp_beam_path("bad_aliases_dup_map"),
     ok = file:write_file(TempFile, BeamBinary),
-    ?assertError(
-        {invalid_spectra_field, field_aliases, {duplicate_json_name, <<"name">>}},
-        spectra_abstract_code:types_in_module_path(TempFile)
-    ),
-    file:delete(TempFile).
+    try
+        ?assertError(
+            {invalid_spectra_field, field_aliases, {duplicate_json_name, <<"name">>}},
+            spectra_abstract_code:types_in_module_path(TempFile)
+        )
+    after
+        file:delete(TempFile)
+    end.
 
 duplicate_alias_in_record_test() ->
     Code =
@@ -171,11 +180,14 @@ duplicate_alias_in_record_test() ->
     {ok, bad_aliases_dup_rec, BeamBinary} = spectra_test_compile:compile_module(Code),
     TempFile = spectra_test_compile:temp_beam_path("bad_aliases_dup_rec"),
     ok = file:write_file(TempFile, BeamBinary),
-    ?assertError(
-        {invalid_spectra_field, field_aliases, {duplicate_json_name, <<"name">>}},
-        spectra_abstract_code:types_in_module_path(TempFile)
-    ),
-    file:delete(TempFile).
+    try
+        ?assertError(
+            {invalid_spectra_field, field_aliases, {duplicate_json_name, <<"name">>}},
+            spectra_abstract_code:types_in_module_path(TempFile)
+        )
+    after
+        file:delete(TempFile)
+    end.
 
 alias_collides_with_default_name_test() ->
     Code =
@@ -186,11 +198,14 @@ alias_collides_with_default_name_test() ->
     {ok, bad_aliases_collide, BeamBinary} = spectra_test_compile:compile_module(Code),
     TempFile = spectra_test_compile:temp_beam_path("bad_aliases_collide"),
     ok = file:write_file(TempFile, BeamBinary),
-    ?assertError(
-        {invalid_spectra_field, field_aliases, {duplicate_json_name, <<"last_name">>}},
-        spectra_abstract_code:types_in_module_path(TempFile)
-    ),
-    file:delete(TempFile).
+    try
+        ?assertError(
+            {invalid_spectra_field, field_aliases, {duplicate_json_name, <<"last_name">>}},
+            spectra_abstract_code:types_in_module_path(TempFile)
+        )
+    after
+        file:delete(TempFile)
+    end.
 
 schema_uses_aliased_names_test() ->
     SchemaJson = spectra:schema(json_schema, ?MODULE, {type, person_map, 0}),

--- a/test/field_alias_test.erl
+++ b/test/field_alias_test.erl
@@ -14,6 +14,19 @@
 -spectra(#{description => <<"A person">>, field_aliases => #{last_name => <<"lastName">>}}).
 -type person_with_doc() :: #{last_name := binary()}.
 
+-spectra(#{field_aliases => #{1 => <<"one">>}}).
+-type int_key_map() :: #{1 := binary()}.
+
+%% Union: alias applies to the map branch inside the union
+-spectra(#{field_aliases => #{last_name => <<"lastName">>}}).
+-type person_or_nil() :: #{last_name := binary()} | nil.
+
+%% Type with variables: alias applies to the map inside the parameterized type.
+%% Tested via a concrete instantiation (named_binary/0) which inherits the alias.
+-spectra(#{field_aliases => #{name => <<"fullName">>}}).
+-type named(T) :: #{name := T}.
+-type named_binary() :: named(binary()).
+
 record_encode_test() ->
     ?assertEqual(
         {ok, #{<<"firstName">> => <<"John">>, <<"lastName">> => <<"Smith">>}},
@@ -188,3 +201,54 @@ schema_record_uses_aliased_names_test() ->
     SchemaJson = spectra:schema(json_schema, ?MODULE, {record, person}),
     Schema = json:decode(iolist_to_binary(SchemaJson)),
     ?assertMatch(#{<<"properties">> := #{<<"firstName">> := _, <<"lastName">> := _}}, Schema).
+
+int_key_map_alias_encode_test() ->
+    ?assertEqual(
+        {ok, #{<<"one">> => <<"val">>}},
+        spectra:encode(json, ?MODULE, {type, int_key_map, 0}, #{1 => <<"val">>}, [pre_encoded])
+    ).
+
+int_key_map_alias_decode_test() ->
+    ?assertEqual(
+        {ok, #{1 => <<"val">>}},
+        spectra:decode(json, ?MODULE, {type, int_key_map, 0}, #{<<"one">> => <<"val">>}, [
+            pre_decoded
+        ])
+    ).
+
+int_key_map_alias_roundtrip_test() ->
+    Original = #{1 => <<"val">>},
+    {ok, Json} = spectra:encode(json, ?MODULE, {type, int_key_map, 0}, Original, [pre_encoded]),
+    ?assertEqual(
+        {ok, Original}, spectra:decode(json, ?MODULE, {type, int_key_map, 0}, Json, [pre_decoded])
+    ).
+
+union_map_branch_alias_encode_test() ->
+    ?assertEqual(
+        {ok, #{<<"lastName">> => <<"Smith">>}},
+        spectra:encode(
+            json, ?MODULE, {type, person_or_nil, 0}, #{last_name => <<"Smith">>}, [pre_encoded]
+        )
+    ).
+
+union_map_branch_alias_decode_test() ->
+    ?assertEqual(
+        {ok, #{last_name => <<"Smith">>}},
+        spectra:decode(
+            json, ?MODULE, {type, person_or_nil, 0}, #{<<"lastName">> => <<"Smith">>}, [pre_decoded]
+        )
+    ).
+
+type_with_variables_alias_encode_test() ->
+    ?assertEqual(
+        {ok, #{<<"fullName">> => <<"Alice">>}},
+        spectra:encode(json, ?MODULE, {type, named_binary, 0}, #{name => <<"Alice">>}, [pre_encoded])
+    ).
+
+type_with_variables_alias_decode_test() ->
+    ?assertEqual(
+        {ok, #{name => <<"Alice">>}},
+        spectra:decode(json, ?MODULE, {type, named_binary, 0}, #{<<"fullName">> => <<"Alice">>}, [
+            pre_decoded
+        ])
+    ).

--- a/test/field_alias_test.erl
+++ b/test/field_alias_test.erl
@@ -57,6 +57,18 @@ record_decode_rejects_unaliased_name_test() ->
         )
     ).
 
+map_decode_rejects_unaliased_name_test() ->
+    ?assertMatch(
+        {error, _},
+        spectra:decode(
+            json,
+            ?MODULE,
+            {type, person_map, 0},
+            #{<<"last_name">> => <<"Smith">>},
+            [pre_decoded]
+        )
+    ).
+
 map_encode_test() ->
     ?assertEqual(
         {ok, #{<<"lastName">> => <<"Smith">>}},
@@ -118,6 +130,51 @@ invalid_field_aliases_bad_value_test() ->
     ok = file:write_file(TempFile, BeamBinary),
     ?assertError(
         {invalid_spectra_field, field_aliases, {name, not_a_binary}},
+        spectra_abstract_code:types_in_module_path(TempFile)
+    ),
+    file:delete(TempFile).
+
+duplicate_alias_in_map_type_test() ->
+    Code =
+        "-module(bad_aliases_dup_map).\n"
+        "-compile(nowarn_unused_type).\n"
+        "-spectra(#{field_aliases => #{first_name => <<\"name\">>, last_name => <<\"name\">>}}).\n"
+        "-type t() :: #{first_name := binary(), last_name := binary()}.\n",
+    {ok, bad_aliases_dup_map, BeamBinary} = spectra_test_compile:compile_module(Code),
+    TempFile = spectra_test_compile:temp_beam_path("bad_aliases_dup_map"),
+    ok = file:write_file(TempFile, BeamBinary),
+    ?assertError(
+        {invalid_spectra_field, field_aliases, {duplicate_json_name, <<"name">>}},
+        spectra_abstract_code:types_in_module_path(TempFile)
+    ),
+    file:delete(TempFile).
+
+duplicate_alias_in_record_test() ->
+    Code =
+        "-module(bad_aliases_dup_rec).\n"
+        "-compile(nowarn_unused_record).\n"
+        "-spectra(#{field_aliases => #{first_name => <<\"name\">>, last_name => <<\"name\">>}}).\n"
+        "-record(t, {first_name :: binary(), last_name :: binary()}).\n",
+    {ok, bad_aliases_dup_rec, BeamBinary} = spectra_test_compile:compile_module(Code),
+    TempFile = spectra_test_compile:temp_beam_path("bad_aliases_dup_rec"),
+    ok = file:write_file(TempFile, BeamBinary),
+    ?assertError(
+        {invalid_spectra_field, field_aliases, {duplicate_json_name, <<"name">>}},
+        spectra_abstract_code:types_in_module_path(TempFile)
+    ),
+    file:delete(TempFile).
+
+alias_collides_with_default_name_test() ->
+    Code =
+        "-module(bad_aliases_collide).\n"
+        "-compile(nowarn_unused_type).\n"
+        "-spectra(#{field_aliases => #{first_name => <<\"last_name\">>}}).\n"
+        "-type t() :: #{first_name := binary(), last_name := binary()}.\n",
+    {ok, bad_aliases_collide, BeamBinary} = spectra_test_compile:compile_module(Code),
+    TempFile = spectra_test_compile:temp_beam_path("bad_aliases_collide"),
+    ok = file:write_file(TempFile, BeamBinary),
+    ?assertError(
+        {invalid_spectra_field, field_aliases, {duplicate_json_name, <<"last_name">>}},
         spectra_abstract_code:types_in_module_path(TempFile)
     ),
     file:delete(TempFile).

--- a/test/field_alias_test.erl
+++ b/test/field_alias_test.erl
@@ -15,7 +15,7 @@
 -type person_with_doc() :: #{last_name := binary()}.
 
 -spectra(#{field_aliases => #{1 => <<"one">>}}).
--type int_key_map() :: #{1 := binary()}.
+-type int_key_map() :: #{1 => binary()}.
 
 %% Union: alias applies to the map branch inside the union
 -spectra(#{field_aliases => #{last_name => <<"lastName">>}}).

--- a/test/openapi_endpoint_test.erl
+++ b/test/openapi_endpoint_test.erl
@@ -266,10 +266,8 @@ generate_parameter_without_description_test() ->
             [pre_encoded]
         ),
 
-    [Parameter] = maps:get(
-        <<"parameters">>,
-        maps:get(<<"get">>, maps:get(<<"/items/{id}">>, maps:get(<<"paths">>, OpenAPISpec)))
-    ),
+    #{<<"paths">> := #{<<"/items/{id}">> := #{<<"get">> := #{<<"parameters">> := [Parameter]}}}} =
+        OpenAPISpec,
     ?assertNot(maps:is_key(<<"description">>, Parameter)).
 
 %% Test that deprecated comes from type doc
@@ -293,10 +291,8 @@ generate_parameter_deprecated_test() ->
             [pre_encoded]
         ),
 
-    [Parameter] = maps:get(
-        <<"parameters">>,
-        maps:get(<<"get">>, maps:get(<<"/items">>, maps:get(<<"paths">>, OpenAPISpec)))
-    ),
+    #{<<"paths">> := #{<<"/items">> := #{<<"get">> := #{<<"parameters">> := [Parameter]}}}} =
+        OpenAPISpec,
     ?assertMatch(#{<<"deprecated">> := true}, Parameter).
 
 %% Test that non-deprecated parameter does not include the field
@@ -320,10 +316,8 @@ generate_parameter_not_deprecated_test() ->
             [pre_encoded]
         ),
 
-    [Parameter] = maps:get(
-        <<"parameters">>,
-        maps:get(<<"get">>, maps:get(<<"/items">>, maps:get(<<"paths">>, OpenAPISpec)))
-    ),
+    #{<<"paths">> := #{<<"/items">> := #{<<"get">> := #{<<"parameters">> := [Parameter]}}}} =
+        OpenAPISpec,
     ?assertNot(maps:is_key(<<"deprecated">>, Parameter)).
 
 %% Test generating OpenAPI spec from single endpoint
@@ -436,8 +430,7 @@ openapi_with_components_test() ->
 
     ?assertMatch(#{<<"components">> := #{<<"schemas">> := _}}, OpenAPISpec),
 
-    Components = maps:get(<<"components">>, OpenAPISpec),
-    Schemas = maps:get(<<"schemas">>, Components),
+    #{<<"components">> := #{<<"schemas">> := Schemas}} = OpenAPISpec,
 
     ?assert(maps:is_key(<<"User">>, Schemas) orelse maps:is_key(<<"user">>, Schemas)),
     ?assert(
@@ -464,7 +457,7 @@ openapi_without_documentation_test() ->
         ),
 
     #{<<"components">> := #{<<"schemas">> := Schemas}} = OpenAPISpec,
-    UserSchema = maps:get(<<"User">>, Schemas),
+    #{<<"User">> := UserSchema} = Schemas,
 
     %% Verify basic schema structure exists
     ?assertMatch(#{type := <<"object">>}, UserSchema),
@@ -741,22 +734,17 @@ response_header_deprecated_test() ->
             [pre_encoded]
         ),
 
-    Header = maps:get(
-        <<"X-Old-Header">>,
-        maps:get(
-            <<"headers">>,
-            maps:get(
-                <<"200">>,
-                maps:get(
-                    <<"responses">>,
-                    maps:get(
-                        <<"get">>,
-                        maps:get(<<"/items">>, maps:get(<<"paths">>, OpenAPISpec))
-                    )
-                )
-            )
-        )
-    ),
+    #{
+        <<"paths">> := #{
+            <<"/items">> := #{
+                <<"get">> := #{
+                    <<"responses">> := #{
+                        <<"200">> := #{<<"headers">> := #{<<"X-Old-Header">> := Header}}
+                    }
+                }
+            }
+        }
+    } = OpenAPISpec,
     ?assertMatch(#{<<"deprecated">> := true}, Header).
 
 %% Test that non-deprecated response header does not include the field
@@ -779,22 +767,17 @@ response_header_not_deprecated_test() ->
             [pre_encoded]
         ),
 
-    Header = maps:get(
-        <<"X-Rate-Limit">>,
-        maps:get(
-            <<"headers">>,
-            maps:get(
-                <<"200">>,
-                maps:get(
-                    <<"responses">>,
-                    maps:get(
-                        <<"get">>,
-                        maps:get(<<"/items">>, maps:get(<<"paths">>, OpenAPISpec))
-                    )
-                )
-            )
-        )
-    ),
+    #{
+        <<"paths">> := #{
+            <<"/items">> := #{
+                <<"get">> := #{
+                    <<"responses">> := #{
+                        <<"200">> := #{<<"headers">> := #{<<"X-Rate-Limit">> := Header}}
+                    }
+                }
+            }
+        }
+    } = OpenAPISpec,
     ?assertNot(maps:is_key(<<"deprecated">>, Header)).
 
 %% Test adding multiple response headers
@@ -1185,10 +1168,8 @@ request_body_without_description_test() ->
             [pre_encoded]
         ),
 
-    RequestBody = maps:get(
-        <<"requestBody">>,
-        maps:get(<<"post">>, maps:get(<<"/items">>, maps:get(<<"paths">>, OpenAPISpec)))
-    ),
+    #{<<"paths">> := #{<<"/items">> := #{<<"post">> := #{<<"requestBody">> := RequestBody}}}} =
+        OpenAPISpec,
     ?assertNot(maps:is_key(<<"description">>, RequestBody)).
 
 %% Test that info description is included in the generated OpenAPI output
@@ -1226,7 +1207,8 @@ info_without_description_test() ->
             [pre_encoded]
         ),
 
-    ?assertNot(maps:is_key(<<"description">>, maps:get(<<"info">>, OpenAPISpec))).
+    #{<<"info">> := Info} = OpenAPISpec,
+    ?assertNot(maps:is_key(<<"description">>, Info)).
 
 %% Test info extended fields: summary, termsOfService, contact, license
 info_extended_fields_test() ->
@@ -1247,7 +1229,7 @@ info_extended_fields_test() ->
             [pre_encoded]
         ),
 
-    Info = maps:get(<<"info">>, OpenAPISpec),
+    #{<<"info">> := Info} = OpenAPISpec,
     ?assertMatch(#{<<"summary">> := <<"Short summary">>}, Info),
     ?assertMatch(#{<<"termsOfService">> := <<"https://example.com/tos">>}, Info),
     ?assertMatch(#{<<"contact">> := #{<<"name">> := <<"Support">>}}, Info),
@@ -1265,7 +1247,7 @@ info_extended_fields_absent_test() ->
             [pre_encoded]
         ),
 
-    Info = maps:get(<<"info">>, OpenAPISpec),
+    #{<<"info">> := Info} = OpenAPISpec,
     ?assertNot(maps:is_key(<<"summary">>, Info)),
     ?assertNot(maps:is_key(<<"termsOfService">>, Info)),
     ?assertNot(maps:is_key(<<"contact">>, Info)),

--- a/test/openapi_endpoint_test.erl
+++ b/test/openapi_endpoint_test.erl
@@ -859,14 +859,15 @@ response_builder_basic_test() ->
     Endpoint1 = spectra_openapi:endpoint(get, <<"/users">>),
     Endpoint = spectra_openapi:add_response(Endpoint1, Response),
 
-    #{responses := #{200 := AddedResponse}} = Endpoint,
     ?assertMatch(
         #{
-            description := <<"Success">>,
-            schema := {record, user_list},
-            module := ?MODULE
+            responses := #{
+                200 := #{
+                    description := <<"Success">>, schema := {record, user_list}, module := ?MODULE
+                }
+            }
         },
-        AddedResponse
+        Endpoint
     ).
 
 %% Test response builder with custom content type
@@ -883,8 +884,7 @@ response_builder_with_content_type_test() ->
     Endpoint1 = spectra_openapi:endpoint(get, <<"/users">>),
     Endpoint = spectra_openapi:add_response(Endpoint1, Response),
 
-    #{responses := #{200 := AddedResponse}} = Endpoint,
-    ?assertMatch(#{content_type := <<"application/xml">>}, AddedResponse).
+    ?assertMatch(#{responses := #{200 := #{content_type := <<"application/xml">>}}}, Endpoint).
 
 %% Test response builder with headers
 response_builder_with_headers_test() ->
@@ -914,10 +914,9 @@ response_builder_with_headers_test() ->
     Endpoint1 = spectra_openapi:endpoint(get, <<"/users">>),
     Endpoint = spectra_openapi:add_response(Endpoint1, Response),
 
-    #{responses := #{200 := AddedResponse}} = Endpoint,
     ?assertMatch(
-        #{headers := #{<<"X-Rate-Limit">> := _, <<"X-Request-ID">> := _}},
-        AddedResponse
+        #{responses := #{200 := #{headers := #{<<"X-Rate-Limit">> := _, <<"X-Request-ID">> := _}}}},
+        Endpoint
     ).
 
 %% Test response builder with everything
@@ -952,16 +951,19 @@ response_builder_complete_test() ->
     Endpoint1 = spectra_openapi:endpoint(post, <<"/users">>),
     Endpoint = spectra_openapi:add_response(Endpoint1, Response),
 
-    #{responses := #{201 := AddedResponse}} = Endpoint,
     ?assertMatch(
         #{
-            description := <<"User created">>,
-            schema := {record, user},
-            module := ?MODULE,
-            content_type := <<"application/json">>,
-            headers := #{<<"Location">> := _, <<"X-Request-ID">> := _}
+            responses := #{
+                201 := #{
+                    description := <<"User created">>,
+                    schema := {record, user},
+                    module := ?MODULE,
+                    content_type := <<"application/json">>,
+                    headers := #{<<"Location">> := _, <<"X-Request-ID">> := _}
+                }
+            }
         },
-        AddedResponse
+        Endpoint
     ).
 
 %% Test multiple responses built with builder pattern
@@ -1229,11 +1231,17 @@ info_extended_fields_test() ->
             [pre_encoded]
         ),
 
-    #{<<"info">> := Info} = OpenAPISpec,
-    ?assertMatch(#{<<"summary">> := <<"Short summary">>}, Info),
-    ?assertMatch(#{<<"termsOfService">> := <<"https://example.com/tos">>}, Info),
-    ?assertMatch(#{<<"contact">> := #{<<"name">> := <<"Support">>}}, Info),
-    ?assertMatch(#{<<"license">> := #{<<"name">> := <<"MIT">>}}, Info).
+    ?assertMatch(
+        #{
+            <<"info">> := #{
+                <<"summary">> := <<"Short summary">>,
+                <<"termsOfService">> := <<"https://example.com/tos">>,
+                <<"contact">> := #{<<"name">> := <<"Support">>},
+                <<"license">> := #{<<"name">> := <<"MIT">>}
+            }
+        },
+        OpenAPISpec
+    ).
 
 %% Test that absent info fields are not included in output
 info_extended_fields_absent_test() ->

--- a/test/schema_consistency_demo_test.erl
+++ b/test/schema_consistency_demo_test.erl
@@ -31,11 +31,13 @@ atom_vs_tuple_consistency_test() ->
     % Both should be identical and include metadata
     ?assertEqual(DecodedFromTuple, DecodedFromAtom),
 
-    % Verify metadata is present
-    ?assertEqual(<<"User Age">>, maps:get(<<"title">>, DecodedFromAtom)),
-    ?assertEqual(<<"Age of a user in years">>, maps:get(<<"description">>, DecodedFromAtom)),
-    ?assertEqual([18, 25, 42, 65], maps:get(<<"examples">>, DecodedFromAtom)),
-
-    % Verify the schema structure is correct
-    ?assertEqual(<<"integer">>, maps:get(<<"type">>, DecodedFromAtom)),
-    ?assertEqual(0, maps:get(<<"minimum">>, DecodedFromAtom)).
+    ?assertMatch(
+        #{
+            <<"title">> := <<"User Age">>,
+            <<"description">> := <<"Age of a user in years">>,
+            <<"examples">> := [18, 25, 42, 65],
+            <<"type">> := <<"integer">>,
+            <<"minimum">> := 0
+        },
+        DecodedFromAtom
+    ).

--- a/test/sp_type_generators.erl
+++ b/test/sp_type_generators.erl
@@ -83,24 +83,47 @@ shrink_tuple_gen(Fields) ->
         [exactly(#sp_tuple{fields = any})] ++ [exactly(F) || F <- Fields]
     ).
 
+%% Binary field name generator — usually the atom default, occasionally a camelCase alias
+my_json_field_name() ->
+    frequency([
+        {3, ?LET(A, my_atom(), atom_to_binary(A, utf8))},
+        {1,
+            oneof([
+                <<"firstName">>,
+                <<"lastName">>,
+                <<"userId">>,
+                <<"itemId">>,
+                <<"createdAt">>,
+                <<"updatedAt">>
+            ])}
+    ]).
+
 %% Map field generator
 map_field() ->
     ?SIZED(Size, map_field(Size)).
 
 map_field(Size) ->
     oneof([
-        ?LET({Name, Type}, {my_atom(), sp_type(Size)}, #literal_map_field{
-            kind = assoc,
-            name = Name,
-            binary_name = atom_to_binary(Name, utf8),
-            val_type = Type
-        }),
-        ?LET({Name, Type}, {my_atom(), sp_type(Size)}, #literal_map_field{
-            kind = exact,
-            name = Name,
-            binary_name = atom_to_binary(Name, utf8),
-            val_type = Type
-        }),
+        ?LET(
+            {Name, BinaryName, Type},
+            {my_atom(), my_json_field_name(), sp_type(Size)},
+            #literal_map_field{
+                kind = assoc,
+                name = Name,
+                binary_name = BinaryName,
+                val_type = Type
+            }
+        ),
+        ?LET(
+            {Name, BinaryName, Type},
+            {my_atom(), my_json_field_name(), sp_type(Size)},
+            #literal_map_field{
+                kind = exact,
+                name = Name,
+                binary_name = BinaryName,
+                val_type = Type
+            }
+        ),
         ?LET(
             {KeyType, ValueType},
             {sp_type(Size), sp_type(Size)},
@@ -132,12 +155,17 @@ sp_map(Size) ->
         ?LET(
             Fields0,
             vector(Len, map_field(Size)),
-            shrink_map_gen(dedupe_by(fun map_field_key/1, Fields0))
+            shrink_map_gen(
+                dedupe_by(fun map_field_bin_key/1, dedupe_by(fun map_field_key/1, Fields0))
+            )
         )
     ).
 
 map_field_key(#literal_map_field{name = Name}) -> {literal, Name};
 map_field_key(#typed_map_field{key_type = KT}) -> {typed, KT}.
+
+map_field_bin_key(#literal_map_field{binary_name = BN}) -> {literal_bin, BN};
+map_field_bin_key(#typed_map_field{key_type = KT}) -> {typed, KT}.
 
 %% Generator for maps with shrinking support
 shrink_map_gen([]) ->
@@ -155,11 +183,11 @@ sp_rec() ->
 
 sp_rec_field(Size) ->
     ?LET(
-        {FieldName, FieldType},
-        {my_atom(), sp_type(Size)},
+        {FieldName, BinaryName, FieldType},
+        {my_atom(), my_json_field_name(), sp_type(Size)},
         #sp_rec_field{
             name = FieldName,
-            binary_name = atom_to_binary(FieldName, utf8),
+            binary_name = BinaryName,
             type = FieldType
         }
     ).
@@ -172,7 +200,8 @@ sp_rec(Size) ->
             {Name, Fields0},
             {my_atom(), non_empty(vector(Len, sp_rec_field(Size)))},
             begin
-                Fields = dedupe_by(fun(#sp_rec_field{name = FN}) -> FN end, Fields0),
+                Fields1 = dedupe_by(fun(#sp_rec_field{name = FN}) -> FN end, Fields0),
+                Fields = dedupe_by(fun(#sp_rec_field{binary_name = BN}) -> BN end, Fields1),
                 #sp_rec{
                     name = Name,
                     fields = Fields,

--- a/test/spectra_json_schema_test.erl
+++ b/test/spectra_json_schema_test.erl
@@ -445,8 +445,6 @@ record_with_enum_fields_test() ->
         },
         UserWithRoleSchema
     ),
-    %% Verify role field is required
-    ?assert(lists:member(<<"role">>, maps:get(required, UserWithRoleSchema))),
     validate_with_python(UserWithRoleSchema),
 
     %% Record with optional enum field (contains undefined)
@@ -468,8 +466,6 @@ record_with_enum_fields_test() ->
         },
         UserWithOptionalRoleSchema
     ),
-    %% Verify role field is NOT required
-    ?assertNot(lists:member(<<"role">>, maps:get(required, UserWithOptionalRoleSchema))),
     validate_with_python(UserWithOptionalRoleSchema).
 
 %% Test enum type optimization (unions of literals should become single enum)

--- a/test/spectra_transform_tests.erl
+++ b/test/spectra_transform_tests.erl
@@ -34,7 +34,7 @@ injects_function_when_only_export_present_test() ->
     ?assertEqual(Module, TypeInfo#type_info.module),
     %% The injected value reflects the module's declared types.
     Types = TypeInfo#type_info.types,
-    ?assert(maps:is_key({only_export_type, 0}, Types)).
+    ?assertMatch(#{{only_export_type, 0} := _}, Types).
 
 injects_function_when_export_and_spec_present_test() ->
     %% Module opts into the transform and provides -export and a hand-written
@@ -44,7 +44,7 @@ injects_function_when_export_and_spec_present_test() ->
     TypeInfo = Module:'__spectra_type_info__'(),
     ?assertEqual(Module, TypeInfo#type_info.module),
     Types = TypeInfo#type_info.types,
-    ?assert(maps:is_key({only_spec_type, 0}, Types)).
+    ?assertMatch(#{{only_spec_type, 0} := _}, Types).
 
 types_in_forms_does_not_orphan_spectra_doc_on_handwritten_spec_test() ->
     %% Module opts into the transform and fully defines


### PR DESCRIPTION
## Summary

Adds `field_aliases` support to the `-spectra(#{...})` attribute, letting users map Erlang field names (snake_case) to different JSON keys (e.g. camelCase) without changing the Erlang type definition.

```erlang
-spectra(#{field_aliases => #{last_name => <<"lastName">>, first_name => <<"firstName">>}}).
-record(person, {first_name :: binary(), last_name :: binary()}).

-spectra(#{field_aliases => #{last_name => <<"lastName">>}}).
-type person_map() :: #{last_name := binary()}.
```

- Alias is a **strict rename**: encode writes `lastName`, decode requires `lastName`
- Applies to all formats (JSON, DynamoDB JSON, JSON Schema, OpenAPI) automatically, since all formats use `binary_name` for the external key
- Alias keys may be `atom()` or `integer()` (matching `#literal_map_field.name :: atom() | integer()`)
- `only` filtering is applied before aliases, so uniqueness checks operate on the post-filter field set
- Can be combined with doc fields in the same `-spectra` attribute

## Files changed

- **`src/spectra_abstract_code.erl`** — `validate_field_aliases/1`, `apply_field_aliases/2`, `alias_map_field/2`, `alias_rec_field/2`, `check_unique_binary_names/1`; merged duplicate `attach_doc` type clauses into one
- **`test/field_alias_test.erl`** (new) — 23 tests covering records, map types, union branches, type-with-variables, integer keys, round-trips, strict rename enforcement, collision detection, and JSON Schema output
- **`test/sp_type_generators.erl`** — property test generators extended to produce fields with non-default `binary_name` values, exercising alias paths in existing property tests

## Test plan

- [ ] `make format && make build-test`
- [ ] `make proper` (9 property suites)