### PR TITLE
Add OTP 29 to CI matrix

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -12,9 +12,11 @@ jobs:
 
     strategy:
       matrix:
-        otp: ["28", "27"]
+        otp: ["29", "28", "27"]
         rebar3: ["3.25"]
         include:
+          # ELP (used by the lint and type_check steps) ships per-OTP builds.
+          # There is no OTP 29 build yet, so those steps are skipped on OTP 29.
           - otp: "28"
             elp_build: "https://github.com/WhatsApp/erlang-language-platform/releases/download/2026-02-27/elp-linux-x86_64-unknown-linux-gnu-otp-28.tar.gz"
           - otp: "27"
@@ -30,6 +32,7 @@ jobs:
           rebar3-version: ${{ matrix.rebar3 }}
 
       - name: Download and Setup ELP
+        if: matrix.elp_build
         run: |
           mkdir -p bin
           wget -q ${{ matrix.elp_build }} -O elp.tar.gz
@@ -61,6 +64,7 @@ jobs:
         run: make proper
 
       - name: Type check
+        if: matrix.elp_build
         run: make type_check
 
       - name: Check format
@@ -73,6 +77,7 @@ jobs:
         run: make hank
 
       - name: Lint
+        if: matrix.elp_build
         run: make lint
 
       - name: Generate coverage report


### PR DESCRIPTION
## What

Adds OTP 29 to the CI test matrix alongside OTP 27 and 28.

## Why

Spectra should be tested against OTP 29 now that it is released (29.0.1 is available on builds.hex.pm and supported by `erlef/setup-beam@v1`).

## Notes for reviewers

- **ELP has no OTP 29 build yet.** WhatsApp's erlang-language-platform ships per-OTP binaries, and the latest release (`2026-02-27`) only provides OTP 26.2 / 27.3 / 28. Since `make lint` and `make type_check` (eqwalizer) both shell out to `elp`, those steps cannot run on OTP 29.
- The OTP 29 matrix entry therefore has no `elp_build`, and the **Download and Setup ELP**, **Type check**, and **Lint** steps are gated with `if: matrix.elp_build`. They still run on the 27/28 jobs. When an OTP 29 ELP build is published, adding an `elp_build` include for otp `"29"` will re-enable them automatically.
- On OTP 29, CI still runs compile, eunit, proper, dialyzer, format check, hank, and coverage.
- Local dev stays on OTP 28 (`.tool-versions` unchanged). README already states "OTP 27 or later" and `rebar.config` has no upper OTP bound, so no doc/config changes were needed.

Actual OTP 29 code compatibility will be validated by this CI run on push.