### PR TITLE
Return structured error for invalid iolist/iodata JSON encoding

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,9 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Fixed
+- Encoding an `iolist()` or `iodata()` value that is not a valid iolist (e.g. a list containing a byte outside `0..255` such as `[-1]` or `[256]`) now returns a structured `{error, [spectra:error()]}` instead of crashing with a raw `badarg` from `erlang:iolist_to_binary/1`. This also fixes a union-disambiguation inconsistency where such a value produced a different exception type from JSON encoding than from schema generation.
+
 ## [0.13.3] - 2026-06-14
 
 ### Fixed

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.13.4] - 2026-06-14
+
 ### Fixed
 - Encoding an `iolist()` or `iodata()` value that is not a valid iolist (e.g. a list containing a byte outside `0..255` such as `[-1]` or `[256]`) now returns a structured `{error, [spectra:error()]}` instead of crashing with a raw `badarg` from `erlang:iolist_to_binary/1`. This also fixes a union-disambiguation inconsistency where such a value produced a different exception type from JSON encoding than from schema generation.
 

--- a/README.md
+++ b/README.md
@@ -17,7 +17,7 @@ Add spectra to your rebar.config dependencies:
 
 ```erlang
 {deps, [
-    {spectra, "~> 0.13.3"}
+    {spectra, "~> 0.13.4"}
 ]}.
 ```
 

--- a/src/spectra_json.erl
+++ b/src/spectra_json.erl
@@ -788,15 +788,26 @@ check_type_from_json(Type, Json) ->
 check_type_to_json(iodata, Json) when is_binary(Json) ->
     {true, Json};
 check_type_to_json(iodata, Json) when is_list(Json) ->
-    {true, iolist_to_binary(Json)};
+    iolist_to_json(Json);
 check_type_to_json(iolist, Json) when is_list(Json) ->
-    {true, iolist_to_binary(Json)};
+    iolist_to_json(Json);
 check_type_to_json(nonempty_string, Json) when is_list(Json), Json =/= [] ->
     do_string_to_json(nonempty_string, Json);
 check_type_to_json(string, Json) when is_list(Json) ->
     do_string_to_json(string, Json);
 check_type_to_json(Type, Json) ->
     check_type(Type, Json).
+
+%% A list typed as iodata/iolist is only valid if it is a proper iolist.
+%% `iolist_to_binary/1` raises badarg on malformed input (e.g. `[-1]`, `[256]`),
+%% so catch it and report `false`, which the caller turns into a type_mismatch.
+iolist_to_json(Json) ->
+    try
+        {true, iolist_to_binary(Json)}
+    catch
+        error:badarg ->
+            false
+    end.
 
 check_type(integer, Json) when is_integer(Json) ->
     {true, Json};

--- a/test/iodata_iolist_test.erl
+++ b/test/iodata_iolist_test.erl
@@ -162,3 +162,19 @@ iolist_unicode_test() ->
     {ok, Decoded} = spectra:decode(json, ?MODULE, my_iolist, EncodedBinary),
     Expected = [<<"hello 世界"/utf8>>],
     ?assertEqual(Expected, Decoded).
+
+%%% Invalid input — must return a structured error, not crash with badarg %%%
+
+iolist_negative_byte_returns_error_test() ->
+    %% -1 is not a valid byte, so this is not a valid iolist.
+    ?assertMatch({error, [_]}, spectra:encode(json, ?MODULE, my_iolist, [-1])).
+
+iolist_too_large_byte_returns_error_test() ->
+    %% 256 is out of the 0..255 byte range.
+    ?assertMatch({error, [_]}, spectra:encode(json, ?MODULE, my_iolist, [256])).
+
+iodata_negative_byte_returns_error_test() ->
+    ?assertMatch({error, [_]}, spectra:encode(json, ?MODULE, my_iodata, [-1])).
+
+iodata_too_large_byte_returns_error_test() ->
+    ?assertMatch({error, [_]}, spectra:encode(json, ?MODULE, my_iodata, [256])).


### PR DESCRIPTION
Fixes #184.

## Problem

Encoding an `iolist()` / `iodata()` value that is not a valid iolist (e.g. a list containing a byte outside `0..255` like `[-1]` or `[256]`) crashed with a raw `badarg` from `erlang:iolist_to_binary/1` in `spectra_json:check_type_to_json/2`, instead of returning a structured `{error, ...}`.

This was surfaced by the `prop_json_encode_schema_consistency` property: `to_json` raised `badarg` while `to_schema` raised `spectra_error`, so the exception types differed and the property failed.

## Fix

Wrap the `iolist_to_binary/1` calls in a helper that catches `error:badarg` and returns `false`, which the caller (`prim_type_to_json/2`) already converts into a `type_mismatch` error — mirroring how the `atom` and string paths already handle invalid input.

## Tests (TDD — written first, confirmed red, then fixed)

Added four regression tests in `test/iodata_iolist_test.erl` covering invalid bytes (`[-1]`, `[256]`) for both `iolist()` and `iodata()`, asserting a structured `{error, [_]}` result.

- `rebar3 eunit`: 743 tests, 0 failures
- `make proper`: 9/9 properties pass (formerly-failing property re-run 3× clean)