### PR TITLE
Add OpenAPI security scheme support

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.13.2] - 2026-06-12
+
 ### Added
 - OpenAPI security schemes. `spectra_openapi:endpoints_to_openapi/2,3` now accepts two optional metadata keys: `security_schemes` (a map of named [Security Scheme Objects](https://spec.openapis.org/oas/v3.1.0#security-scheme-object), emitted under `components.securitySchemes`) and `security` (a list of [Security Requirement Objects](https://spec.openapis.org/oas/v3.1.0#security-requirement-object), emitted at the top level). This is what makes Swagger UI render the **Authorize** button. Scheme values are passed through as JSON values (like schemas), so any scheme type works — `apiKey`, `http`/`bearer`, `oauth2`, `openIdConnect`.
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,9 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Added
+- OpenAPI security schemes. `spectra_openapi:endpoints_to_openapi/2,3` now accepts two optional metadata keys: `security_schemes` (a map of named [Security Scheme Objects](https://spec.openapis.org/oas/v3.1.0#security-scheme-object), emitted under `components.securitySchemes`) and `security` (a list of [Security Requirement Objects](https://spec.openapis.org/oas/v3.1.0#security-requirement-object), emitted at the top level). This is what makes Swagger UI render the **Authorize** button. Scheme values are passed through as JSON values (like schemas), so any scheme type works — `apiKey`, `http`/`bearer`, `oauth2`, `openIdConnect`.
+
 ## [0.13.1] - 2026-05-07
 
 ### Added

--- a/README.md
+++ b/README.md
@@ -17,7 +17,7 @@ Add spectra to your rebar.config dependencies:
 
 ```erlang
 {deps, [
-    {spectra, "~> 0.13.1"}
+    {spectra, "~> 0.13.2"}
 ]}.
 ```
 

--- a/README.md
+++ b/README.md
@@ -606,6 +606,8 @@ The `Metadata` map in `endpoints_to_openapi/2,3` supports the following fields:
 - `contact` — contact information map with optional `name`, `url`, `email` fields (binary values)
 - `license` — license map with required `name` and optional `url` or `identifier` (binary values)
 - `servers` — list of server objects, each with required `url` and optional `description` (binary values)
+- `security_schemes` — map of named [Security Scheme Objects](https://spec.openapis.org/oas/v3.1.0#security-scheme-object), emitted under `components.securitySchemes`. This is what makes Swagger UI render the **Authorize** button. Values are passed through as JSON, so any scheme type works (`apiKey`, `http`/`bearer`, `oauth2`, `openIdConnect`), e.g. `#{<<"bearer_auth">> => #{type => <<"http">>, scheme => <<"bearer">>, bearerFormat => <<"JWT">>}}`
+- `security` — list of [Security Requirement Objects](https://spec.openapis.org/oas/v3.1.0#security-requirement-object) emitted at the top level as the global default applied to every operation, e.g. `[#{<<"bearer_auth">> => []}]` (the list holds required scopes, empty for `apiKey`/`http`)
 
 
 ## Error Handling

--- a/src/spectra_openapi.erl
+++ b/src/spectra_openapi.erl
@@ -100,6 +100,8 @@
 -type openapi_server() :: #{url := binary(), description => binary()}.
 -type openapi_contact() :: #{name => binary(), url => binary(), email => binary()}.
 -type openapi_license() :: #{name := binary(), url => binary(), identifier => binary()}.
+-type openapi_security_scheme() :: json:encode_value().
+-type openapi_security_requirement() :: #{binary() => [binary()]}.
 -type openapi_metadata() ::
     #{
         title := binary(),
@@ -109,7 +111,9 @@
         terms_of_service => binary(),
         contact => openapi_contact(),
         license => openapi_license(),
-        servers => [openapi_server()]
+        servers => [openapi_server()],
+        security_schemes => #{binary() => openapi_security_scheme()},
+        security => [openapi_security_requirement()]
     }.
 -type endpoint_spec() ::
     #{
@@ -176,7 +180,12 @@
             },
         paths := #{binary() => path_operations()},
         servers => [openapi_server()],
-        components => #{schemas => #{binary() => openapi_schema()}}
+        security => [openapi_security_requirement()],
+        components =>
+            #{
+                schemas => #{binary() => openapi_schema()},
+                securitySchemes => #{binary() => openapi_security_scheme()}
+            }
     }.
 
 -doc """
@@ -599,7 +608,9 @@ endpoints_to_openapi(MetaData, Endpoints, Options) when is_list(Endpoints) ->
             ),
 
         SchemaRefs = collect_schema_refs(Endpoints, Config),
-        ComponentsResult = generate_components(SchemaRefs, Config),
+        ComponentsResult = add_security_schemes(
+            generate_components(SchemaRefs, Config), MetaData
+        ),
         BaseInfo = #{title => maps:get(title, MetaData), version => maps:get(version, MetaData)},
         Info = lists:foldl(
             fun({MetaKey, InfoKey}, Acc) ->
@@ -620,7 +631,8 @@ endpoints_to_openapi(MetaData, Endpoints, Options) when is_list(Endpoints) ->
         BaseSpec = #{
             openapi => <<"3.1.0">>, info => Info, paths => Paths, components => ComponentsResult
         },
-        OpenAPISpec = copy_if_present(servers, MetaData, BaseSpec),
+        WithServers = copy_if_present(servers, MetaData, BaseSpec),
+        OpenAPISpec = copy_if_present(security, MetaData, WithServers),
         spectra:encode(json, ?MODULE, {type, openapi_spec, 0}, OpenAPISpec, Options)
     after
         spectra_module_types:clear_local()
@@ -783,6 +795,13 @@ copy_if_present(Key, Source, Target) ->
     case maps:get(Key, Source, undefined) of
         undefined -> Target;
         Value -> Target#{Key => Value}
+    end.
+
+-spec add_security_schemes(map(), openapi_metadata()) -> map().
+add_security_schemes(Components, MetaData) ->
+    case maps:get(security_schemes, MetaData, undefined) of
+        undefined -> Components;
+        SecuritySchemes -> Components#{securitySchemes => SecuritySchemes}
     end.
 
 -spec generate_response_header(response_header_spec(), spectra:sp_config()) -> openapi_header().

--- a/test/openapi_json_test.erl
+++ b/test/openapi_json_test.erl
@@ -319,6 +319,96 @@ openapi_spec_completeness_test() ->
     ?assert(is_map(Paths)),
     ?assert(map_size(Paths) > 0).
 
+%% Test that security schemes from metadata land under components.securitySchemes.
+%% The scheme value is passed through as a JSON value, so assert against the
+%% actually-serialized JSON where keys are encoded to strings.
+security_schemes_in_components_test() ->
+    Endpoint =
+        spectra_openapi:add_response(
+            spectra_openapi:endpoint(get, <<"/health">>),
+            spectra_openapi:response(200, <<"OK">>)
+        ),
+    SecuritySchemes =
+        #{
+            <<"api_key">> =>
+                #{
+                    type => <<"apiKey">>,
+                    in => <<"header">>,
+                    name => <<"x-api-key">>,
+                    description => <<"API key">>
+                }
+        },
+    {ok, OpenAPISpec} =
+        spectra_openapi:endpoints_to_openapi(
+            #{
+                title => <<"API">>,
+                version => <<"1.0.0">>,
+                security_schemes => SecuritySchemes
+            },
+            [Endpoint],
+            [pre_encoded]
+        ),
+    Decoded = json:decode(iolist_to_binary(json:encode(OpenAPISpec))),
+    ?assertMatch(
+        #{
+            <<"components">> :=
+                #{
+                    <<"securitySchemes">> :=
+                        #{
+                            <<"api_key">> :=
+                                #{
+                                    <<"type">> := <<"apiKey">>,
+                                    <<"in">> := <<"header">>,
+                                    <<"name">> := <<"x-api-key">>,
+                                    <<"description">> := <<"API key">>
+                                }
+                        }
+                }
+        },
+        Decoded
+    ).
+
+%% Test that a global security requirement is emitted at the top level.
+security_requirement_at_top_level_test() ->
+    Endpoint =
+        spectra_openapi:add_response(
+            spectra_openapi:endpoint(get, <<"/health">>),
+            spectra_openapi:response(200, <<"OK">>)
+        ),
+    {ok, OpenAPISpec} =
+        spectra_openapi:endpoints_to_openapi(
+            #{
+                title => <<"API">>,
+                version => <<"1.0.0">>,
+                security_schemes =>
+                    #{
+                        <<"api_key">> =>
+                            #{type => <<"apiKey">>, in => <<"header">>, name => <<"x-api-key">>}
+                    },
+                security => [#{<<"api_key">> => []}]
+            },
+            [Endpoint],
+            [pre_encoded]
+        ),
+    ?assertMatch(#{<<"security">> := [#{<<"api_key">> := []}]}, OpenAPISpec).
+
+%% Test that security keys are absent when no security metadata is provided.
+no_security_without_metadata_test() ->
+    Endpoint =
+        spectra_openapi:add_response(
+            spectra_openapi:endpoint(get, <<"/health">>),
+            spectra_openapi:response(200, <<"OK">>)
+        ),
+    {ok, OpenAPISpec} =
+        spectra_openapi:endpoints_to_openapi(
+            #{title => <<"API">>, version => <<"1.0.0">>},
+            [Endpoint],
+            [pre_encoded]
+        ),
+    ?assertNot(maps:is_key(<<"security">>, OpenAPISpec)),
+    Components = maps:get(<<"components">>, OpenAPISpec, #{}),
+    ?assertNot(maps:is_key(<<"securitySchemes">>, Components)).
+
 %% Test that complex nested structures are properly formed
 complex_nested_structure_test() ->
     %% Test endpoint with all possible features


### PR DESCRIPTION
## What

Adds OpenAPI security schemes to `spectra_openapi:endpoints_to_openapi/2,3` via two new optional metadata keys:

- **`security_schemes`** — a map of named [Security Scheme Objects](https://spec.openapis.org/oas/v3.1.0#security-scheme-object), emitted under `components.securitySchemes`.
- **`security`** — a list of [Security Requirement Objects](https://spec.openapis.org/oas/v3.1.0#security-requirement-object), emitted at the top level as the global default applied to every operation.

```erlang
spectra_openapi:endpoints_to_openapi(
    #{
        title => <<"API">>, version => <<"1.0.0">>,
        security_schemes => #{
            <<"bearer_auth">> => #{type => <<"http">>, scheme => <<"bearer">>, bearerFormat => <<"JWT">>}
        },
        security => [#{<<"bearer_auth">> => []}]
    },
    Endpoints
).
```

## Why

This is what makes Swagger UI render the **Authorize** button. Without `components.securitySchemes` in the served spec there is no way to attach credentials (API keys, bearer tokens, OAuth) from the UI. Downstream, [phoenix_spectral](https://github.com/andreashasse/phoenix_spectral) exposes these as `:security_schemes` / `:security` options on its `OpenAPIController`.

## How

The final spec is type-encoded against `openapi_spec()`, so new fields have to be part of the type — they can't just be passed through. Changes:

- New types `openapi_security_scheme() :: json:encode_value()` and `openapi_security_requirement() :: #{binary() => [binary()]}`.
- Extended `openapi_metadata()`, `openapi_spec()` (top-level `security`), and the `components` shape (`securitySchemes`).
- `endpoints_to_openapi/3` merges `securitySchemes` into the components map and copies `security` to the top level (same `copy_if_present` pattern already used for `servers`).

Scheme values are typed as `json:encode_value()` and passed through verbatim — the same approach `openapi_schema()` already uses — so spectra does not enforce a sub-schema and **every** scheme type works: `apiKey`, `http`/`bearer`, `oauth2`, `openIdConnect`.

## Reviewer notes

- **Pass-through behaviour**: in `pre_encoded` mode a scheme value keeps the atom keys it was given (it's a JSON passthrough, identical to how `openapi_schema` behaves there). The actually-serialized JSON stringifies keys correctly, so Swagger UI sees a valid spec. The new test asserts against a real `json:encode` → `json:decode` round-trip to reflect that contract.
- **Backwards compatible**: both keys are optional; specs without them are byte-for-byte unchanged.

## Tests

Three EUnit tests in `openapi_json_test.erl`: schemes land under `components.securitySchemes` (real-JSON round-trip), the global requirement appears at the top level, and both are absent when no security metadata is given. Full openapi suite: 21 tests in `openapi_json_test`, 0 failures; `rebar3 fmt --check` clean.