### PR TITLE
Fix JSON schema overstating required map/struct fields

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,11 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.13.3] - 2026-06-14
+
+### Fixed
+- JSON schema no longer marks nilable exact map/struct fields as required. The schema generator treated every exact (`:=`) map field as required based on the field kind alone, so a field whose type can be missing (e.g. `field | nil` / `field | undefined`) — including Elixir struct fields, which all emit as exact — was wrongly listed in `required` even though the decoder tolerates its absence. An exact field is now required only when its type cannot be missing, matching the decoder and the record schema path.
+
 ## [0.13.2] - 2026-06-12
 
 ### Added

--- a/README.md
+++ b/README.md
@@ -17,7 +17,7 @@ Add spectra to your rebar.config dependencies:
 
 ```erlang
 {deps, [
-    {spectra, "~> 0.13.2"}
+    {spectra, "~> 0.13.3"}
 ]}.
 ```
 

--- a/src/spectra_json_schema.erl
+++ b/src/spectra_json_schema.erl
@@ -326,10 +326,13 @@ process_map_fields(
 ) ->
     FieldSchema = do_to_schema(TypeInfo, FieldType, Config),
     NewProperties = Properties#{BinaryName => FieldSchema},
+    %% A field is required only when it is exact (`:=`) and cannot be missing.
+    %% Optional (`=>`) fields and exact fields whose type can be missing
+    %% (e.g. `field | nil`) are absent-tolerant, matching the decoder.
     NewRequired =
-        case Kind of
-            exact -> [BinaryName | Required];
-            assoc -> Required
+        case {Kind, spectra_type:can_be_missing(TypeInfo, FieldType)} of
+            {exact, false} -> [BinaryName | Required];
+            _ -> Required
         end,
     process_map_fields(TypeInfo, Rest, NewProperties, NewRequired, HasAdditional, Config);
 process_map_fields(

--- a/test/spectra_json_schema_test.erl
+++ b/test/spectra_json_schema_test.erl
@@ -43,6 +43,9 @@ validate_with_python(Schema) ->
 -type mixed_enum() :: admin | 42 | true.
 %% Map types
 -type my_map() :: #{name := string(), age := integer()}.
+%% Exact (`:=`) field whose type can be missing must not be required,
+%% matching the decoder which tolerates its absence.
+-type my_map_with_optional() :: #{name := string(), age := integer() | undefined}.
 -type my_flexible_map() :: #{config := string(), timeout := integer()}.
 %% Generic map types (allow additional properties)
 -type my_generic_map() :: #{atom() => integer()}.
@@ -331,6 +334,29 @@ map_types_test() ->
         FlexibleMapSchema
     ),
     validate_with_python(FlexibleMapSchema).
+
+%% Exact map field whose type can be missing (`age := integer() | undefined`)
+%% must be excluded from required, mirroring record_with_optional_fields_test
+%% and the decoder's handling of `{exact, {true, _}}`.
+map_with_optional_field_test() ->
+    Schema = spectra:schema(
+        json_schema, ?MODULE, {type, my_map_with_optional, 0}, [pre_encoded]
+    ),
+    ?assertEqual(
+        #{
+            '$schema' => <<"https://json-schema.org/draft/2020-12/schema">>,
+            type => <<"object">>,
+            properties =>
+                #{
+                    <<"name">> => #{type => <<"string">>},
+                    <<"age">> => #{type => <<"integer">>}
+                },
+            required => [<<"name">>],
+            additionalProperties => false
+        },
+        Schema
+    ),
+    validate_with_python(Schema).
 
 %% Test generic map types with additional properties
 generic_map_types_test() ->


### PR DESCRIPTION
## What

`spectra_json_schema` marked every exact (`:=`) map field as `required` based on the field *kind* alone, never consulting whether the field type can be missing.

```erlang
%% before
case Kind of
    exact -> [BinaryName | Required];
    assoc -> Required
end
%% after
case {Kind, spectra_type:can_be_missing(TypeInfo, FieldType)} of
    {exact, false} -> [BinaryName | Required];
    _ -> Required
end
```

## Why

Elixir struct types emit all fields as `map_field_exact`. So a nilable field (`field | nil` / `field | undefined`) ended up in the generated schema's `required` list even though the **decoder** tolerates its absence (`{exact, {true, _}}` is treated as optional), and even though the **record** schema path already consults `can_be_missing/2`. The result: a minimal request body would decode/return 201 while the published schema demanded every field — an overstated contract.

This change makes the map path mirror both the decoder and the record path: an exact field is required only when its type cannot be missing.

## Reviewer notes

- This only touches the `required` list. Property schemas for nilable fields are unchanged — `| nil` means "may be omitted" in spectra's missing-sentinel model, not "may be JSON `null`", so nullability is intentionally not surfaced here.
- Added `map_with_optional_field_test` (exact field `age := integer() | undefined` → excluded from `required`); the `spectra_json_schema_test` module passes (14/14).
- Verified end-to-end through the Spectral wrapper: a `Person` struct with `age`/`address` typed `| nil` now yields `required: ["name"]` instead of `["name","age","address"]`, with nested non-nilable fields still required.
- One full-suite failure (`spectra_transform_tests:generated_function_matches_beam_lib_test`) is pre-existing on clean `main` and unrelated to this change.