### PR TITLE
Add OTP 29 to CI matrix

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -12,7 +12,7 @@ jobs:
 
     strategy:
       matrix:
-        otp: ["28", "27"]
+        otp: ["29", "28", "27"]
         rebar3: ["3.25"]
         include:
           - otp: "28"
@@ -30,6 +30,7 @@ jobs:
           rebar3-version: ${{ matrix.rebar3 }}
 
       - name: Download and Setup ELP
+        if: matrix.elp_build != ''
         run: |
           mkdir -p bin
           wget -q ${{ matrix.elp_build }} -O elp.tar.gz
@@ -61,6 +62,7 @@ jobs:
         run: make proper
 
       - name: Type check
+        if: matrix.elp_build != ''
         run: make type_check
 
       - name: Check format
@@ -73,6 +75,7 @@ jobs:
         run: make hank
 
       - name: Lint
+        if: matrix.elp_build != ''
         run: make lint
 
       - name: Generate coverage report


### PR DESCRIPTION
## What changed

Added OTP 29 to the CI test matrix in `.github/workflows/ci.yml`.

## Why

Keeps the library verified against newer Erlang/OTP releases as they ship.

## Reviewer notes

ELP (Erlang Language Platform) has no pre-built OTP 29 binary yet — the latest release (2026-02-27) tops out at OTP 28. To avoid blocking CI, the three ELP-dependent steps are gated on `matrix.elp_build != ''`:

- **Download and Setup ELP**
- **Type check** (`make type_check`)
- **Lint** (`make lint`)

All other steps (compile, tests, property tests, format check, dialyzer, hank, coverage) run on OTP 29. Once ELP ships an OTP 29 binary, add its URL to the `include` block and remove the `if` conditions.