### PR TITLE
Document field_aliases and extend -spectra() transforms through type refs

### DIFF
--- a/.elp.toml
+++ b/.elp.toml
@@ -121,5 +121,10 @@ ignore_modules = [
     "typed_map_field_json_test",
     "typed_map_field_schema_test",
     "undefined_test",
-    "union_test"
+    "union_test",
+    "field_alias_test",
+    "field_alias_remote_type_a",
+    "field_alias_remote_type_b",
+    "spectra_attr_interaction_test",
+    "spectra_attr_interaction_base"
 ]

--- a/README.md
+++ b/README.md
@@ -397,6 +397,7 @@ The `-spectra()` attribute annotates types, records, and function specs with met
 | `examples` | `[term()]` | Example values (use tuple syntax for records) |
 | `examples_function` | `{module(), atom(), [term()]}` | MFA returning example values — avoids tuple syntax for records |
 | `type_parameters` | `term()` | Passed to codec callbacks; also enables string/binary constraints (see [Type Parameters](#type-parameters)) |
+| `field_aliases` | `#{atom() \| integer() => binary()}` | Map Erlang field names to different JSON key names (see [Field Aliases with `field_aliases`](#field-aliases-with-field_aliases)) |
 | `only` | `[atom()]` | Restrict encoding, decoding, and schema to the listed field names (see [Field Filtering with `only`](#field-filtering-with-only)) |
 
 **Before a `-spec` declaration:**
@@ -483,6 +484,23 @@ The `only` filter propagates through union types, so `t() | undefined` works as 
 > decoded plain maps, and absent from the encoded JSON — the result does not fully conform to the
 > declared Erlang type. This is intentional: `only` is an opt-in escape hatch for controlling the
 > external representation independently of the internal type. Dialyzer will not warn about this.
+
+## Field Aliases with `field_aliases`
+
+The `field_aliases` key in the `-spectra()` attribute renames fields in the external (JSON) representation without changing the Erlang field names. It is useful for mapping snake_case Erlang conventions to camelCase JSON conventions, or any other name transformation.
+
+```erlang
+-spectra(#{field_aliases => #{first_name => <<"firstName">>, last_name => <<"lastName">>}}).
+-record(person, {first_name :: binary(), last_name :: binary()}).
+```
+
+With this definition:
+
+- **Encoding**: `#person{first_name = <<"Alice">>, last_name = <<"Smith">>}` encodes to `{"firstName":"Alice","lastName":"Smith"}`
+- **Decoding**: expects `<<"firstName">>` and `<<"lastName">>` in the JSON — the original atom name is rejected
+- **Schema**: the generated schema uses `firstName` and `lastName` as property names
+
+`field_aliases` works for both records and maps (including integer-keyed maps).
 
 ## OpenAPI Spec
 

--- a/src/spectra.erl
+++ b/src/spectra.erl
@@ -29,7 +29,9 @@
 -type sp_type_meta() :: #{
     doc => type_doc(),
     name => sp_type_reference(),
-    parameters => term()
+    parameters => term(),
+    only => [atom()],
+    field_aliases => #{atom() | integer() => binary()}
 }.
 
 -type sp_function_spec_meta() :: #{

--- a/src/spectra_abstract_code.erl
+++ b/src/spectra_abstract_code.erl
@@ -232,6 +232,8 @@ to the declared Erlang type. This is intentional.
 apply_only(#sp_map{fields = Fields} = Map, Only) ->
     FilteredFields = [F || #literal_map_field{name = N} = F <- Fields, lists:member(N, Only)],
     Map#sp_map{fields = FilteredFields};
+apply_only(#sp_rec{meta = Meta} = Rec, Only) ->
+    Rec#sp_rec{meta = Meta#{only => Only}};
 apply_only(#sp_union{types = Types} = Union, Only) ->
     Union#sp_union{types = [apply_only(T, Only) || T <- Types]};
 apply_only(#sp_type_with_variables{type = Inner} = TypeWithVars, Only) ->

--- a/src/spectra_abstract_code.erl
+++ b/src/spectra_abstract_code.erl
@@ -185,6 +185,8 @@ apply_field_aliases(#sp_remote_type{meta = Meta} = Remote, Aliases) when map_siz
     Remote#sp_remote_type{meta = Meta#{field_aliases => Aliases}};
 apply_field_aliases(#sp_user_type_ref{meta = Meta} = Ref, Aliases) when map_size(Aliases) > 0 ->
     Ref#sp_user_type_ref{meta = Meta#{field_aliases => Aliases}};
+apply_field_aliases(#sp_rec_ref{meta = Meta} = RecRef, Aliases) when map_size(Aliases) > 0 ->
+    RecRef#sp_rec_ref{meta = Meta#{field_aliases => Aliases}};
 apply_field_aliases(Other, _Aliases) ->
     Other.
 
@@ -238,10 +240,12 @@ apply_only(#sp_remote_type{meta = Meta} = Remote, Only) ->
     Remote#sp_remote_type{meta = Meta#{only => Only}};
 apply_only(#sp_user_type_ref{meta = Meta} = Ref, Only) ->
     Ref#sp_user_type_ref{meta = Meta#{only => Only}};
+apply_only(#sp_rec_ref{meta = Meta} = RecRef, Only) ->
+    RecRef#sp_rec_ref{meta = Meta#{only => Only}};
 apply_only(Other, _Only) ->
     Other.
 
--doc "Applies all structural transforms stored in a type-ref meta map (`only`, `field_aliases`) to a resolved type. Call after resolving a `#sp_user_type_ref{}` or `#sp_remote_type{}` to honour transforms declared at the alias site.".
+-doc "Applies all structural transforms stored in a type-ref meta map (`only`, `field_aliases`) to a resolved type. Call after resolving a `#sp_user_type_ref{}`, `#sp_remote_type{}`, or `#sp_rec_ref{}` to honour transforms declared at the alias site.".
 -spec apply_ref_meta(spectra:sp_type(), spectra:sp_type_meta()) -> spectra:sp_type().
 apply_ref_meta(Type, Meta) ->
     OnlyFiltered =

--- a/src/spectra_abstract_code.erl
+++ b/src/spectra_abstract_code.erl
@@ -3,9 +3,10 @@
 -include("../include/spectra_internal.hrl").
 
 -export([
-    types_in_module/1, types_in_module_path/1, types_in_forms/2, apply_only/2, apply_field_aliases/2
+    types_in_module/1, types_in_module_path/1, types_in_forms/2,
+    apply_only/2, apply_field_aliases/2, apply_ref_meta/2
 ]).
--ignore_xref([types_in_module_path/1, apply_only/2, apply_field_aliases/2]).
+-ignore_xref([types_in_module_path/1, apply_only/2, apply_field_aliases/2, apply_ref_meta/2]).
 
 -define(TYPE_INFO_FUNCTION, '__spectra_type_info__').
 
@@ -176,6 +177,10 @@ apply_field_aliases(#sp_union{types = Types} = Union, Aliases) ->
     Union#sp_union{types = [apply_field_aliases(T, Aliases) || T <- Types]};
 apply_field_aliases(#sp_type_with_variables{type = Inner} = TWV, Aliases) ->
     TWV#sp_type_with_variables{type = apply_field_aliases(Inner, Aliases)};
+apply_field_aliases(#sp_remote_type{meta = Meta} = Remote, Aliases) when map_size(Aliases) > 0 ->
+    Remote#sp_remote_type{meta = Meta#{field_aliases => Aliases}};
+apply_field_aliases(#sp_user_type_ref{meta = Meta} = Ref, Aliases) when map_size(Aliases) > 0 ->
+    Ref#sp_user_type_ref{meta = Meta#{field_aliases => Aliases}};
 apply_field_aliases(Other, _Aliases) ->
     Other.
 
@@ -210,9 +215,9 @@ check_unique_binary_names(Names) ->
 Filters the fields of a map type to only those named in `Only`.
 
 Propagates through `#sp_union{}` members so that types like `MyStruct | nil`
-work correctly. `#sp_user_type_ref{}` and `#sp_remote_type{}` nodes are passed
-through unchanged — they resolve at encode/decode time and cannot be filtered
-here without cross-module type resolution.
+work correctly. For `#sp_user_type_ref{}` and `#sp_remote_type{}` nodes the
+filter list is stored in the node's `meta` map and applied after the type is
+resolved at encode/decode/schema time.
 
 **Note:** When `only` is used, the produced or accepted maps may not fully conform
 to the declared Erlang type. This is intentional.
@@ -225,8 +230,23 @@ apply_only(#sp_union{types = Types} = Union, Only) ->
     Union#sp_union{types = [apply_only(T, Only) || T <- Types]};
 apply_only(#sp_type_with_variables{type = Inner} = TypeWithVars, Only) ->
     TypeWithVars#sp_type_with_variables{type = apply_only(Inner, Only)};
+apply_only(#sp_remote_type{meta = Meta} = Remote, Only) ->
+    Remote#sp_remote_type{meta = Meta#{only => Only}};
+apply_only(#sp_user_type_ref{meta = Meta} = Ref, Only) ->
+    Ref#sp_user_type_ref{meta = Meta#{only => Only}};
 apply_only(Other, _Only) ->
     Other.
+
+-doc "Applies all structural transforms stored in a type-ref meta map (`only`, `field_aliases`) to a resolved type. Call after resolving a `#sp_user_type_ref{}` or `#sp_remote_type{}` to honour transforms declared at the alias site.".
+-spec apply_ref_meta(spectra:sp_type(), spectra:sp_type_meta()) -> spectra:sp_type().
+apply_ref_meta(Type, Meta) ->
+    OnlyFiltered =
+        case Meta of
+            #{only := Only} -> apply_only(Type, Only);
+            _ -> Type
+        end,
+    Aliases = maps:get(field_aliases, Meta, #{}),
+    apply_field_aliases(OnlyFiltered, Aliases).
 
 -spec apply_type_parameters(spectra:sp_type(), map()) -> spectra:sp_type().
 apply_type_parameters(Type, #{type_parameters := Params}) ->

--- a/src/spectra_abstract_code.erl
+++ b/src/spectra_abstract_code.erl
@@ -3,8 +3,12 @@
 -include("../include/spectra_internal.hrl").
 
 -export([
-    types_in_module/1, types_in_module_path/1, types_in_forms/2,
-    apply_only/2, apply_field_aliases/2, apply_ref_meta/2
+    types_in_module/1,
+    types_in_module_path/1,
+    types_in_forms/2,
+    apply_only/2,
+    apply_field_aliases/2,
+    apply_ref_meta/2
 ]).
 -ignore_xref([types_in_module_path/1, apply_only/2, apply_field_aliases/2, apply_ref_meta/2]).
 

--- a/src/spectra_abstract_code.erl
+++ b/src/spectra_abstract_code.erl
@@ -173,20 +173,29 @@ apply_field_aliases(#sp_map{fields = Fields} = Map, Aliases) ->
     Updated = [alias_map_field(F, Aliases) || F <- Fields],
     check_unique_binary_names([BN || #literal_map_field{binary_name = BN} <- Updated]),
     Map#sp_map{fields = Updated};
-apply_field_aliases(#sp_rec{fields = Fields} = Rec, Aliases) ->
+apply_field_aliases(#sp_rec{fields = Fields, meta = Meta} = Rec, Aliases) ->
     Updated = [alias_rec_field(F, Aliases) || F <- Fields],
-    check_unique_binary_names([BN || #sp_rec_field{binary_name = BN} <- Updated]),
+    Only = maps:get(only, Meta, all),
+    IncludedNames = [
+        BN
+     || #sp_rec_field{binary_name = BN, name = N} <- Updated,
+        Only =:= all orelse lists:member(N, Only)
+    ],
+    check_unique_binary_names(IncludedNames),
     Rec#sp_rec{fields = Updated};
 apply_field_aliases(#sp_union{types = Types} = Union, Aliases) ->
     Union#sp_union{types = [apply_field_aliases(T, Aliases) || T <- Types]};
 apply_field_aliases(#sp_type_with_variables{type = Inner} = TWV, Aliases) ->
     TWV#sp_type_with_variables{type = apply_field_aliases(Inner, Aliases)};
 apply_field_aliases(#sp_remote_type{meta = Meta} = Remote, Aliases) when map_size(Aliases) > 0 ->
-    Remote#sp_remote_type{meta = Meta#{field_aliases => Aliases}};
+    Merged = maps:merge(maps:get(field_aliases, Meta, #{}), Aliases),
+    Remote#sp_remote_type{meta = Meta#{field_aliases => Merged}};
 apply_field_aliases(#sp_user_type_ref{meta = Meta} = Ref, Aliases) when map_size(Aliases) > 0 ->
-    Ref#sp_user_type_ref{meta = Meta#{field_aliases => Aliases}};
+    Merged = maps:merge(maps:get(field_aliases, Meta, #{}), Aliases),
+    Ref#sp_user_type_ref{meta = Meta#{field_aliases => Merged}};
 apply_field_aliases(#sp_rec_ref{meta = Meta} = RecRef, Aliases) when map_size(Aliases) > 0 ->
-    RecRef#sp_rec_ref{meta = Meta#{field_aliases => Aliases}};
+    Merged = maps:merge(maps:get(field_aliases, Meta, #{}), Aliases),
+    RecRef#sp_rec_ref{meta = Meta#{field_aliases => Merged}};
 apply_field_aliases(Other, _Aliases) ->
     Other.
 
@@ -228,22 +237,30 @@ resolved at encode/decode/schema time.
 **Note:** When `only` is used, the produced or accepted maps may not fully conform
 to the declared Erlang type. This is intentional.
 """.
+-spec intersect_only([atom()], [atom()] | all) -> [atom()].
+intersect_only(New, all) -> New;
+intersect_only(New, Existing) -> [F || F <- New, lists:member(F, Existing)].
+
 -spec apply_only(spectra:sp_type(), [atom()]) -> spectra:sp_type().
 apply_only(#sp_map{fields = Fields} = Map, Only) ->
     FilteredFields = [F || #literal_map_field{name = N} = F <- Fields, lists:member(N, Only)],
     Map#sp_map{fields = FilteredFields};
 apply_only(#sp_rec{meta = Meta} = Rec, Only) ->
-    Rec#sp_rec{meta = Meta#{only => Only}};
+    Intersected = intersect_only(Only, maps:get(only, Meta, all)),
+    Rec#sp_rec{meta = Meta#{only => Intersected}};
 apply_only(#sp_union{types = Types} = Union, Only) ->
     Union#sp_union{types = [apply_only(T, Only) || T <- Types]};
 apply_only(#sp_type_with_variables{type = Inner} = TypeWithVars, Only) ->
     TypeWithVars#sp_type_with_variables{type = apply_only(Inner, Only)};
 apply_only(#sp_remote_type{meta = Meta} = Remote, Only) ->
-    Remote#sp_remote_type{meta = Meta#{only => Only}};
+    Intersected = intersect_only(Only, maps:get(only, Meta, all)),
+    Remote#sp_remote_type{meta = Meta#{only => Intersected}};
 apply_only(#sp_user_type_ref{meta = Meta} = Ref, Only) ->
-    Ref#sp_user_type_ref{meta = Meta#{only => Only}};
+    Intersected = intersect_only(Only, maps:get(only, Meta, all)),
+    Ref#sp_user_type_ref{meta = Meta#{only => Intersected}};
 apply_only(#sp_rec_ref{meta = Meta} = RecRef, Only) ->
-    RecRef#sp_rec_ref{meta = Meta#{only => Only}};
+    Intersected = intersect_only(Only, maps:get(only, Meta, all)),
+    RecRef#sp_rec_ref{meta = Meta#{only => Intersected}};
 apply_only(Other, _Only) ->
     Other.
 

--- a/src/spectra_abstract_code.erl
+++ b/src/spectra_abstract_code.erl
@@ -245,8 +245,10 @@ apply_ref_meta(Type, Meta) ->
             #{only := Only} -> apply_only(Type, Only);
             _ -> Type
         end,
-    Aliases = maps:get(field_aliases, Meta, #{}),
-    apply_field_aliases(OnlyFiltered, Aliases).
+    case Meta of
+        #{field_aliases := Aliases} -> apply_field_aliases(OnlyFiltered, Aliases);
+        _ -> OnlyFiltered
+    end.
 
 -spec apply_type_parameters(spectra:sp_type(), map()) -> spectra:sp_type().
 apply_type_parameters(Type, #{type_parameters := Params}) ->

--- a/src/spectra_json.erl
+++ b/src/spectra_json.erl
@@ -55,7 +55,10 @@ to_json(
     of
         continue ->
             Type = spectra_type_info:get_type(TypeInfo, TypeName, Arity),
-            TypeWithoutVars = spectra_util:apply_args(TypeInfo, Type, Args),
+            TypeWithoutVars0 = spectra_util:apply_args(TypeInfo, Type, Args),
+            TypeWithoutVars = spectra_abstract_code:apply_ref_meta(
+                TypeWithoutVars0, UserTypeRef#sp_user_type_ref.meta
+            ),
             to_json(TypeInfo, TypeWithoutVars, Data, Config);
         Result ->
             Result
@@ -71,8 +74,11 @@ to_json(
         continue ->
             RemoteTypeInfo = spectra_module_types:get(Module, Config),
             RemoteType = spectra_type_info:get_type(RemoteTypeInfo, TypeName, TypeArity),
-            TypeResolved = spectra_type:propagate_params(
+            TypeResolved0 = spectra_type:propagate_params(
                 RemoteRef, spectra_util:apply_args(RemoteTypeInfo, RemoteType, Args)
+            ),
+            TypeResolved = spectra_abstract_code:apply_ref_meta(
+                TypeResolved0, RemoteRef#sp_remote_type.meta
             ),
             to_json(RemoteTypeInfo, TypeResolved, Data, Config);
         Result ->
@@ -531,7 +537,10 @@ do_from_json(
     of
         continue ->
             Type = spectra_type_info:get_type(TypeInfo, TypeName, Arity),
-            TypeWithoutVars = spectra_util:apply_args(TypeInfo, Type, Args),
+            TypeWithoutVars0 = spectra_util:apply_args(TypeInfo, Type, Args),
+            TypeWithoutVars = spectra_abstract_code:apply_ref_meta(
+                TypeWithoutVars0, UserTypeRef#sp_user_type_ref.meta
+            ),
             do_from_json(TypeInfo, TypeWithoutVars, Json, Config);
         Result ->
             Result
@@ -547,8 +556,11 @@ do_from_json(
         continue ->
             RemoteTypeInfo = spectra_module_types:get(Module, Config),
             RemoteType = spectra_type_info:get_type(RemoteTypeInfo, TypeName, TypeArity),
-            TypeResolved = spectra_type:propagate_params(
+            TypeResolved0 = spectra_type:propagate_params(
                 RemoteRef, spectra_util:apply_args(RemoteTypeInfo, RemoteType, Args)
+            ),
+            TypeResolved = spectra_abstract_code:apply_ref_meta(
+                TypeResolved0, RemoteRef#sp_remote_type.meta
             ),
             do_from_json(RemoteTypeInfo, TypeResolved, Json, Config);
         Result ->

--- a/src/spectra_json.erl
+++ b/src/spectra_json.erl
@@ -100,7 +100,10 @@ to_json(
         spectra_codec:try_codec_encode(json, TypeInfo, Module, TypeRef, RecordRef, Record, Config)
     of
         continue ->
-            RecordType = spectra_type_info:get_record(TypeInfo, RecordName),
+            RecordType0 = spectra_type_info:get_record(TypeInfo, RecordName),
+            RecordType = spectra_abstract_code:apply_ref_meta(
+                RecordType0, RecordRef#sp_rec_ref.meta
+            ),
             record_to_json(TypeInfo, RecordType, Record, TypeArgs, Config);
         Result ->
             Result
@@ -580,7 +583,10 @@ do_from_json(
     Module = spectra_type_info:get_module(TypeInfo),
     case spectra_codec:try_codec_decode(json, TypeInfo, Module, TypeRef, RecordRef, Json, Config) of
         continue ->
-            RecordType = spectra_type_info:get_record(TypeInfo, RecordName),
+            RecordType0 = spectra_type_info:get_record(TypeInfo, RecordName),
+            RecordType = spectra_abstract_code:apply_ref_meta(
+                RecordType0, RecordRef#sp_rec_ref.meta
+            ),
             record_from_json(TypeInfo, RecordType, Json, TypeArgs, Config);
         Result ->
             Result

--- a/src/spectra_json.erl
+++ b/src/spectra_json.erl
@@ -101,9 +101,10 @@ to_json(
     of
         continue ->
             RecordType0 = spectra_type_info:get_record(TypeInfo, RecordName),
-            RecordType = spectra_abstract_code:apply_ref_meta(
-                RecordType0, RecordRef#sp_rec_ref.meta
-            ),
+            #sp_rec{} =
+                RecordType = spectra_abstract_code:apply_ref_meta(
+                    RecordType0, RecordRef#sp_rec_ref.meta
+                ),
             record_to_json(TypeInfo, RecordType, Record, TypeArgs, Config);
         Result ->
             Result
@@ -445,7 +446,8 @@ record_to_json(
     #sp_rec{
         name = RecordName,
         fields = Fields,
-        arity = Arity
+        arity = Arity,
+        meta = Meta
     },
     Record,
     TypeArgs,
@@ -457,7 +459,18 @@ record_to_json(
 ->
     [RecordName | FieldsData] = tuple_to_list(Record),
     RecFieldTypes = spectra_util:record_replace_vars(Fields, TypeArgs),
-    RecFieldTypesWithData = lists:zip(RecFieldTypes, FieldsData),
+    RecFieldTypesWithData0 = lists:zip(RecFieldTypes, FieldsData),
+    RecFieldTypesWithData =
+        case Meta of
+            #{only := Only} ->
+                [
+                    {F, D}
+                 || {#sp_rec_field{name = N} = F, D} <- RecFieldTypesWithData0,
+                    lists:member(N, Only)
+                ];
+            _ ->
+                RecFieldTypesWithData0
+        end,
     do_record_to_json(TypeInfo, RecFieldTypesWithData, Config);
 record_to_json(_TypeInfo, RecordType, Record, TypeArgs, _Config) ->
     {error, [sp_error:type_mismatch(RecordType, Record, #{type_args => TypeArgs})]}.
@@ -584,9 +597,10 @@ do_from_json(
     case spectra_codec:try_codec_decode(json, TypeInfo, Module, TypeRef, RecordRef, Json, Config) of
         continue ->
             RecordType0 = spectra_type_info:get_record(TypeInfo, RecordName),
-            RecordType = spectra_abstract_code:apply_ref_meta(
-                RecordType0, RecordRef#sp_rec_ref.meta
-            ),
+            #sp_rec{} =
+                RecordType = spectra_abstract_code:apply_ref_meta(
+                    RecordType0, RecordRef#sp_rec_ref.meta
+                ),
             record_from_json(TypeInfo, RecordType, Json, TypeArgs, Config);
         Result ->
             Result
@@ -1131,33 +1145,42 @@ record_from_json(
     Config :: spectra:sp_config()
 ) ->
     {ok, dynamic()} | {error, [spectra:error()]}.
-do_record_from_json(TypeInfo, #sp_rec{name = RecordName, fields = RecordInfo}, Json, Config) when
+do_record_from_json(
+    TypeInfo, #sp_rec{name = RecordName, fields = RecordInfo, meta = Meta}, Json, Config
+) when
     is_map(Json)
 ->
+    Only = maps:get(only, Meta, all),
     Fun = fun(
         #sp_rec_field{name = FieldName, binary_name = BinaryName, type = FieldType} = Type,
         {FieldsAcc, ConsumedFields}
     ) ->
-        case Json of
-            #{BinaryName := RecordFieldData} ->
-                case do_from_json(TypeInfo, FieldType, RecordFieldData, Config) of
-                    {ok, FieldJson} ->
-                        {ok, {[FieldJson | FieldsAcc], [BinaryName | ConsumedFields]}};
-                    {error, Errs} ->
-                        Errs2 =
-                            lists:map(
-                                fun(Err) -> sp_error:append_location(Err, FieldName) end,
-                                Errs
-                            ),
-                        {error, Errs2}
-                end;
-            #{} ->
-                case spectra_type:can_be_missing(TypeInfo, FieldType) of
-                    {true, MissingValue} ->
-                        {ok, {[MissingValue | FieldsAcc], ConsumedFields}};
-                    false ->
-                        RemainingJson = maps:without(ConsumedFields, Json),
-                        {error, [sp_error:missing_data(Type, RemainingJson, [FieldName])]}
+        IsIncluded = Only =:= all orelse lists:member(FieldName, Only),
+        case IsIncluded of
+            false ->
+                {ok, {[undefined | FieldsAcc], ConsumedFields}};
+            true ->
+                case Json of
+                    #{BinaryName := RecordFieldData} ->
+                        case do_from_json(TypeInfo, FieldType, RecordFieldData, Config) of
+                            {ok, FieldJson} ->
+                                {ok, {[FieldJson | FieldsAcc], [BinaryName | ConsumedFields]}};
+                            {error, Errs} ->
+                                Errs2 =
+                                    lists:map(
+                                        fun(Err) -> sp_error:append_location(Err, FieldName) end,
+                                        Errs
+                                    ),
+                                {error, Errs2}
+                        end;
+                    #{} ->
+                        case spectra_type:can_be_missing(TypeInfo, FieldType) of
+                            {true, MissingValue} ->
+                                {ok, {[MissingValue | FieldsAcc], ConsumedFields}};
+                            false ->
+                                RemainingJson = maps:without(ConsumedFields, Json),
+                                {error, [sp_error:missing_data(Type, RemainingJson, [FieldName])]}
+                        end
                 end
         end
     end,

--- a/src/spectra_json_schema.erl
+++ b/src/spectra_json_schema.erl
@@ -118,7 +118,10 @@ do_to_schema(TypeInfo, #sp_rec_ref{record_name = N} = RecordRef, Config) ->
         spectra_codec:try_codec_schema(json_schema, TypeInfo, Module, TypeRef, RecordRef, Config)
     of
         continue ->
-            RecordType = spectra_type_info:get_record(TypeInfo, N),
+            RecordType0 = spectra_type_info:get_record(TypeInfo, N),
+            RecordType = spectra_abstract_code:apply_ref_meta(
+                RecordType0, RecordRef#sp_rec_ref.meta
+            ),
             Schema = record_to_schema_internal(TypeInfo, RecordType, Config),
             merge_type_doc_into_schema(TypeInfo, RecordType, Schema, Config);
         Schema ->

--- a/src/spectra_json_schema.erl
+++ b/src/spectra_json_schema.erl
@@ -119,9 +119,10 @@ do_to_schema(TypeInfo, #sp_rec_ref{record_name = N} = RecordRef, Config) ->
     of
         continue ->
             RecordType0 = spectra_type_info:get_record(TypeInfo, N),
-            RecordType = spectra_abstract_code:apply_ref_meta(
-                RecordType0, RecordRef#sp_rec_ref.meta
-            ),
+            #sp_rec{} =
+                RecordType = spectra_abstract_code:apply_ref_meta(
+                    RecordType0, RecordRef#sp_rec_ref.meta
+                ),
             Schema = record_to_schema_internal(TypeInfo, RecordType, Config),
             merge_type_doc_into_schema(TypeInfo, RecordType, Schema, Config);
         Schema ->
@@ -356,8 +357,13 @@ record_to_schema_internal(TypeInfo, #sp_rec{} = Record, Config) ->
 
 -spec record_fields_to_schema(spectra:type_info(), #sp_rec{}, spectra:sp_config()) ->
     json_schema_object().
-record_fields_to_schema(TypeInfo, #sp_rec{fields = Fields}, Config) ->
-    {Properties, Required} = process_record_fields(TypeInfo, Fields, #{}, [], Config),
+record_fields_to_schema(TypeInfo, #sp_rec{fields = Fields, meta = Meta}, Config) ->
+    FilteredFields =
+        case Meta of
+            #{only := Only} -> [F || #sp_rec_field{name = N} = F <- Fields, lists:member(N, Only)];
+            _ -> Fields
+        end,
+    {Properties, Required} = process_record_fields(TypeInfo, FilteredFields, #{}, [], Config),
     #{
         type => <<"object">>,
         properties => Properties,

--- a/src/spectra_json_schema.erl
+++ b/src/spectra_json_schema.erl
@@ -83,7 +83,10 @@ do_to_schema(
     of
         continue ->
             Type = spectra_type_info:get_type(TypeInfo, N, Arity),
-            TypeWithoutVars = spectra_util:apply_args(TypeInfo, Type, Args),
+            TypeWithoutVars0 = spectra_util:apply_args(TypeInfo, Type, Args),
+            TypeWithoutVars = spectra_abstract_code:apply_ref_meta(
+                TypeWithoutVars0, UserTypeRef#sp_user_type_ref.meta
+            ),
             do_to_schema(TypeInfo, TypeWithoutVars, Config);
         Schema ->
             Schema
@@ -98,8 +101,11 @@ do_to_schema(
         continue ->
             RemoteTypeInfo = spectra_module_types:get(Mod, Config),
             RemoteType = spectra_type_info:get_type(RemoteTypeInfo, TypeName, Arity),
-            TypeResolved = spectra_type:propagate_params(
+            TypeResolved0 = spectra_type:propagate_params(
                 RemoteRef, spectra_util:apply_args(RemoteTypeInfo, RemoteType, Args)
+            ),
+            TypeResolved = spectra_abstract_code:apply_ref_meta(
+                TypeResolved0, RemoteRef#sp_remote_type.meta
             ),
             do_to_schema(RemoteTypeInfo, TypeResolved, Config);
         Schema ->

--- a/src/spectra_util.erl
+++ b/src/spectra_util.erl
@@ -220,11 +220,12 @@ type_replace_vars(TypeInfo, #sp_type_with_variables{type = Type}, NamedTypes) ->
                         Fields
                     )
             };
-        #sp_rec_ref{record_name = RecordName, field_types = RefFieldTypes} ->
+        #sp_rec_ref{record_name = RecordName, field_types = RefFieldTypes, meta = RefMeta} ->
             {ok, #sp_rec{fields = Fields} = Rec} = spectra_type_info:find_record(
                 TypeInfo, RecordName
             ),
-            NewRec = Rec#sp_rec{fields = record_replace_vars(Fields, RefFieldTypes)},
+            NewRec0 = Rec#sp_rec{fields = record_replace_vars(Fields, RefFieldTypes)},
+            NewRec = spectra_abstract_code:apply_ref_meta(NewRec0, RefMeta),
             type_replace_vars(TypeInfo, NewRec, NamedTypes);
         _ ->
             type_replace_vars(TypeInfo, Type, NamedTypes)

--- a/test/field_alias_remote_type_a.erl
+++ b/test/field_alias_remote_type_a.erl
@@ -1,0 +1,5 @@
+-module(field_alias_remote_type_a).
+
+-export_type([t/0]).
+
+-type t() :: #{first_name := binary(), last_name := binary()} | undefined.

--- a/test/field_alias_remote_type_b.erl
+++ b/test/field_alias_remote_type_b.erl
@@ -1,0 +1,6 @@
+-module(field_alias_remote_type_b).
+
+-export_type([my_t/0]).
+
+-spectra(#{field_aliases => #{first_name => <<"firstName">>}}).
+-type my_t() :: field_alias_remote_type_a:t().

--- a/test/field_alias_test.erl
+++ b/test/field_alias_test.erl
@@ -325,7 +325,9 @@ remote_type_roundtrip_test() ->
     Value = #{first_name => <<"Alice">>, last_name => <<"Smith">>},
     {ok, JsonIO} = spectra:encode(json, field_alias_remote_type_b, {type, my_t, 0}, Value),
     Json = iolist_to_binary(JsonIO),
-    ?assertEqual({ok, Value}, spectra:decode(json, field_alias_remote_type_b, {type, my_t, 0}, Json)).
+    ?assertEqual(
+        {ok, Value}, spectra:decode(json, field_alias_remote_type_b, {type, my_t, 0}, Json)
+    ).
 
 remote_type_schema_test() ->
     Schema = spectra:schema(
@@ -343,7 +345,9 @@ local_type_ref_encode_test() ->
     ?assertEqual(
         {ok, #{<<"firstName">> => <<"Alice">>, <<"last_name">> => <<"Smith">>}},
         spectra:encode(
-            json, ?MODULE, {type, aliased_person, 0},
+            json,
+            ?MODULE,
+            {type, aliased_person, 0},
             #{first_name => <<"Alice">>, last_name => <<"Smith">>},
             [pre_encoded]
         )
@@ -353,7 +357,9 @@ local_type_ref_decode_test() ->
     ?assertEqual(
         {ok, #{first_name => <<"Alice">>, last_name => <<"Smith">>}},
         spectra:decode(
-            json, ?MODULE, {type, aliased_person, 0},
+            json,
+            ?MODULE,
+            {type, aliased_person, 0},
             #{<<"firstName">> => <<"Alice">>, <<"last_name">> => <<"Smith">>},
             [pre_decoded]
         )
@@ -379,7 +385,9 @@ only_local_ref_encode_test() ->
     ?assertEqual(
         {ok, #{<<"first_name">> => <<"Alice">>}},
         spectra:encode(
-            json, ?MODULE, {type, only_local_ref, 0},
+            json,
+            ?MODULE,
+            {type, only_local_ref, 0},
             #{first_name => <<"Alice">>, last_name => <<"Smith">>},
             [pre_encoded]
         )
@@ -389,7 +397,9 @@ only_local_ref_decode_test() ->
     ?assertEqual(
         {ok, #{first_name => <<"Alice">>}},
         spectra:decode(
-            json, ?MODULE, {type, only_local_ref, 0},
+            json,
+            ?MODULE,
+            {type, only_local_ref, 0},
             #{<<"first_name">> => <<"Alice">>},
             [pre_decoded]
         )
@@ -401,7 +411,9 @@ only_remote_ref_encode_test() ->
     ?assertEqual(
         {ok, #{<<"first_name">> => <<"Alice">>}},
         spectra:encode(
-            json, ?MODULE, {type, only_remote_ref, 0},
+            json,
+            ?MODULE,
+            {type, only_remote_ref, 0},
             #{first_name => <<"Alice">>, last_name => <<"Smith">>},
             [pre_encoded]
         )
@@ -411,7 +423,9 @@ only_remote_ref_decode_test() ->
     ?assertEqual(
         {ok, #{first_name => <<"Alice">>}},
         spectra:decode(
-            json, ?MODULE, {type, only_remote_ref, 0},
+            json,
+            ?MODULE,
+            {type, only_remote_ref, 0},
             #{<<"first_name">> => <<"Alice">>},
             [pre_decoded]
         )

--- a/test/field_alias_test.erl
+++ b/test/field_alias_test.erl
@@ -331,16 +331,8 @@ remote_type_schema_test() ->
     Schema = spectra:schema(
         json_schema, field_alias_remote_type_b, {type, my_t, 0}, [pre_encoded]
     ),
-    %% Locate the object branch (may be top-level or inside oneOf/anyOf).
     %% pre_encoded returns Erlang maps with atom keys.
-    MapBranch =
-        case Schema of
-            #{oneOf := Branches} ->
-                hd([B || B = #{type := <<"object">>} <- Branches]);
-            #{type := <<"object">>} ->
-                Schema
-        end,
-    #{properties := Props} = MapBranch,
+    #{properties := Props} = Schema,
     ?assert(maps:is_key(<<"firstName">>, Props)),
     ?assert(maps:is_key(<<"last_name">>, Props)),
     ?assertNot(maps:is_key(<<"first_name">>, Props)).

--- a/test/field_alias_test.erl
+++ b/test/field_alias_test.erl
@@ -33,6 +33,13 @@
 -spectra(#{field_aliases => #{first_name => <<"firstName">>}}).
 -type aliased_person() :: base_person().
 
+%% Record ref: alias-site field_aliases applied to a type that resolves to #sp_rec_ref{}.
+%% employee has no definition-site aliases; aliases are applied at the type reference site.
+-record(employee, {emp_id :: integer(), full_name :: binary()}).
+
+-spectra(#{field_aliases => #{emp_id => <<"employeeId">>, full_name => <<"fullName">>}}).
+-type employee_ref() :: #employee{}.
+
 %% only through a local type reference
 -spectra(#{only => [first_name]}).
 -type only_local_ref() :: base_person().
@@ -430,3 +437,43 @@ only_remote_ref_decode_test() ->
             [pre_decoded]
         )
     ).
+
+%% Record ref: field_aliases applied via a type that resolves to #sp_rec_ref{}.
+
+rec_ref_alias_encode_test() ->
+    ?assertEqual(
+        {ok, #{<<"employeeId">> => 42, <<"fullName">> => <<"Alice">>}},
+        spectra:encode(
+            json,
+            ?MODULE,
+            {type, employee_ref, 0},
+            #employee{emp_id = 42, full_name = <<"Alice">>},
+            [pre_encoded]
+        )
+    ).
+
+rec_ref_alias_decode_test() ->
+    ?assertEqual(
+        {ok, #employee{emp_id = 42, full_name = <<"Alice">>}},
+        spectra:decode(
+            json,
+            ?MODULE,
+            {type, employee_ref, 0},
+            #{<<"employeeId">> => 42, <<"fullName">> => <<"Alice">>},
+            [pre_decoded]
+        )
+    ).
+
+rec_ref_alias_roundtrip_test() ->
+    Original = #employee{emp_id = 1, full_name = <<"Bob">>},
+    {ok, Json} = spectra:encode(json, ?MODULE, {type, employee_ref, 0}, Original, [pre_encoded]),
+    ?assertEqual(
+        {ok, Original}, spectra:decode(json, ?MODULE, {type, employee_ref, 0}, Json, [pre_decoded])
+    ).
+
+rec_ref_alias_schema_test() ->
+    SchemaJson = spectra:schema(json_schema, ?MODULE, {type, employee_ref, 0}),
+    Schema = json:decode(iolist_to_binary(SchemaJson)),
+    ?assertMatch(#{<<"properties">> := #{<<"employeeId">> := _, <<"fullName">> := _}}, Schema),
+    ?assertNot(maps:is_key(<<"emp_id">>, maps:get(<<"properties">>, Schema))),
+    ?assertNot(maps:is_key(<<"full_name">>, maps:get(<<"properties">>, Schema))).

--- a/test/field_alias_test.erl
+++ b/test/field_alias_test.erl
@@ -40,6 +40,10 @@
 -spectra(#{field_aliases => #{emp_id => <<"employeeId">>, full_name => <<"fullName">>}}).
 -type employee_ref() :: #employee{}.
 
+%% only through a record ref: expose just emp_id.
+-spectra(#{only => [emp_id]}).
+-type employee_id_only() :: #employee{}.
+
 %% only through a local type reference
 -spectra(#{only => [first_name]}).
 -type only_local_ref() :: base_person().
@@ -476,4 +480,36 @@ rec_ref_alias_schema_test() ->
     Schema = json:decode(iolist_to_binary(SchemaJson)),
     ?assertMatch(#{<<"properties">> := #{<<"employeeId">> := _, <<"fullName">> := _}}, Schema),
     ?assertNot(maps:is_key(<<"emp_id">>, maps:get(<<"properties">>, Schema))),
+    ?assertNot(maps:is_key(<<"full_name">>, maps:get(<<"properties">>, Schema))).
+
+%% only through a record ref: expose just emp_id.
+
+only_rec_ref_encode_test() ->
+    ?assertEqual(
+        {ok, #{<<"emp_id">> => 42}},
+        spectra:encode(
+            json,
+            ?MODULE,
+            {type, employee_id_only, 0},
+            #employee{emp_id = 42, full_name = <<"Alice">>},
+            [pre_encoded]
+        )
+    ).
+
+only_rec_ref_decode_test() ->
+    ?assertEqual(
+        {ok, #employee{emp_id = 42, full_name = undefined}},
+        spectra:decode(
+            json,
+            ?MODULE,
+            {type, employee_id_only, 0},
+            #{<<"emp_id">> => 42},
+            [pre_decoded]
+        )
+    ).
+
+only_rec_ref_schema_test() ->
+    SchemaJson = spectra:schema(json_schema, ?MODULE, {type, employee_id_only, 0}),
+    Schema = json:decode(iolist_to_binary(SchemaJson)),
+    ?assertMatch(#{<<"properties">> := #{<<"emp_id">> := _}}, Schema),
     ?assertNot(maps:is_key(<<"full_name">>, maps:get(<<"properties">>, Schema))).

--- a/test/field_alias_test.erl
+++ b/test/field_alias_test.erl
@@ -27,6 +27,20 @@
 -type named(T) :: #{name := T}.
 -type named_binary() :: named(binary()).
 
+%% Local type reference: alias applied at the alias site, not the definition site.
+-type base_person() :: #{first_name := binary(), last_name := binary()} | undefined.
+
+-spectra(#{field_aliases => #{first_name => <<"firstName">>}}).
+-type aliased_person() :: base_person().
+
+%% only through a local type reference
+-spectra(#{only => [first_name]}).
+-type only_local_ref() :: base_person().
+
+%% only through a remote type reference
+-spectra(#{only => [first_name]}).
+-type only_remote_ref() :: field_alias_remote_type_a:t().
+
 record_encode_test() ->
     ?assertEqual(
         {ok, #{<<"firstName">> => <<"John">>, <<"lastName">> => <<"Smith">>}},
@@ -266,4 +280,147 @@ type_with_variables_alias_decode_test() ->
         spectra:decode(json, ?MODULE, {type, named_binary, 0}, #{<<"fullName">> => <<"Alice">>}, [
             pre_decoded
         ])
+    ).
+
+%% Remote type aliasing: field_aliases on a type that is defined in another module.
+%% Module B aliases first_name => <<"firstName">> on a:t() which is #{first_name, last_name} | undefined.
+
+remote_type_encode_test() ->
+    ?assertEqual(
+        {ok, #{<<"firstName">> => <<"Alice">>, <<"last_name">> => <<"Smith">>}},
+        spectra:encode(
+            json,
+            field_alias_remote_type_b,
+            {type, my_t, 0},
+            #{first_name => <<"Alice">>, last_name => <<"Smith">>},
+            [pre_encoded]
+        )
+    ).
+
+remote_type_decode_test() ->
+    ?assertEqual(
+        {ok, #{first_name => <<"Alice">>, last_name => <<"Smith">>}},
+        spectra:decode(
+            json,
+            field_alias_remote_type_b,
+            {type, my_t, 0},
+            #{<<"firstName">> => <<"Alice">>, <<"last_name">> => <<"Smith">>},
+            [pre_decoded]
+        )
+    ).
+
+remote_type_undefined_branch_test() ->
+    ?assertEqual(
+        {ok, undefined},
+        spectra:decode(
+            json,
+            field_alias_remote_type_b,
+            {type, my_t, 0},
+            null,
+            [pre_decoded]
+        )
+    ).
+
+remote_type_roundtrip_test() ->
+    Value = #{first_name => <<"Alice">>, last_name => <<"Smith">>},
+    {ok, JsonIO} = spectra:encode(json, field_alias_remote_type_b, {type, my_t, 0}, Value),
+    Json = iolist_to_binary(JsonIO),
+    ?assertEqual({ok, Value}, spectra:decode(json, field_alias_remote_type_b, {type, my_t, 0}, Json)).
+
+remote_type_schema_test() ->
+    Schema = spectra:schema(
+        json_schema, field_alias_remote_type_b, {type, my_t, 0}, [pre_encoded]
+    ),
+    %% Locate the object branch (may be top-level or inside oneOf/anyOf).
+    %% pre_encoded returns Erlang maps with atom keys.
+    MapBranch =
+        case Schema of
+            #{oneOf := Branches} ->
+                hd([B || B = #{type := <<"object">>} <- Branches]);
+            #{type := <<"object">>} ->
+                Schema
+        end,
+    #{properties := Props} = MapBranch,
+    ?assert(maps:is_key(<<"firstName">>, Props)),
+    ?assert(maps:is_key(<<"last_name">>, Props)),
+    ?assertNot(maps:is_key(<<"first_name">>, Props)).
+
+%% Local type reference aliasing: alias applied in the same module at the alias site.
+
+local_type_ref_encode_test() ->
+    ?assertEqual(
+        {ok, #{<<"firstName">> => <<"Alice">>, <<"last_name">> => <<"Smith">>}},
+        spectra:encode(
+            json, ?MODULE, {type, aliased_person, 0},
+            #{first_name => <<"Alice">>, last_name => <<"Smith">>},
+            [pre_encoded]
+        )
+    ).
+
+local_type_ref_decode_test() ->
+    ?assertEqual(
+        {ok, #{first_name => <<"Alice">>, last_name => <<"Smith">>}},
+        spectra:decode(
+            json, ?MODULE, {type, aliased_person, 0},
+            #{<<"firstName">> => <<"Alice">>, <<"last_name">> => <<"Smith">>},
+            [pre_decoded]
+        )
+    ).
+
+local_type_ref_undefined_branch_test() ->
+    ?assertEqual(
+        {ok, undefined},
+        spectra:decode(
+            json, ?MODULE, {type, aliased_person, 0}, null, [pre_decoded]
+        )
+    ).
+
+local_type_ref_roundtrip_test() ->
+    Value = #{first_name => <<"Alice">>, last_name => <<"Smith">>},
+    {ok, JsonIO} = spectra:encode(json, ?MODULE, {type, aliased_person, 0}, Value),
+    Json = iolist_to_binary(JsonIO),
+    ?assertEqual({ok, Value}, spectra:decode(json, ?MODULE, {type, aliased_person, 0}, Json)).
+
+%% only through a local type reference
+
+only_local_ref_encode_test() ->
+    ?assertEqual(
+        {ok, #{<<"first_name">> => <<"Alice">>}},
+        spectra:encode(
+            json, ?MODULE, {type, only_local_ref, 0},
+            #{first_name => <<"Alice">>, last_name => <<"Smith">>},
+            [pre_encoded]
+        )
+    ).
+
+only_local_ref_decode_test() ->
+    ?assertEqual(
+        {ok, #{first_name => <<"Alice">>}},
+        spectra:decode(
+            json, ?MODULE, {type, only_local_ref, 0},
+            #{<<"first_name">> => <<"Alice">>},
+            [pre_decoded]
+        )
+    ).
+
+%% only through a remote type reference
+
+only_remote_ref_encode_test() ->
+    ?assertEqual(
+        {ok, #{<<"first_name">> => <<"Alice">>}},
+        spectra:encode(
+            json, ?MODULE, {type, only_remote_ref, 0},
+            #{first_name => <<"Alice">>, last_name => <<"Smith">>},
+            [pre_encoded]
+        )
+    ).
+
+only_remote_ref_decode_test() ->
+    ?assertEqual(
+        {ok, #{first_name => <<"Alice">>}},
+        spectra:decode(
+            json, ?MODULE, {type, only_remote_ref, 0},
+            #{<<"first_name">> => <<"Alice">>},
+            [pre_decoded]
+        )
     ).

--- a/test/spectra_attr_interaction_base.erl
+++ b/test/spectra_attr_interaction_base.erl
@@ -1,0 +1,17 @@
+%% Helper module for spectra_attr_interaction_test.
+%% Defines base types with definition-site -spectra() attributes.
+-module(spectra_attr_interaction_base).
+
+-export_type([t/0, t_only/0]).
+
+%% t/0: first_name aliased to "firstName" at definition site.
+-spectra(#{field_aliases => #{first_name => <<"firstName">>}}).
+-type t() :: #{first_name := binary(), last_name := binary(), email := binary()}.
+
+%% t_only/0: only [first_name, last_name] exposed at definition site (email excluded).
+%% Also aliases first_name → "firstName".
+-spectra(#{
+    only => [first_name, last_name],
+    field_aliases => #{first_name => <<"firstName">>}
+}).
+-type t_only() :: #{first_name := binary(), last_name := binary(), email := binary()}.

--- a/test/spectra_attr_interaction_test.erl
+++ b/test/spectra_attr_interaction_test.erl
@@ -1,0 +1,160 @@
+%% Regression tests for -spectra() attribute interactions when both the
+%% definition site and the alias site define the same attribute.
+%%
+%% The base type used throughout is defined in spectra_attr_interaction_base:
+%%   t/0      :: #{first_name, last_name, email} with first_name → "firstName"
+%%   t_only/0 :: same but with only => [first_name, last_name] at definition site
+%%
+%% Summary of expected behaviour:
+%%
+%%   field_aliases
+%%     - Definition-site and alias-site aliases MERGE.
+%%     - Alias-site wins when both sides alias the SAME field.
+%%
+%%   only
+%%     - The two filters INTERSECT (both must allow a field for it to survive).
+%%     - Alias-site cannot add back fields the definition site removed.
+-module(spectra_attr_interaction_test).
+
+-include_lib("eunit/include/eunit.hrl").
+
+-compile(nowarn_unused_type).
+
+%% field_aliases: different fields at each site → merge
+%% Base aliases first_name → "firstName"; this module aliases last_name → "lastName".
+-spectra(#{field_aliases => #{last_name => <<"lastName">>}}).
+-type aliases_merge() :: spectra_attr_interaction_base:t().
+
+%% field_aliases: same field at both sites → alias site wins
+%% Base aliases first_name → "firstName"; this module re-aliases it to "fn".
+-spectra(#{field_aliases => #{first_name => <<"fn">>}}).
+-type aliases_override() :: spectra_attr_interaction_base:t().
+
+%% only: definition site keeps [first_name, last_name]; alias site narrows to [first_name].
+%% Expected intersection: [first_name].
+-spectra(#{only => [first_name]}).
+-type only_intersection() :: spectra_attr_interaction_base:t_only().
+
+%% only: alias site requests a field the definition site already removed.
+%% Definition site keeps [first_name, last_name] (email gone); alias site asks for [first_name, email].
+%% Expected: only first_name survives — email cannot come back.
+-spectra(#{only => [first_name, email]}).
+-type only_cannot_expand() :: spectra_attr_interaction_base:t_only().
+
+%% ---------------------------------------------------------------------------
+%% field_aliases merge tests
+%% ---------------------------------------------------------------------------
+
+aliases_merge_encode_test() ->
+    ?assertEqual(
+        {ok, #{
+            <<"firstName">> => <<"Alice">>, <<"lastName">> => <<"Smith">>, <<"email">> => <<"a@b">>
+        }},
+        spectra:encode(
+            json,
+            ?MODULE,
+            {type, aliases_merge, 0},
+            #{first_name => <<"Alice">>, last_name => <<"Smith">>, email => <<"a@b">>},
+            [pre_encoded]
+        )
+    ).
+
+aliases_merge_decode_test() ->
+    ?assertEqual(
+        {ok, #{first_name => <<"Alice">>, last_name => <<"Smith">>, email => <<"a@b">>}},
+        spectra:decode(
+            json,
+            ?MODULE,
+            {type, aliases_merge, 0},
+            #{
+                <<"firstName">> => <<"Alice">>,
+                <<"lastName">> => <<"Smith">>,
+                <<"email">> => <<"a@b">>
+            },
+            [pre_decoded]
+        )
+    ).
+
+%% ---------------------------------------------------------------------------
+%% field_aliases override tests
+%% ---------------------------------------------------------------------------
+
+aliases_override_encode_test() ->
+    ?assertEqual(
+        {ok, #{<<"fn">> => <<"Alice">>, <<"last_name">> => <<"Smith">>, <<"email">> => <<"a@b">>}},
+        spectra:encode(
+            json,
+            ?MODULE,
+            {type, aliases_override, 0},
+            #{first_name => <<"Alice">>, last_name => <<"Smith">>, email => <<"a@b">>},
+            [pre_encoded]
+        )
+    ).
+
+aliases_override_decode_test() ->
+    ?assertEqual(
+        {ok, #{first_name => <<"Alice">>, last_name => <<"Smith">>, email => <<"a@b">>}},
+        spectra:decode(
+            json,
+            ?MODULE,
+            {type, aliases_override, 0},
+            #{<<"fn">> => <<"Alice">>, <<"last_name">> => <<"Smith">>, <<"email">> => <<"a@b">>},
+            [pre_decoded]
+        )
+    ).
+
+%% ---------------------------------------------------------------------------
+%% only intersection tests
+%% ---------------------------------------------------------------------------
+
+only_intersection_encode_test() ->
+    ?assertEqual(
+        {ok, #{<<"firstName">> => <<"Alice">>}},
+        spectra:encode(
+            json,
+            ?MODULE,
+            {type, only_intersection, 0},
+            #{first_name => <<"Alice">>, last_name => <<"Smith">>, email => <<"a@b">>},
+            [pre_encoded]
+        )
+    ).
+
+only_intersection_decode_test() ->
+    ?assertEqual(
+        {ok, #{first_name => <<"Alice">>}},
+        spectra:decode(
+            json,
+            ?MODULE,
+            {type, only_intersection, 0},
+            #{<<"firstName">> => <<"Alice">>, <<"last_name">> => <<"Smith">>},
+            [pre_decoded]
+        )
+    ).
+
+%% ---------------------------------------------------------------------------
+%% only cannot expand tests
+%% ---------------------------------------------------------------------------
+
+only_cannot_expand_encode_test() ->
+    ?assertEqual(
+        {ok, #{<<"firstName">> => <<"Alice">>}},
+        spectra:encode(
+            json,
+            ?MODULE,
+            {type, only_cannot_expand, 0},
+            #{first_name => <<"Alice">>, last_name => <<"Smith">>, email => <<"a@b">>},
+            [pre_encoded]
+        )
+    ).
+
+only_cannot_expand_decode_test() ->
+    ?assertEqual(
+        {ok, #{first_name => <<"Alice">>}},
+        spectra:decode(
+            json,
+            ?MODULE,
+            {type, only_cannot_expand, 0},
+            #{<<"firstName">> => <<"Alice">>, <<"email">> => <<"a@b">>},
+            [pre_decoded]
+        )
+    ).


### PR DESCRIPTION
## Summary

- **README**: add `field_aliases` to the `-spectra()` attribute table and a dedicated \"Field Aliases with `field_aliases`\" section (the feature shipped in #175 with no documentation)
- **Bug fix**: `-spectra()` structural transforms (`only`, `field_aliases`) were silently dropped when the annotated type body was a local (`#sp_user_type_ref{}`) or cross-module (`#sp_remote_type{}`) type reference — the aliases/filter were computed but never reached the resolved type
- **Refactor**: replace six per-attribute `case` blocks in the format modules with a single `spectra_abstract_code:apply_ref_meta/2` call so all transforms travel together

## What changed

### `only` and `field_aliases` through type references

Previously this did nothing useful:

```erlang
-type base() :: #{first_name := binary(), last_name := binary()} | undefined.

-spectra(#{field_aliases => #{first_name => <<"firstName">>}}).
-type aliased() :: base().                          %% local ref — broken

-spectra(#{only => [first_name]}).
-type filtered() :: other_module:base_type().       %% remote ref — broken
```

Both transforms are now applied after the type reference is resolved, in all three format modules (`spectra_json`, `spectra_json_schema`) for both `#sp_user_type_ref{}` and `#sp_remote_type{}`.

### Implementation

`apply_only/2` and `apply_field_aliases/2` gained new clauses that store their payload in the type-ref's existing `meta` map instead of falling through to the catch-all. At each of the six resolution sites the new `apply_ref_meta/2` helper reads `only` and `field_aliases` from the ref's meta and applies them (in the same order as `attach_doc`) to the concrete resolved type.

`type_parameters` had no gap — it was already propagated via `spectra_type:propagate_params/2` at every remote-type resolution site.

## Tests

- New helper modules `test/field_alias_remote_type_{a,b}.erl` for cross-module testing
- New tests in `field_alias_test.erl`: encode/decode/roundtrip for `field_aliases` through local and remote refs; encode/decode for `only` through local and remote refs
- Full suite: 712 tests, 0 failures

## Reviewer notes

The `apply_ref_meta/2` helper is exported and `ignore_xref`-listed alongside the existing `apply_only/2` and `apply_field_aliases/2`, consistent with how those are exposed for testing and the parse-transform.

🤖 Generated with [Claude Code](https://claude.com/claude-code)